### PR TITLE
Protocols for typing of Gramps objects

### DIFF
--- a/gramps/gen/test/types_test.py
+++ b/gramps/gen/test/types_test.py
@@ -1,0 +1,234 @@
+# -*- coding: utf-8 -*-
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025       David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Unittest for types.py protocols"""
+
+import unittest
+
+
+class ProtocolTest(unittest.TestCase):
+    """Test that actual Gramps classes match their protocol definitions."""
+
+    def test_person_matches_personlike(self):
+        """Test that a Person instance matches the PersonLike protocol."""
+        from ..lib.person import Person
+        from ..types import PersonLike
+        
+        person = Person()
+        self.assertIsInstance(person, PersonLike)
+
+    def test_person_datadict_matches_personlike(self):
+        """Test that a DataDict from Person has PersonLike attributes."""
+        from ..lib.person import Person
+        from ..lib.json_utils import object_to_data
+        from ..types import PersonLike
+        
+        person = Person()
+        data_dict: PersonLike = object_to_data(person)
+
+    def test_family_matches_familylike(self):
+        """Test that a Family instance matches the FamilyLike protocol."""
+        from ..lib.family import Family
+        from ..types import FamilyLike
+        
+        family = Family()
+        self.assertIsInstance(family, FamilyLike)
+
+    def test_family_datadict_matches_familylike(self):
+        """Test that a DataDict from Family has FamilyLike attributes."""
+        from ..lib.family import Family
+        from ..lib.json_utils import object_to_data
+        from ..types import FamilyLike
+        
+        family = Family()
+        data_dict: FamilyLike = object_to_data(family)
+
+    def test_event_matches_eventlike(self):
+        """Test that an Event instance matches the EventLike protocol."""
+        from ..lib.event import Event
+        from ..types import EventLike
+        
+        event = Event()
+        self.assertIsInstance(event, EventLike)
+
+    def test_event_datadict_matches_eventlike(self):
+        """Test that a DataDict from Event has EventLike attributes."""
+        from ..lib.event import Event
+        from ..lib.json_utils import object_to_data
+        from ..types import EventLike
+        
+        event = Event()
+        data_dict: EventLike = object_to_data(event)
+
+    def test_source_matches_sourcelike(self):
+        """Test that a Source instance matches the SourceLike protocol."""
+        from ..lib.src import Source
+        from ..types import SourceLike
+        
+        source = Source()
+        self.assertIsInstance(source, SourceLike)
+
+    def test_source_datadict_matches_sourcelike(self):
+        """Test that a DataDict from Source has SourceLike attributes."""
+        from ..lib.src import Source
+        from ..lib.json_utils import object_to_data
+        from ..types import SourceLike
+        
+        source = Source()
+        data_dict: SourceLike = object_to_data(source)
+
+    def test_citation_matches_citationlike(self):
+        """Test that a Citation instance matches the CitationLike protocol."""
+        from ..lib.citation import Citation
+        from ..types import CitationLike
+        
+        citation = Citation()
+        self.assertIsInstance(citation, CitationLike)
+
+    def test_citation_datadict_matches_citationlike(self):
+        """Test that a DataDict from Citation has CitationLike attributes."""
+        from ..lib.citation import Citation
+        from ..lib.json_utils import object_to_data
+        from ..types import CitationLike
+        
+        citation = Citation()
+        data_dict: CitationLike = object_to_data(citation)
+
+    def test_media_matches_medialike(self):
+        """Test that a Media instance matches the MediaLike protocol."""
+        from ..lib.media import Media
+        from ..types import MediaLike
+        
+        media = Media()
+        self.assertIsInstance(media, MediaLike)
+
+    def test_media_datadict_matches_medialike(self):
+        """Test that a DataDict from Media has MediaLike attributes."""
+        from ..lib.media import Media
+        from ..lib.json_utils import object_to_data
+        from ..types import MediaLike
+        
+        media = Media()
+        data_dict: MediaLike = object_to_data(media)
+
+    def test_place_matches_placelike(self):
+        """Test that a Place instance matches the PlaceLike protocol."""
+        from ..lib.place import Place
+        from ..types import PlaceLike
+        
+        place = Place()
+        self.assertIsInstance(place, PlaceLike)
+
+    def test_place_datadict_matches_placelike(self):
+        """Test that a DataDict from Place has PlaceLike attributes."""
+        from ..lib.place import Place
+        from ..lib.json_utils import object_to_data
+        from ..types import PlaceLike
+        
+        place = Place()
+        data_dict: PlaceLike = object_to_data(place)
+
+    def test_repository_matches_repositorylike(self):
+        """Test that a Repository instance matches the RepositoryLike protocol."""
+        from ..lib.repo import Repository
+        from ..types import RepositoryLike
+        
+        repository = Repository()
+        self.assertIsInstance(repository, RepositoryLike)
+
+    def test_repository_datadict_matches_repositorylike(self):
+        """Test that a DataDict from Repository has RepositoryLike attributes."""
+        from ..lib.repo import Repository
+        from ..lib.json_utils import object_to_data
+        from ..types import RepositoryLike
+        
+        repository = Repository()
+        data_dict: RepositoryLike = object_to_data(repository)
+
+    def test_note_matches_notelike(self):
+        """Test that a Note instance matches the NoteLike protocol."""
+        from ..lib.note import Note
+        from ..types import NoteLike
+        
+        note = Note()
+        self.assertIsInstance(note, NoteLike)
+
+    def test_note_datadict_matches_notelike(self):
+        """Test that a DataDict from Note has NoteLike attributes."""
+        from ..lib.note import Note
+        from ..lib.json_utils import object_to_data
+        from ..types import NoteLike
+        
+        note = Note()
+        data_dict: NoteLike = object_to_data(note)
+
+    def test_tag_matches_taglike(self):
+        """Test that a Tag instance matches the TagLike protocol."""
+        from ..lib.tag import Tag
+        from ..types import TagLike
+        
+        tag = Tag()
+        self.assertIsInstance(tag, TagLike)
+
+    def test_tag_datadict_matches_taglike(self):
+        """Test that a DataDict from Tag has TagLike attributes."""
+        from ..lib.tag import Tag
+        from ..lib.json_utils import object_to_data
+        from ..types import TagLike
+        
+        tag = Tag()
+        data_dict: TagLike = object_to_data(tag)
+
+    def test_date_matches_datelike(self):
+        """Test that a Date instance matches the DateLike protocol."""
+        from ..lib.date import Date
+        from ..types import DateLike
+        
+        date = Date()
+        self.assertIsInstance(date, DateLike)
+
+    def test_name_matches_namelike(self):
+        """Test that a Name instance matches the NameLike protocol."""
+        from ..lib.name import Name
+        from ..types import NameLike
+        
+        name = Name()
+        self.assertIsInstance(name, NameLike)
+
+    def test_grampstype_matches_grampstypelike(self):
+        """Test that GrampsType instances match the GrampsTypeLike protocol."""
+        from ..lib.grampstype import GrampsType
+        from ..lib.nametype import NameType
+        from ..lib.eventtype import EventType
+        from ..types import GrampsTypeLike
+        
+        # Test with base GrampsType and subclasses
+        gt = GrampsType()
+        self.assertIsInstance(gt, GrampsTypeLike)
+        
+        nt = NameType()
+        self.assertIsInstance(nt, GrampsTypeLike)
+        
+        et = EventType()
+        self.assertIsInstance(et, GrampsTypeLike)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gen/types.py
+++ b/gramps/gen/types.py
@@ -25,6 +25,7 @@ from typing import (
     TYPE_CHECKING,
     NewType,
     Protocol,
+    Sequence,
     Type,
     TypeVar,
     Union,
@@ -50,16 +51,33 @@ if TYPE_CHECKING:
     from .lib.address import Address
     from .lib.attribute import Attribute
     from .lib.attrtype import AttributeType
+    from .lib.childref import ChildRef
+    from .lib.childreftype import ChildRefType
     from .lib.date import Date
     from .lib.eventref import EventRef
     from .lib.eventroletype import EventRoleType
+    from .lib.eventtype import EventType
+    from .lib.familyreltype import FamilyRelType
     from .lib.grampstype import GrampsType
     from .lib.ldsord import LdsOrd
+    from .lib.location import Location
     from .lib.mediaref import MediaRef
     from .lib.name import Name
     from .lib.nameorigintype import NameOriginType
     from .lib.nametype import NameType
+    from .lib.notetype import NoteType
     from .lib.personref import PersonRef
+    from .lib.placename import PlaceName
+    from .lib.placeref import PlaceRef
+    from .lib.placetype import PlaceType
+    from .lib.reporef import RepoRef
+    from .lib.repotype import RepositoryType
+    from .lib.srcattribute import SrcAttribute
+    from .lib.srcattrtype import SrcAttributeType
+    from .lib.srcmediatype import SourceMediaType
+    from .lib.styledtext import StyledText
+    from .lib.styledtexttag import StyledTextTag
+    from .lib.styledtexttagtype import StyledTextTagType
     from .lib.surname import Surname
     from .lib.url import Url
     from .lib.urltype import UrlType
@@ -149,11 +167,11 @@ class NameLike(Protocol):
     """Protocol for Name-like objects."""
 
     private: bool
-    citation_list: list[str]
-    note_list: list[str]
+    citation_list: Sequence[str]
+    note_list: Sequence[str]
     date: DateLike
     first_name: str
-    surname_list: list[SurnameLike]
+    surname_list: Sequence[SurnameLike]
     suffix: str
     title: str
     type: GrampsTypeLike  # NameType
@@ -170,9 +188,9 @@ class EventRefLike(Protocol):
     """Protocol for EventRef-like objects."""
 
     private: bool
-    citation_list: list[str]
-    note_list: list[str]
-    attribute_list: list[AttributeLike]
+    citation_list: Sequence[str]
+    note_list: Sequence[str]
+    attribute_list: Sequence[AttributeLike]
     ref: str  # Event handle
     role: GrampsTypeLike  # EventRoleType
 
@@ -182,11 +200,11 @@ class MediaRefLike(Protocol):
     """Protocol for MediaRef-like objects."""
 
     private: bool
-    citation_list: list[str]
-    note_list: list[str]
-    attribute_list: list[AttributeLike]
+    citation_list: Sequence[str]
+    note_list: Sequence[str]
+    attribute_list: Sequence[AttributeLike]
     ref: str  # Media handle
-    rect: list[int] | None  # Region coordinates [x, y, width, height]
+    rect: Sequence[int] | None  # Region coordinates [x, y, width, height]
 
 
 @runtime_checkable
@@ -194,8 +212,8 @@ class AddressLike(Protocol):
     """Protocol for Address-like objects."""
 
     private: bool
-    citation_list: list[str]
-    note_list: list[str]
+    citation_list: Sequence[str]
+    note_list: Sequence[str]
     date: DateLike
     street: str
     locality: str
@@ -212,8 +230,8 @@ class AttributeLike(Protocol):
     """Protocol for Attribute-like objects."""
 
     private: bool
-    citation_list: list[str]
-    note_list: list[str]
+    citation_list: Sequence[str]
+    note_list: Sequence[str]
     type: GrampsTypeLike  # AttributeType
     value: str
 
@@ -232,8 +250,8 @@ class UrlLike(Protocol):
 class LdsOrdLike(Protocol):
     """Protocol for LdsOrd-like objects."""
 
-    citation_list: list[str]
-    note_list: list[str]
+    citation_list: Sequence[str]
+    note_list: Sequence[str]
     date: DateLike
     type: int  # LDS ordinance type
     place: str
@@ -248,10 +266,91 @@ class PersonRefLike(Protocol):
     """Protocol for PersonRef-like objects."""
 
     private: bool
-    citation_list: list[str]
-    note_list: list[str]
+    citation_list: Sequence[str]
+    note_list: Sequence[str]
     ref: str  # Person handle
     rel: str  # Association/relationship
+
+
+@runtime_checkable
+class ChildRefLike(Protocol):
+    """Protocol for ChildRef-like objects."""
+
+    private: bool
+    citation_list: Sequence[str]
+    note_list: Sequence[str]
+    ref: str  # Child handle
+    frel: GrampsTypeLike  # ChildRefType - Father relationship
+    mrel: GrampsTypeLike  # ChildRefType - Mother relationship
+
+
+@runtime_checkable
+class PlaceRefLike(Protocol):
+    """Protocol for PlaceRef-like objects."""
+
+    ref: str  # Place handle
+    date: DateLike
+
+
+@runtime_checkable
+class RepoRefLike(Protocol):
+    """Protocol for RepoRef-like objects."""
+
+    private: bool
+    note_list: Sequence[str]
+    ref: str  # Repository handle
+    call_number: str
+    media_type: GrampsTypeLike  # SourceMediaType
+
+
+@runtime_checkable
+class SrcAttributeLike(Protocol):
+    """Protocol for SrcAttribute-like objects."""
+
+    private: bool
+    type: GrampsTypeLike  # SrcAttributeType
+    value: str
+
+
+@runtime_checkable
+class StyledTextTagLike(Protocol):
+    """Protocol for StyledTextTag-like objects."""
+
+    name: GrampsTypeLike  # StyledTextTagType
+    value: str | int | None
+    ranges: Sequence[tuple[int, int]]
+
+
+@runtime_checkable
+class StyledTextLike(Protocol):
+    """Protocol for StyledText-like objects."""
+
+    string: str
+    tags: Sequence[StyledTextTagLike]
+
+
+@runtime_checkable
+class PlaceNameLike(Protocol):
+    """Protocol for PlaceName-like objects."""
+
+    value: str
+    date: DateLike
+    lang: str
+
+
+@runtime_checkable
+class LocationLike(Protocol):
+    """Protocol for Location-like objects."""
+
+    street: str
+    locality: str
+    city: str
+    county: str
+    state: str
+    country: str
+    postal: str
+    phone: str
+    parish: str
 
 
 @runtime_checkable
@@ -262,42 +361,230 @@ class PersonLike(Protocol):
     gramps_id: str
     gender: int
     primary_name: NameLike
-    alternate_names: list[NameLike]
+    alternate_names: Sequence[NameLike]
     death_ref_index: int
     birth_ref_index: int
-    event_ref_list: list[EventRefLike]
-    family_list: list[str]
-    parent_family_list: list[str]
-    media_list: list[MediaRefLike]
-    address_list: list[AddressLike]
-    attribute_list: list[AttributeLike]
-    urls: list[UrlLike]
-    lds_ord_list: list[LdsOrdLike]
-    citation_list: list[str]
-    note_list: list[str]
+    event_ref_list: Sequence[EventRefLike]
+    family_list: Sequence[str]
+    parent_family_list: Sequence[str]
+    media_list: Sequence[MediaRefLike]
+    address_list: Sequence[AddressLike]
+    attribute_list: Sequence[AttributeLike]
+    urls: Sequence[UrlLike]
+    lds_ord_list: Sequence[LdsOrdLike]
+    citation_list: Sequence[str]
+    note_list: Sequence[str]
     change: int
-    tag_list: list[str]
+    tag_list: Sequence[str]
     private: bool
-    person_ref_list: list[PersonRefLike]
+    person_ref_list: Sequence[PersonRefLike]
+
+
+@runtime_checkable
+class FamilyLike(Protocol):
+    """Protocol for Family-like objects."""
+
+    handle: str
+    gramps_id: str
+    father_handle: str | None
+    mother_handle: str | None
+    child_ref_list: Sequence[ChildRefLike]
+    type: GrampsTypeLike  # FamilyRelType
+    event_ref_list: Sequence[EventRefLike]
+    media_list: Sequence[MediaRefLike]
+    attribute_list: Sequence[AttributeLike]
+    lds_ord_list: Sequence[LdsOrdLike]
+    citation_list: Sequence[str]
+    note_list: Sequence[str]
+    change: int
+    tag_list: Sequence[str]
+    private: bool
+
+
+@runtime_checkable
+class EventLike(Protocol):
+    """Protocol for Event-like objects."""
+
+    handle: str
+    gramps_id: str
+    type: GrampsTypeLike  # EventType
+    date: DateLike
+    description: str
+    place: str | None
+    citation_list: Sequence[str]
+    note_list: Sequence[str]
+    media_list: Sequence[MediaRefLike]
+    attribute_list: Sequence[AttributeLike]
+    change: int
+    tag_list: Sequence[str]
+    private: bool
+
+
+@runtime_checkable
+class MediaLike(Protocol):
+    """Protocol for Media-like objects."""
+
+    handle: str
+    gramps_id: str
+    path: str
+    mime: str
+    desc: str
+    checksum: str
+    attribute_list: Sequence[AttributeLike]
+    citation_list: Sequence[str]
+    note_list: Sequence[str]
+    change: int
+    date: DateLike
+    tag_list: Sequence[str]
+    private: bool
+
+
+@runtime_checkable
+class PlaceLike(Protocol):
+    """Protocol for Place-like objects."""
+
+    handle: str
+    gramps_id: str
+    title: str
+    long: str
+    lat: str
+    placeref_list: Sequence[PlaceRefLike]
+    name: PlaceNameLike
+    alt_names: Sequence[PlaceNameLike]
+    place_type: GrampsTypeLike  # PlaceType
+    code: str
+    alt_loc: Sequence[LocationLike]
+    urls: Sequence[UrlLike]
+    media_list: Sequence[MediaRefLike]
+    citation_list: Sequence[str]
+    note_list: Sequence[str]
+    change: int
+    tag_list: Sequence[str]
+    private: bool
+
+
+@runtime_checkable
+class SourceLike(Protocol):
+    """Protocol for Source-like objects."""
+
+    handle: str
+    gramps_id: str
+    title: str
+    author: str
+    pubinfo: str
+    note_list: Sequence[str]
+    media_list: Sequence[MediaRefLike]
+    abbrev: str
+    change: int
+    attribute_list: Sequence[SrcAttributeLike]
+    reporef_list: Sequence[RepoRefLike]
+    tag_list: Sequence[str]
+    private: bool
+
+
+@runtime_checkable
+class CitationLike(Protocol):
+    """Protocol for Citation-like objects."""
+
+    handle: str
+    gramps_id: str
+    date: DateLike
+    page: str
+    confidence: int
+    source_handle: str
+    note_list: Sequence[str]
+    media_list: Sequence[MediaRefLike]
+    attribute_list: Sequence[SrcAttributeLike]
+    change: int
+    tag_list: Sequence[str]
+    private: bool
+
+
+@runtime_checkable
+class RepositoryLike(Protocol):
+    """Protocol for Repository-like objects."""
+
+    handle: str
+    gramps_id: str
+    type: GrampsTypeLike  # RepositoryType
+    name: str
+    note_list: Sequence[str]
+    address_list: Sequence[AddressLike]
+    urls: Sequence[UrlLike]
+    change: int
+    tag_list: Sequence[str]
+    private: bool
+
+
+@runtime_checkable
+class NoteLike(Protocol):
+    """Protocol for Note-like objects."""
+
+    handle: str
+    gramps_id: str
+    text: StyledTextLike
+    format: int
+    type: GrampsTypeLike  # NoteType
+    change: int
+    tag_list: Sequence[str]
+    private: bool
+
+
+@runtime_checkable
+class TagLike(Protocol):
+    """Protocol for Tag-like objects."""
+
+    handle: str
+    name: str
+    color: str
+    priority: int
+    change: int
 
 
 if TYPE_CHECKING:
     # Verify that actual classes implement their corresponding protocols
-    _gramps_type: type[GrampsTypeLike] = GrampsType
-    _name_type: type[GrampsTypeLike] = NameType
-    _attribute_type: type[GrampsTypeLike] = AttributeType
-    _url_type: type[GrampsTypeLike] = UrlType
-    _event_role_type: type[GrampsTypeLike] = EventRoleType
-    _name_origin_type: type[GrampsTypeLike] = NameOriginType
+    _gramps_type: Type[GrampsTypeLike] = GrampsType
+    _name_type: Type[GrampsTypeLike] = NameType
+    _attribute_type: Type[GrampsTypeLike] = AttributeType
+    _url_type: Type[GrampsTypeLike] = UrlType
+    _event_role_type: Type[GrampsTypeLike] = EventRoleType
+    _name_origin_type: Type[GrampsTypeLike] = NameOriginType
+    _event_type: Type[GrampsTypeLike] = EventType
+    _family_rel_type: Type[GrampsTypeLike] = FamilyRelType
+    _child_ref_type: Type[GrampsTypeLike] = ChildRefType
+    _place_type: Type[GrampsTypeLike] = PlaceType
+    _repository_type: Type[GrampsTypeLike] = RepositoryType
+    _src_attribute_type: Type[GrampsTypeLike] = SrcAttributeType
+    _source_media_type: Type[GrampsTypeLike] = SourceMediaType
+    _styled_text_tag_type: Type[GrampsTypeLike] = StyledTextTagType
+    _note_type: Type[GrampsTypeLike] = NoteType
 
-    _date: type[DateLike] = Date
-    _surname: type[SurnameLike] = Surname
-    _name: type[NameLike] = Name
-    _event_ref: type[EventRefLike] = EventRef
-    _media_ref: type[MediaRefLike] = MediaRef
-    _address: type[AddressLike] = Address
-    _attribute: type[AttributeLike] = Attribute
-    _url: type[UrlLike] = Url
-    _lds_ord: type[LdsOrdLike] = LdsOrd
-    _person_ref: type[PersonRefLike] = PersonRef
-    _person: type[PersonLike] = Person
+    _date: Type[DateLike] = Date
+    _surname: Type[SurnameLike] = Surname
+    _name: Type[NameLike] = Name
+    _event_ref: Type[EventRefLike] = EventRef
+    _media_ref: Type[MediaRefLike] = MediaRef
+    _address: Type[AddressLike] = Address
+    _attribute: Type[AttributeLike] = Attribute
+    _url: Type[UrlLike] = Url
+    _lds_ord: Type[LdsOrdLike] = LdsOrd
+    _person_ref: Type[PersonRefLike] = PersonRef
+    _child_ref: Type[ChildRefLike] = ChildRef
+    _place_ref: Type[PlaceRefLike] = PlaceRef
+    _repo_ref: Type[RepoRefLike] = RepoRef
+    _src_attribute: Type[SrcAttributeLike] = SrcAttribute
+    _styled_text_tag: Type[StyledTextTagLike] = StyledTextTag
+    _styled_text: Type[StyledTextLike] = StyledText
+    _place_name: Type[PlaceNameLike] = PlaceName
+    _location: Type[LocationLike] = Location
+
+    _person: Type[PersonLike] = Person
+    _family: Type[FamilyLike] = Family
+    _event: Type[EventLike] = Event
+    _media: Type[MediaLike] = Media
+    _place: Type[PlaceLike] = Place
+    _source: Type[SourceLike] = Source
+    _citation: Type[CitationLike] = Citation
+    _repository: Type[RepositoryLike] = Repository
+    _note: Type[NoteLike] = Note
+    _tag: Type[TagLike] = Tag

--- a/gramps/gen/types.py
+++ b/gramps/gen/types.py
@@ -22,7 +22,6 @@
 from __future__ import annotations
 
 from typing import (
-    TYPE_CHECKING,
     NewType,
     Protocol,
     Type,
@@ -45,41 +44,6 @@ from .lib import (
     Tag,
 )
 from .lib.tableobj import TableObject
-
-if TYPE_CHECKING:
-    from .lib.address import Address
-    from .lib.attribute import Attribute
-    from .lib.attrtype import AttributeType
-    from .lib.childref import ChildRef
-    from .lib.childreftype import ChildRefType
-    from .lib.date import Date
-    from .lib.eventref import EventRef
-    from .lib.eventroletype import EventRoleType
-    from .lib.eventtype import EventType
-    from .lib.familyreltype import FamilyRelType
-    from .lib.grampstype import GrampsType
-    from .lib.ldsord import LdsOrd
-    from .lib.location import Location
-    from .lib.mediaref import MediaRef
-    from .lib.name import Name
-    from .lib.nameorigintype import NameOriginType
-    from .lib.nametype import NameType
-    from .lib.notetype import NoteType
-    from .lib.personref import PersonRef
-    from .lib.placename import PlaceName
-    from .lib.placeref import PlaceRef
-    from .lib.placetype import PlaceType
-    from .lib.reporef import RepoRef
-    from .lib.repotype import RepositoryType
-    from .lib.srcattribute import SrcAttribute
-    from .lib.srcattrtype import SrcAttributeType
-    from .lib.srcmediatype import SourceMediaType
-    from .lib.styledtext import StyledText
-    from .lib.styledtexttag import StyledTextTag
-    from .lib.styledtexttagtype import StyledTextTagType
-    from .lib.surname import Surname
-    from .lib.url import Url
-    from .lib.urltype import UrlType
 
 PersonHandle = NewType("PersonHandle", str)
 FamilyHandle = NewType("FamilyHandle", str)

--- a/gramps/gen/types.py
+++ b/gramps/gen/types.py
@@ -21,7 +21,15 @@
 
 from __future__ import annotations
 
-from typing import NewType, Type, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    NewType,
+    Protocol,
+    Type,
+    TypeVar,
+    Union,
+    runtime_checkable,
+)
 
 from .lib import (
     Citation,
@@ -37,6 +45,24 @@ from .lib import (
     Tag,
 )
 from .lib.tableobj import TableObject
+
+if TYPE_CHECKING:
+    from .lib.address import Address
+    from .lib.attribute import Attribute
+    from .lib.attrtype import AttributeType
+    from .lib.date import Date
+    from .lib.eventref import EventRef
+    from .lib.eventroletype import EventRoleType
+    from .lib.grampstype import GrampsType
+    from .lib.ldsord import LdsOrd
+    from .lib.mediaref import MediaRef
+    from .lib.name import Name
+    from .lib.nameorigintype import NameOriginType
+    from .lib.nametype import NameType
+    from .lib.personref import PersonRef
+    from .lib.surname import Surname
+    from .lib.url import Url
+    from .lib.urltype import UrlType
 
 PersonHandle = NewType("PersonHandle", str)
 FamilyHandle = NewType("FamilyHandle", str)
@@ -84,3 +110,194 @@ PrimaryObjectGrampsID = Union[
     NoteGrampsID,
 ]
 AnyGrampsID = PrimaryObjectGrampsID  # No Tag IDs
+
+
+@runtime_checkable
+class GrampsTypeLike(Protocol):
+    """Protocol for GrampsType-like objects (NameType, AttributeType, etc.)."""
+
+    string: str  # Custom type string
+    value: int  # Type code
+
+
+@runtime_checkable
+class DateLike(Protocol):
+    """Protocol for Date-like objects."""
+
+    calendar: int
+    modifier: int
+    quality: int
+    dateval: tuple[int | bool, ...]  # Array of date values
+    text: str
+    sortval: int
+    newyear: int  # New year begins
+
+
+@runtime_checkable
+class SurnameLike(Protocol):
+    """Protocol for Surname-like objects."""
+
+    surname: str
+    prefix: str
+    primary: bool
+    origintype: GrampsTypeLike  # NameOriginType
+    connector: str
+
+
+@runtime_checkable
+class NameLike(Protocol):
+    """Protocol for Name-like objects."""
+
+    private: bool
+    citation_list: list[str]
+    note_list: list[str]
+    date: DateLike
+    first_name: str
+    surname_list: list[SurnameLike]
+    suffix: str
+    title: str
+    type: GrampsTypeLike  # NameType
+    group_as: str
+    sort_as: int
+    display_as: int
+    call: str
+    nick: str
+    famnick: str
+
+
+@runtime_checkable
+class EventRefLike(Protocol):
+    """Protocol for EventRef-like objects."""
+
+    private: bool
+    citation_list: list[str]
+    note_list: list[str]
+    attribute_list: list[AttributeLike]
+    ref: str  # Event handle
+    role: GrampsTypeLike  # EventRoleType
+
+
+@runtime_checkable
+class MediaRefLike(Protocol):
+    """Protocol for MediaRef-like objects."""
+
+    private: bool
+    citation_list: list[str]
+    note_list: list[str]
+    attribute_list: list[AttributeLike]
+    ref: str  # Media handle
+    rect: list[int] | None  # Region coordinates [x, y, width, height]
+
+
+@runtime_checkable
+class AddressLike(Protocol):
+    """Protocol for Address-like objects."""
+
+    private: bool
+    citation_list: list[str]
+    note_list: list[str]
+    date: DateLike
+    street: str
+    locality: str
+    city: str
+    county: str
+    state: str
+    country: str
+    postal: str  # Postal Code
+    phone: str
+
+
+@runtime_checkable
+class AttributeLike(Protocol):
+    """Protocol for Attribute-like objects."""
+
+    private: bool
+    citation_list: list[str]
+    note_list: list[str]
+    type: GrampsTypeLike  # AttributeType
+    value: str
+
+
+@runtime_checkable
+class UrlLike(Protocol):
+    """Protocol for Url-like objects."""
+
+    private: bool
+    path: str
+    desc: str  # Description
+    type: GrampsTypeLike  # UrlType
+
+
+@runtime_checkable
+class LdsOrdLike(Protocol):
+    """Protocol for LdsOrd-like objects."""
+
+    citation_list: list[str]
+    note_list: list[str]
+    date: DateLike
+    type: int  # LDS ordinance type
+    place: str
+    famc: str | None  # Family
+    temple: str
+    status: int
+    private: bool
+
+
+@runtime_checkable
+class PersonRefLike(Protocol):
+    """Protocol for PersonRef-like objects."""
+
+    private: bool
+    citation_list: list[str]
+    note_list: list[str]
+    ref: str  # Person handle
+    rel: str  # Association/relationship
+
+
+@runtime_checkable
+class PersonLike(Protocol):
+    """Protocol for Person-like objects."""
+
+    handle: str
+    gramps_id: str
+    gender: int
+    primary_name: NameLike
+    alternate_names: list[NameLike]
+    death_ref_index: int
+    birth_ref_index: int
+    event_ref_list: list[EventRefLike]
+    family_list: list[str]
+    parent_family_list: list[str]
+    media_list: list[MediaRefLike]
+    address_list: list[AddressLike]
+    attribute_list: list[AttributeLike]
+    urls: list[UrlLike]
+    lds_ord_list: list[LdsOrdLike]
+    citation_list: list[str]
+    note_list: list[str]
+    change: int
+    tag_list: list[str]
+    private: bool
+    person_ref_list: list[PersonRefLike]
+
+
+if TYPE_CHECKING:
+    # Verify that actual classes implement their corresponding protocols
+    _gramps_type: type[GrampsTypeLike] = GrampsType
+    _name_type: type[GrampsTypeLike] = NameType
+    _attribute_type: type[GrampsTypeLike] = AttributeType
+    _url_type: type[GrampsTypeLike] = UrlType
+    _event_role_type: type[GrampsTypeLike] = EventRoleType
+    _name_origin_type: type[GrampsTypeLike] = NameOriginType
+
+    _date: type[DateLike] = Date
+    _surname: type[SurnameLike] = Surname
+    _name: type[NameLike] = Name
+    _event_ref: type[EventRefLike] = EventRef
+    _media_ref: type[MediaRefLike] = MediaRef
+    _address: type[AddressLike] = Address
+    _attribute: type[AttributeLike] = Attribute
+    _url: type[UrlLike] = Url
+    _lds_ord: type[LdsOrdLike] = LdsOrd
+    _person_ref: type[PersonRefLike] = PersonRef
+    _person: type[PersonLike] = Person

--- a/gramps/gen/types.py
+++ b/gramps/gen/types.py
@@ -25,7 +25,6 @@ from typing import (
     TYPE_CHECKING,
     NewType,
     Protocol,
-    Sequence,
     Type,
     TypeVar,
     Union,
@@ -167,11 +166,11 @@ class NameLike(Protocol):
     """Protocol for Name-like objects."""
 
     private: bool
-    citation_list: Sequence[str]
-    note_list: Sequence[str]
+    citation_list: list[str]
+    note_list: list[str]
     date: DateLike
     first_name: str
-    surname_list: Sequence[SurnameLike]
+    surname_list: list[SurnameLike]
     suffix: str
     title: str
     type: GrampsTypeLike  # NameType
@@ -188,9 +187,9 @@ class EventRefLike(Protocol):
     """Protocol for EventRef-like objects."""
 
     private: bool
-    citation_list: Sequence[str]
-    note_list: Sequence[str]
-    attribute_list: Sequence[AttributeLike]
+    citation_list: list[str]
+    note_list: list[str]
+    attribute_list: list[AttributeLike]
     ref: str  # Event handle
     role: GrampsTypeLike  # EventRoleType
 
@@ -200,11 +199,11 @@ class MediaRefLike(Protocol):
     """Protocol for MediaRef-like objects."""
 
     private: bool
-    citation_list: Sequence[str]
-    note_list: Sequence[str]
-    attribute_list: Sequence[AttributeLike]
+    citation_list: list[str]
+    note_list: list[str]
+    attribute_list: list[AttributeLike]
     ref: str  # Media handle
-    rect: Sequence[int] | None  # Region coordinates [x, y, width, height]
+    rect: list[int] | None  # Region coordinates [x, y, width, height]
 
 
 @runtime_checkable
@@ -212,8 +211,8 @@ class AddressLike(Protocol):
     """Protocol for Address-like objects."""
 
     private: bool
-    citation_list: Sequence[str]
-    note_list: Sequence[str]
+    citation_list: list[str]
+    note_list: list[str]
     date: DateLike
     street: str
     locality: str
@@ -230,8 +229,8 @@ class AttributeLike(Protocol):
     """Protocol for Attribute-like objects."""
 
     private: bool
-    citation_list: Sequence[str]
-    note_list: Sequence[str]
+    citation_list: list[str]
+    note_list: list[str]
     type: GrampsTypeLike  # AttributeType
     value: str
 
@@ -250,8 +249,8 @@ class UrlLike(Protocol):
 class LdsOrdLike(Protocol):
     """Protocol for LdsOrd-like objects."""
 
-    citation_list: Sequence[str]
-    note_list: Sequence[str]
+    citation_list: list[str]
+    note_list: list[str]
     date: DateLike
     type: int  # LDS ordinance type
     place: str
@@ -266,8 +265,8 @@ class PersonRefLike(Protocol):
     """Protocol for PersonRef-like objects."""
 
     private: bool
-    citation_list: Sequence[str]
-    note_list: Sequence[str]
+    citation_list: list[str]
+    note_list: list[str]
     ref: str  # Person handle
     rel: str  # Association/relationship
 
@@ -277,8 +276,8 @@ class ChildRefLike(Protocol):
     """Protocol for ChildRef-like objects."""
 
     private: bool
-    citation_list: Sequence[str]
-    note_list: Sequence[str]
+    citation_list: list[str]
+    note_list: list[str]
     ref: str  # Child handle
     frel: GrampsTypeLike  # ChildRefType - Father relationship
     mrel: GrampsTypeLike  # ChildRefType - Mother relationship
@@ -297,7 +296,7 @@ class RepoRefLike(Protocol):
     """Protocol for RepoRef-like objects."""
 
     private: bool
-    note_list: Sequence[str]
+    note_list: list[str]
     ref: str  # Repository handle
     call_number: str
     media_type: GrampsTypeLike  # SourceMediaType
@@ -318,7 +317,7 @@ class StyledTextTagLike(Protocol):
 
     name: GrampsTypeLike  # StyledTextTagType
     value: str | int | None
-    ranges: Sequence[tuple[int, int]]
+    ranges: list[tuple[int, int]]
 
 
 @runtime_checkable
@@ -326,7 +325,7 @@ class StyledTextLike(Protocol):
     """Protocol for StyledText-like objects."""
 
     string: str
-    tags: Sequence[StyledTextTagLike]
+    tags: list[StyledTextTagLike]
 
 
 @runtime_checkable
@@ -361,23 +360,23 @@ class PersonLike(Protocol):
     gramps_id: str
     gender: int
     primary_name: NameLike
-    alternate_names: Sequence[NameLike]
+    alternate_names: list[NameLike]
     death_ref_index: int
     birth_ref_index: int
-    event_ref_list: Sequence[EventRefLike]
-    family_list: Sequence[str]
-    parent_family_list: Sequence[str]
-    media_list: Sequence[MediaRefLike]
-    address_list: Sequence[AddressLike]
-    attribute_list: Sequence[AttributeLike]
-    urls: Sequence[UrlLike]
-    lds_ord_list: Sequence[LdsOrdLike]
-    citation_list: Sequence[str]
-    note_list: Sequence[str]
+    event_ref_list: list[EventRefLike]
+    family_list: list[str]
+    parent_family_list: list[str]
+    media_list: list[MediaRefLike]
+    address_list: list[AddressLike]
+    attribute_list: list[AttributeLike]
+    urls: list[UrlLike]
+    lds_ord_list: list[LdsOrdLike]
+    citation_list: list[str]
+    note_list: list[str]
     change: int
-    tag_list: Sequence[str]
+    tag_list: list[str]
     private: bool
-    person_ref_list: Sequence[PersonRefLike]
+    person_ref_list: list[PersonRefLike]
 
 
 @runtime_checkable
@@ -388,16 +387,16 @@ class FamilyLike(Protocol):
     gramps_id: str
     father_handle: str | None
     mother_handle: str | None
-    child_ref_list: Sequence[ChildRefLike]
+    child_ref_list: list[ChildRefLike]
     type: GrampsTypeLike  # FamilyRelType
-    event_ref_list: Sequence[EventRefLike]
-    media_list: Sequence[MediaRefLike]
-    attribute_list: Sequence[AttributeLike]
-    lds_ord_list: Sequence[LdsOrdLike]
-    citation_list: Sequence[str]
-    note_list: Sequence[str]
+    event_ref_list: list[EventRefLike]
+    media_list: list[MediaRefLike]
+    attribute_list: list[AttributeLike]
+    lds_ord_list: list[LdsOrdLike]
+    citation_list: list[str]
+    note_list: list[str]
     change: int
-    tag_list: Sequence[str]
+    tag_list: list[str]
     private: bool
 
 
@@ -411,12 +410,12 @@ class EventLike(Protocol):
     date: DateLike
     description: str
     place: str | None
-    citation_list: Sequence[str]
-    note_list: Sequence[str]
-    media_list: Sequence[MediaRefLike]
-    attribute_list: Sequence[AttributeLike]
+    citation_list: list[str]
+    note_list: list[str]
+    media_list: list[MediaRefLike]
+    attribute_list: list[AttributeLike]
     change: int
-    tag_list: Sequence[str]
+    tag_list: list[str]
     private: bool
 
 
@@ -430,12 +429,12 @@ class MediaLike(Protocol):
     mime: str
     desc: str
     checksum: str
-    attribute_list: Sequence[AttributeLike]
-    citation_list: Sequence[str]
-    note_list: Sequence[str]
+    attribute_list: list[AttributeLike]
+    citation_list: list[str]
+    note_list: list[str]
     change: int
     date: DateLike
-    tag_list: Sequence[str]
+    tag_list: list[str]
     private: bool
 
 
@@ -448,18 +447,18 @@ class PlaceLike(Protocol):
     title: str
     long: str
     lat: str
-    placeref_list: Sequence[PlaceRefLike]
+    placeref_list: list[PlaceRefLike]
     name: PlaceNameLike
-    alt_names: Sequence[PlaceNameLike]
+    alt_names: list[PlaceNameLike]
     place_type: GrampsTypeLike  # PlaceType
     code: str
-    alt_loc: Sequence[LocationLike]
-    urls: Sequence[UrlLike]
-    media_list: Sequence[MediaRefLike]
-    citation_list: Sequence[str]
-    note_list: Sequence[str]
+    alt_loc: list[LocationLike]
+    urls: list[UrlLike]
+    media_list: list[MediaRefLike]
+    citation_list: list[str]
+    note_list: list[str]
     change: int
-    tag_list: Sequence[str]
+    tag_list: list[str]
     private: bool
 
 
@@ -472,13 +471,13 @@ class SourceLike(Protocol):
     title: str
     author: str
     pubinfo: str
-    note_list: Sequence[str]
-    media_list: Sequence[MediaRefLike]
+    note_list: list[str]
+    media_list: list[MediaRefLike]
     abbrev: str
     change: int
-    attribute_list: Sequence[SrcAttributeLike]
-    reporef_list: Sequence[RepoRefLike]
-    tag_list: Sequence[str]
+    attribute_list: list[SrcAttributeLike]
+    reporef_list: list[RepoRefLike]
+    tag_list: list[str]
     private: bool
 
 
@@ -492,11 +491,11 @@ class CitationLike(Protocol):
     page: str
     confidence: int
     source_handle: str
-    note_list: Sequence[str]
-    media_list: Sequence[MediaRefLike]
-    attribute_list: Sequence[SrcAttributeLike]
+    note_list: list[str]
+    media_list: list[MediaRefLike]
+    attribute_list: list[SrcAttributeLike]
     change: int
-    tag_list: Sequence[str]
+    tag_list: list[str]
     private: bool
 
 
@@ -508,11 +507,11 @@ class RepositoryLike(Protocol):
     gramps_id: str
     type: GrampsTypeLike  # RepositoryType
     name: str
-    note_list: Sequence[str]
-    address_list: Sequence[AddressLike]
-    urls: Sequence[UrlLike]
+    note_list: list[str]
+    address_list: list[AddressLike]
+    urls: list[UrlLike]
     change: int
-    tag_list: Sequence[str]
+    tag_list: list[str]
     private: bool
 
 
@@ -526,7 +525,7 @@ class NoteLike(Protocol):
     format: int
     type: GrampsTypeLike  # NoteType
     change: int
-    tag_list: Sequence[str]
+    tag_list: list[str]
     private: bool
 
 
@@ -539,52 +538,3 @@ class TagLike(Protocol):
     color: str
     priority: int
     change: int
-
-
-if TYPE_CHECKING:
-    # Verify that actual classes implement their corresponding protocols
-    _gramps_type: Type[GrampsTypeLike] = GrampsType
-    _name_type: Type[GrampsTypeLike] = NameType
-    _attribute_type: Type[GrampsTypeLike] = AttributeType
-    _url_type: Type[GrampsTypeLike] = UrlType
-    _event_role_type: Type[GrampsTypeLike] = EventRoleType
-    _name_origin_type: Type[GrampsTypeLike] = NameOriginType
-    _event_type: Type[GrampsTypeLike] = EventType
-    _family_rel_type: Type[GrampsTypeLike] = FamilyRelType
-    _child_ref_type: Type[GrampsTypeLike] = ChildRefType
-    _place_type: Type[GrampsTypeLike] = PlaceType
-    _repository_type: Type[GrampsTypeLike] = RepositoryType
-    _src_attribute_type: Type[GrampsTypeLike] = SrcAttributeType
-    _source_media_type: Type[GrampsTypeLike] = SourceMediaType
-    _styled_text_tag_type: Type[GrampsTypeLike] = StyledTextTagType
-    _note_type: Type[GrampsTypeLike] = NoteType
-
-    _date: Type[DateLike] = Date
-    _surname: Type[SurnameLike] = Surname
-    _name: Type[NameLike] = Name
-    _event_ref: Type[EventRefLike] = EventRef
-    _media_ref: Type[MediaRefLike] = MediaRef
-    _address: Type[AddressLike] = Address
-    _attribute: Type[AttributeLike] = Attribute
-    _url: Type[UrlLike] = Url
-    _lds_ord: Type[LdsOrdLike] = LdsOrd
-    _person_ref: Type[PersonRefLike] = PersonRef
-    _child_ref: Type[ChildRefLike] = ChildRef
-    _place_ref: Type[PlaceRefLike] = PlaceRef
-    _repo_ref: Type[RepoRefLike] = RepoRef
-    _src_attribute: Type[SrcAttributeLike] = SrcAttribute
-    _styled_text_tag: Type[StyledTextTagLike] = StyledTextTag
-    _styled_text: Type[StyledTextLike] = StyledText
-    _place_name: Type[PlaceNameLike] = PlaceName
-    _location: Type[LocationLike] = Location
-
-    _person: Type[PersonLike] = Person
-    _family: Type[FamilyLike] = Family
-    _event: Type[EventLike] = Event
-    _media: Type[MediaLike] = Media
-    _place: Type[PlaceLike] = Place
-    _source: Type[SourceLike] = Source
-    _citation: Type[CitationLike] = Citation
-    _repository: Type[RepositoryLike] = Repository
-    _note: Type[NoteLike] = Note
-    _tag: Type[TagLike] = Tag

--- a/gramps/gen/types.py
+++ b/gramps/gen/types.py
@@ -320,8 +320,8 @@ class LocationLike(Protocol):
 class PersonLike(Protocol):
     """Protocol for Person-like objects."""
 
-    handle: str
-    gramps_id: str
+    handle: PersonHandle
+    gramps_id: PersonGrampsID
     gender: int
     primary_name: NameLike
     alternate_names: list[NameLike]
@@ -347,8 +347,8 @@ class PersonLike(Protocol):
 class FamilyLike(Protocol):
     """Protocol for Family-like objects."""
 
-    handle: str
-    gramps_id: str
+    handle: FamilyHandle
+    gramps_id: FamilyGrampsID
     father_handle: str | None
     mother_handle: str | None
     child_ref_list: list[ChildRefLike]
@@ -368,8 +368,8 @@ class FamilyLike(Protocol):
 class EventLike(Protocol):
     """Protocol for Event-like objects."""
 
-    handle: str
-    gramps_id: str
+    handle: EventHandle
+    gramps_id: EventGrampsID
     type: GrampsTypeLike  # EventType
     date: DateLike
     description: str
@@ -387,8 +387,8 @@ class EventLike(Protocol):
 class MediaLike(Protocol):
     """Protocol for Media-like objects."""
 
-    handle: str
-    gramps_id: str
+    handle: MediaHandle
+    gramps_id: MediaGrampsID
     path: str
     mime: str
     desc: str
@@ -406,8 +406,8 @@ class MediaLike(Protocol):
 class PlaceLike(Protocol):
     """Protocol for Place-like objects."""
 
-    handle: str
-    gramps_id: str
+    handle: PlaceHandle
+    gramps_id: PlaceGrampsID
     title: str
     long: str
     lat: str
@@ -430,8 +430,8 @@ class PlaceLike(Protocol):
 class SourceLike(Protocol):
     """Protocol for Source-like objects."""
 
-    handle: str
-    gramps_id: str
+    handle: SourceHandle
+    gramps_id: SourceGrampsID
     title: str
     author: str
     pubinfo: str
@@ -449,8 +449,8 @@ class SourceLike(Protocol):
 class CitationLike(Protocol):
     """Protocol for Citation-like objects."""
 
-    handle: str
-    gramps_id: str
+    handle: CitationHandle
+    gramps_id: CitationGrampsID
     date: DateLike
     page: str
     confidence: int
@@ -467,8 +467,8 @@ class CitationLike(Protocol):
 class RepositoryLike(Protocol):
     """Protocol for Repository-like objects."""
 
-    handle: str
-    gramps_id: str
+    handle: RepositoryHandle
+    gramps_id: RepositoryGrampsID
     type: GrampsTypeLike  # RepositoryType
     name: str
     note_list: list[str]
@@ -483,8 +483,8 @@ class RepositoryLike(Protocol):
 class NoteLike(Protocol):
     """Protocol for Note-like objects."""
 
-    handle: str
-    gramps_id: str
+    handle: NoteHandle
+    gramps_id: NoteGrampsID
     text: StyledTextLike
     format: int
     type: GrampsTypeLike  # NoteType
@@ -497,7 +497,7 @@ class NoteLike(Protocol):
 class TagLike(Protocol):
     """Protocol for Tag-like objects."""
 
-    handle: str
+    handle: TagHandle
     name: str
     color: str
     priority: int

--- a/gramps/gen/types.py
+++ b/gramps/gen/types.py
@@ -454,7 +454,7 @@ class CitationLike(Protocol):
     date: DateLike
     page: str
     confidence: int
-    source_handle: str
+    source_handle: str | None
     note_list: list[str]
     media_list: list[MediaRefLike]
     attribute_list: list[SrcAttributeLike]


### PR DESCRIPTION
Typing of functions/methods involving Gramps objects has become significantly more complicated in Gramps 6.0 due to the introduction of `DataDict`.

As was discussed in various places, e.g. [here](https://github.com/gramps-project/gramps/pull/2010#issuecomment-2719256251), protocols seem to be the right way to address this.

This PR contains a proof of concept, adding protocols for ~~all primary~~ the `Person` primary type and some secondary Gramps types. The code at the bottom checks that the instances are compatible with the protocols (at list w.r.t. existence of methods).

Related: #2018, #1934, #1919, #2010.

CC @dsblank, @stevenyoungs, @bartfeenstra 