### PR TITLE
Use filter.apply() rather than apply_to_one()

### DIFF
--- a/gramps/gen/filters/rules/person/_deeprelationshippathbetween.py
+++ b/gramps/gen/filters/rules/person/_deeprelationshippathbetween.py
@@ -24,7 +24,6 @@
 # Standard Python modules
 #
 # -------------------------------------------------------------------------
-from __future__ import annotations
 from collections import deque
 
 # -------------------------------------------------------------------------
@@ -41,7 +40,6 @@ from ....const import GRAMPS_LOCALE as glocale
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Union, List, Set, Dict
 from ....lib import Person
 from ....db import Database
 from ....types import FamilyHandle, PersonHandle
@@ -57,7 +55,7 @@ _ = glocale.translation.gettext
 def get_family_handle_people(
     db: Database, exclude_handle: str, family_handle: FamilyHandle
 ):
-    people: Set[str] = set()
+    people: set[str] = set()
 
     family = db.get_family_from_handle(family_handle)
 
@@ -77,12 +75,13 @@ def get_family_handle_people(
 
 def get_person_family_people(
     db: Database, person: Person, person_handle: PersonHandle
-) -> Set[str]:
-    people: Set[str] = set()
+) -> set[str]:
+    people: set[str] = set()
 
-    def add_family_handle_list(fam_list: List[FamilyHandle]):
+    def add_family_handle_list(fam_list: list[FamilyHandle]):
         for family_handle in fam_list:
-            people.update(get_family_handle_people(db, person_handle, family_handle))
+            ppl = get_family_handle_people(db, person_handle, family_handle)
+            people.update(ppl)
 
     add_family_handle_list(person.family_list)
     add_family_handle_list(person.parent_family_list)
@@ -91,8 +90,8 @@ def get_person_family_people(
 
 
 def find_deep_relations(
-    db: Database, user, person: Person | None, target_people: List[str]
-) -> Set[str]:
+    db: Database, user, person: Person | None, target_people: list[str]
+) -> set[str]:
     """This explores all possible paths between a person and one or more
     targets.  The algorithm processes paths in a breadth first wave, one
     remove at a time.  The first path that reaches a target causes the target
@@ -101,12 +100,12 @@ def find_deep_relations(
     The function stores to do data and intermediate results in an ordered dict,
     rather than using a recursive algorithm because some trees have been found
     that exceed the standard python recursive depth."""
-    return_paths: Set[str] = set()  # all people in paths between targets and person
+    return_paths: set[str] = set()  # people in paths between targets
     if person is None:
         return return_paths
     todo = deque([person.handle])  # list of work to do, handles, add to right,
     #                                pop from left
-    done: Dict[str, Union[str, None]] = {}  # The key records handles already examined,
+    done: dict[str, str | None] = {}  # handles already examined,
     # the value is a handle of the previous person in the path, or None at
     # head of path.  This forms a linked list of handles along the path.
     done[person.handle] = None
@@ -166,28 +165,20 @@ class DeepRelationshipPathBetween(Rule):
         self.filt = MatchesFilter([filter_name])
         self.filt.requestprepare(db, user)
 
+        filt = self.filt.find_filter()
+        target_people = filt.apply(db, user=user) if filt else []
+
         if user:
-            user.begin_progress(
-                _("Finding relationship paths"),
-                _("Retrieving all sub-filter matches"),
-                db.get_number_of_people(),
-            )
-        target_people = []
-        for person in db.iter_people():
-            if self.filt.apply_to_one(db, person):
-                target_people.append(person.handle)
-            if user:
-                user.step_progress()
-        if user:
-            user.end_progress()
             user.begin_progress(
                 _("Finding relationship paths"),
                 _("Evaluating people"),
-                db.get_number_of_people(),
+                len(target_people),
             )
-        self.selected_handles: Set[str] = find_deep_relations(
+
+        self.selected_handles: set[str] = find_deep_relations(
             db, user, root_person, target_people
         )
+
         if user:
             user.end_progress()
 

--- a/gramps/gen/filters/rules/person/_hascommonancestorwithfiltermatch.py
+++ b/gramps/gen/filters/rules/person/_hascommonancestorwithfiltermatch.py
@@ -23,17 +23,10 @@
 #
 # -------------------------------------------------------------------------
 from ....const import GRAMPS_LOCALE as glocale
-
-_ = glocale.translation.gettext
-
-# -------------------------------------------------------------------------
-#
-# Gramps modules
-#
-# -------------------------------------------------------------------------
-from ....utils.db import for_each_ancestor
 from ._hascommonancestorwith import HasCommonAncestorWith
 from ._matchesfilter import MatchesFilter
+
+_ = glocale.translation.gettext
 
 
 # -------------------------------------------------------------------------
@@ -48,7 +41,8 @@ class HasCommonAncestorWithFilterMatch(HasCommonAncestorWith):
     labels = [_("Filter name:")]
     name = _("People with a common ancestor with <filter> match")
     description = _(
-        "Matches people that have a common ancestor " "with anybody matched by a filter"
+        "Matches people that have a common ancestor "  # noqa: E501
+        "with anybody matched by a filter"
     )
     category = _("Ancestral filters")
 
@@ -61,28 +55,20 @@ class HasCommonAncestorWithFilterMatch(HasCommonAncestorWith):
         # For each(!) person we keep track of who their ancestors
         # are, in a set(). So we only have to compute a person's
         # ancestor list once.
-        # Start with filling the cache for root person (gramps_id in self.list[0])
+        # Filling the cache for root person (gramps_id in self.list[0])
         self.ancestor_cache = {}
         self.with_people = []
         self.filt = MatchesFilter(self.list)
         self.filt.requestprepare(db, user)
-        if user:
-            user.begin_progress(
-                self.category,
-                _("Retrieving all sub-filter matches"),
-                db.get_number_of_people(),
-            )
-        for person in db.iter_people():
-            if user:
-                user.step_progress()
-            if person and self.filt.apply_to_one(db, person):
-                # store all people in the filter so as to compare later
-                self.with_people.append(person.handle)
+
+        filt = self.filt.find_filter()
+        if filt:
+            for handle in filt.apply(db, user=user):
+                self.with_people.append(handle)
                 # fill list of ancestor of person if not present yet
-                if person.handle not in self.ancestor_cache:
+                if handle not in self.ancestor_cache:
+                    person = db.get_raw_person_data(handle)
                     self.add_ancs(db, person)
-        if user:
-            user.end_progress()
 
     def reset(self):
         self.filt.requestreset()

--- a/gramps/gen/filters/rules/person/_isancestoroffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_isancestoroffiltermatch.py
@@ -23,25 +23,12 @@
 #
 # -------------------------------------------------------------------------
 from ....const import GRAMPS_LOCALE as glocale
-
-_ = glocale.translation.gettext
-
-# -------------------------------------------------------------------------
-#
-# Gramps modules
-#
-# -------------------------------------------------------------------------
 from ._isancestorof import IsAncestorOf
 from ._matchesfilter import MatchesFilter
-
-# -------------------------------------------------------------------------
-#
-# Typing modules
-#
-# -------------------------------------------------------------------------
-from typing import Set
 from ....lib import Person
 from ....db import Database
+
+_ = glocale.translation.gettext
 
 
 # -------------------------------------------------------------------------
@@ -62,7 +49,7 @@ class IsAncestorOfFilterMatch(IsAncestorOf):
 
     def prepare(self, db: Database, user):
         self.db = db
-        self.selected_handles: Set[str] = set()
+        self.selected_handles: set[str] = set()
         try:
             if int(self.list[1]):
                 first = False
@@ -73,19 +60,12 @@ class IsAncestorOfFilterMatch(IsAncestorOf):
 
         self.filt = MatchesFilter(self.list[0:1])
         self.filt.requestprepare(db, user)
-        if user:
-            user.begin_progress(
-                self.category,
-                _("Retrieving all sub-filter matches"),
-                db.get_number_of_people(),
-            )
-        for person in db.iter_people():
-            if user:
-                user.step_progress()
-            if self.filt.apply_to_one(db, person):
+
+        filt = self.filt.find_filter()
+        if filt:
+            for handle in filt.apply(db, user=user):
+                person = db.get_raw_person_data(handle)
                 self.init_ancestor_list(db, person, first)
-        if user:
-            user.end_progress()
 
     def reset(self):
         self.filt.requestreset()

--- a/gramps/gen/filters/rules/person/_ischildoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_ischildoffiltermatch.py
@@ -23,25 +23,12 @@
 #
 # -------------------------------------------------------------------------
 from ....const import GRAMPS_LOCALE as glocale
-
-_ = glocale.translation.gettext
-
-# -------------------------------------------------------------------------
-#
-# Gramps modules
-#
-# -------------------------------------------------------------------------
 from .. import Rule
 from ._matchesfilter import MatchesFilter
-
-# -------------------------------------------------------------------------
-#
-# Typing modules
-#
-# -------------------------------------------------------------------------
-from typing import Set
 from ....lib import Person
 from ....db import Database
+
+_ = glocale.translation.gettext
 
 
 # -------------------------------------------------------------------------
@@ -60,22 +47,15 @@ class IsChildOfFilterMatch(Rule):
 
     def prepare(self, db: Database, user):
         self.db = db
-        self.selected_handles: Set[str] = set()
+        self.selected_handles: set[str] = set()
         self.filt = MatchesFilter(self.list)
         self.filt.requestprepare(db, user)
-        if user:
-            user.begin_progress(
-                self.category,
-                _("Retrieving all sub-filter matches"),
-                db.get_number_of_people(),
-            )
-        for person in db.iter_people():
-            if user:
-                user.step_progress()
-            if self.filt.apply_to_one(db, person):
+
+        filt = self.filt.find_filter()
+        if filt:
+            for handle in filt.apply(db, user=user):
+                person = db.get_raw_person_data(handle)
                 self.init_list(person)
-        if user:
-            user.end_progress()
 
     def reset(self):
         self.filt.requestreset()

--- a/gramps/gen/filters/rules/person/_isdescendantfamilyoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_isdescendantfamilyoffiltermatch.py
@@ -22,21 +22,13 @@
 # Standard Python modules
 #
 # -------------------------------------------------------------------------
-from typing import Set
-
 from ....const import GRAMPS_LOCALE as glocale
-
-_ = glocale.translation.gettext
-
-# -------------------------------------------------------------------------
-#
-# Gramps modules
-#
-# -------------------------------------------------------------------------
 from ._isdescendantfamilyof import IsDescendantFamilyOf
 from ._matchesfilter import MatchesFilter
 from ....types import PersonHandle
 from ....db.generic import Database
+
+_ = glocale.translation.gettext
 
 
 # -------------------------------------------------------------------------
@@ -58,25 +50,16 @@ class IsDescendantFamilyOfFilterMatch(IsDescendantFamilyOf):
 
     def prepare(self, db: Database, user):
         self.db = db
-        self.selected_handles: Set[PersonHandle] = set()
+        self.selected_handles: set[PersonHandle] = set()
 
         self.matchfilt = MatchesFilter(self.list[0:1])
         self.matchfilt.requestprepare(db, user)
-        if user:
-            user.begin_progress(
-                self.category,
-                _("Retrieving all sub-filter matches"),
-                db.get_number_of_people(),
-            )
-        # Must use db.iter_people() rather that db._iter_raw_person_data()
-        # because of proxies:
-        for person in db.iter_people():
-            if user:
-                user.step_progress()
-            if self.matchfilt.apply_to_one(db, person):
+
+        filt = self.matchfilt.find_filter()
+        if filt:
+            for handle in filt.apply(db, user=user):
+                person = db.get_raw_person_data(handle)
                 self.add_matches(person)
-        if user:
-            user.end_progress()
 
     def reset(self):
         self.matchfilt.requestreset()

--- a/gramps/gen/filters/rules/person/_isdescendantoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_isdescendantoffiltermatch.py
@@ -23,25 +23,12 @@
 #
 # -------------------------------------------------------------------------
 from ....const import GRAMPS_LOCALE as glocale
-
-_ = glocale.translation.gettext
-
-# -------------------------------------------------------------------------
-#
-# Gramps modules
-#
-# -------------------------------------------------------------------------
 from ._isdescendantof import IsDescendantOf
 from ._matchesfilter import MatchesFilter
-
-# -------------------------------------------------------------------------
-#
-# Typing modules
-#
-# -------------------------------------------------------------------------
-from typing import Set
 from ....lib import Person
 from ....db import Database
+
+_ = glocale.translation.gettext
 
 
 # -------------------------------------------------------------------------
@@ -62,7 +49,7 @@ class IsDescendantOfFilterMatch(IsDescendantOf):
 
     def prepare(self, db: Database, user):
         self.db = db
-        self.selected_handles: Set[str] = set()
+        self.selected_handles: set[str] = set()
         try:
             if int(self.list[1]):
                 first = False
@@ -73,19 +60,12 @@ class IsDescendantOfFilterMatch(IsDescendantOf):
 
         self.filt = MatchesFilter(self.list[0:1])
         self.filt.requestprepare(db, user)
-        if user:
-            user.begin_progress(
-                self.category,
-                _("Retrieving all sub-filter matches"),
-                db.get_number_of_people(),
-            )
-        for person in db.iter_people():
-            if user:
-                user.step_progress()
-            if self.filt.apply_to_one(db, person):
+
+        filt = self.filt.find_filter()
+        if filt:
+            for handle in filt.apply(db, user=user):
+                person = db.get_raw_person_data(handle)
                 self.init_list(person, first)
-        if user:
-            user.end_progress()
 
     def reset(self):
         self.filt.requestreset()

--- a/gramps/gen/filters/rules/person/_isparentoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_isparentoffiltermatch.py
@@ -23,25 +23,12 @@
 #
 # -------------------------------------------------------------------------
 from ....const import GRAMPS_LOCALE as glocale
-
-_ = glocale.translation.gettext
-
-# -------------------------------------------------------------------------
-#
-# Gramps modules
-#
-# -------------------------------------------------------------------------
 from .. import Rule
 from ._matchesfilter import MatchesFilter
-
-# -------------------------------------------------------------------------
-#
-# Typing modules
-#
-# -------------------------------------------------------------------------
-from typing import Set
 from ....lib import Person
 from ....db import Database
+
+_ = glocale.translation.gettext
 
 
 # -------------------------------------------------------------------------
@@ -60,22 +47,15 @@ class IsParentOfFilterMatch(Rule):
 
     def prepare(self, db: Database, user):
         self.db = db
-        self.selected_handles: Set[str] = set()
+        self.selected_handles: set[str] = set()
         self.filt = MatchesFilter(self.list)
         self.filt.requestprepare(db, user)
-        if user:
-            user.begin_progress(
-                self.category,
-                _("Retrieving all sub-filter matches"),
-                db.get_number_of_people(),
-            )
-        for person in db.iter_people():
-            if user:
-                user.step_progress()
-            if self.filt.apply_to_one(db, person):
+
+        filt = self.filt.find_filter()
+        if filt:
+            for handle in filt.apply(db, user=user):
+                person = db.get_raw_person_data(handle)
                 self.init_list(person)
-        if user:
-            user.end_progress()
 
     def reset(self):
         self.filt.requestreset()
@@ -86,7 +66,7 @@ class IsParentOfFilterMatch(Rule):
 
     def init_list(self, person: Person):
         for fam_id in person.parent_family_list:
-            fam = self.db.get_family_from_handle(fam_id)
+            fam = self.db.get_raw_family_data(fam_id)
             if fam:
                 self.selected_handles.update(
                     parent_id

--- a/gramps/gen/filters/rules/person/_issiblingoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_issiblingoffiltermatch.py
@@ -23,25 +23,12 @@
 #
 # -------------------------------------------------------------------------
 from ....const import GRAMPS_LOCALE as glocale
-
-_ = glocale.translation.gettext
-
-# -------------------------------------------------------------------------
-#
-# Gramps modules
-#
-# -------------------------------------------------------------------------
 from .. import Rule
 from ._matchesfilter import MatchesFilter
-
-# -------------------------------------------------------------------------
-#
-# Typing modules
-#
-# -------------------------------------------------------------------------
-from typing import Set
 from ....lib import Person
 from ....db import Database
+
+_ = glocale.translation.gettext
 
 
 # -------------------------------------------------------------------------
@@ -59,22 +46,15 @@ class IsSiblingOfFilterMatch(Rule):
 
     def prepare(self, db: Database, user):
         self.db = db
-        self.selected_handles: Set[str] = set()
+        self.selected_handles: set[str] = set()
         self.matchfilt = MatchesFilter(self.list)
         self.matchfilt.requestprepare(db, user)
-        if user:
-            user.begin_progress(
-                self.category,
-                _("Retrieving all sub-filter matches"),
-                db.get_number_of_people(),
-            )
-        for person in db.iter_people():
-            if user:
-                user.step_progress()
-            if self.matchfilt.apply_to_one(db, person):
+
+        filt = self.matchfilt.find_filter()
+        if filt:
+            for handle in filt.apply(db, user=user):
+                person = db.get_raw_person_data(handle)
                 self.init_list(person)
-        if user:
-            user.end_progress()
 
     def reset(self):
         self.matchfilt.requestreset()
@@ -86,11 +66,10 @@ class IsSiblingOfFilterMatch(Rule):
     def init_list(self, person: Person):
         if not person:
             return
-        fam_id = (
-            person.parent_family_list[0] if len(person.parent_family_list) > 0 else None
-        )
+        fam_list = person.parent_family_list
+        fam_id = fam_list[0] if fam_list else None
         if fam_id:
-            fam = self.db.get_family_from_handle(fam_id)
+            fam = self.db.get_raw_family_data(fam_id)
             if fam:
                 self.selected_handles.update(
                     child_ref.ref

--- a/gramps/gen/filters/rules/test/person_rules_test.py
+++ b/gramps/gen/filters/rules/test/person_rules_test.py
@@ -37,8 +37,10 @@ from ....filters import GenericFilter, CustomFilters
 from ....const import TEST_DIR
 from ....user import User
 from ....utils.unittest import localize_date
+from ....proxy import PrivateProxyDb
 
 from ..person import (
+    DeepRelationshipPathBetween,
     Disconnected,
     Everyone,
     FamilyWithIncompleteEvent,
@@ -1552,6 +1554,140 @@ class BaseTest(unittest.TestCase):
             # This test documents the behavior
             self.assertIsInstance(results1, set)
             self.assertIsInstance(results2, set)
+
+
+class FilterMatchMissingFilterTest(unittest.TestCase):
+    """
+    Tests that all filtermatch rules handle find_filter() returning None
+    gracefully (i.e. return an empty result rather than raising AttributeError).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.db = import_as_dict(EXAMPLE, User())
+
+    def _apply_rule(self, rule):
+        """Apply a filter with the given rule directly, no base filter registered."""
+        filter_ = GenericFilter()
+        filter_.add_rule(rule)
+        return set(filter_.apply(self.db))
+
+    def test_IsDescendantOfFilterMatch_missing_filter(self):
+        rule = IsDescendantOfFilterMatch(["_no_such_filter_"])
+        self.assertEqual(self._apply_rule(rule), set())
+
+    def test_IsDescendantFamilyOfFilterMatch_missing_filter(self):
+        rule = IsDescendantFamilyOfFilterMatch(["_no_such_filter_"])
+        self.assertEqual(self._apply_rule(rule), set())
+
+    def test_IsParentOfFilterMatch_missing_filter(self):
+        rule = IsParentOfFilterMatch(["_no_such_filter_"])
+        self.assertEqual(self._apply_rule(rule), set())
+
+    def test_IsSiblingOfFilterMatch_missing_filter(self):
+        rule = IsSiblingOfFilterMatch(["_no_such_filter_"])
+        self.assertEqual(self._apply_rule(rule), set())
+
+    def test_IsAncestorOfFilterMatch_missing_filter(self):
+        rule = IsAncestorOfFilterMatch(["_no_such_filter_"])
+        self.assertEqual(self._apply_rule(rule), set())
+
+    def test_IsChildOfFilterMatch_missing_filter(self):
+        rule = IsChildOfFilterMatch(["_no_such_filter_"])
+        self.assertEqual(self._apply_rule(rule), set())
+
+    def test_HasCommonAncestorWithFilterMatch_missing_filter(self):
+        rule = HasCommonAncestorWithFilterMatch(["_no_such_filter_"])
+        self.assertEqual(self._apply_rule(rule), set())
+
+    def test_DeepRelationshipPathBetween_missing_filter(self):
+        rule = DeepRelationshipPathBetween(["I0005", "_no_such_filter_"])
+        self.assertEqual(self._apply_rule(rule), set())
+
+
+class FilterMatchProxyDbTest(unittest.TestCase):
+    """
+    Tests that filtermatch rules correctly respect proxy databases.
+
+    The example database contains one private person (I0988) who is a parent
+    of I0092. When using PrivateProxyDb, I0988 must not appear in sub-filter
+    seed results, so relationships through that person should not be found.
+    """
+
+    # I0988 is the one private person in example.gramps; I0092 is their child.
+    PRIVATE_PERSON_ID = "I0988"
+    CHILD_OF_PRIVATE_ID = "I0092"
+
+    @classmethod
+    def setUpClass(cls):
+        raw_db = import_as_dict(EXAMPLE, User())
+        cls.db = raw_db
+        cls.proxy_db = PrivateProxyDb(raw_db)
+
+        # Confirm setup assumptions
+        private_person = raw_db.get_person_from_gramps_id(cls.PRIVATE_PERSON_ID)
+        assert (
+            private_person is not None and private_person.private
+        ), "Test setup: I0988 must be private in example.gramps"
+        assert (
+            cls.proxy_db.get_person_from_handle(private_person.handle) is None
+        ), "Test setup: PrivateProxyDb must hide private people"
+
+    def _apply_rule_on(self, rule, db, baserule, base_name="Base"):
+        """Register base filter and apply the outer rule against db."""
+        base_filter = GenericFilter()
+        if isinstance(baserule, list):
+            base_filter.set_rules(baserule)
+        else:
+            base_filter.add_rule(baserule)
+        base_filter.set_name(base_name)
+        CustomFilters.get_filters_dict("Person")[base_name] = base_filter
+
+        outer = GenericFilter()
+        outer.add_rule(rule)
+        return set(outer.apply(db))
+
+    def test_IsChildOfFilterMatch_proxy_excludes_private_seed(self):
+        """
+        When the seed filter contains only the private person I0988,
+        IsChildOfFilterMatch must return empty on PrivateProxyDb because
+        I0988 is excluded from the seed, so their children are not populated.
+        """
+        seed = HasIdOf([self.PRIVATE_PERSON_ID])
+        rule = IsChildOfFilterMatch(["Base"])
+
+        # Normal db: I0988 is the seed, so I0092 (their child) is found.
+        full_result = self._apply_rule_on(rule, self.db, seed)
+        self.assertIn(
+            self.db.get_person_from_gramps_id(self.CHILD_OF_PRIVATE_ID).handle,
+            full_result,
+        )
+
+        # Proxy db: I0988 is hidden, so no seed is found and result is empty.
+        proxy_result = self._apply_rule_on(rule, self.proxy_db, seed)
+        self.assertEqual(proxy_result, set())
+
+    def test_IsParentOfFilterMatch_proxy_excludes_private_from_result(self):
+        """
+        When the seed filter contains I0092 (child of private I0988),
+        IsParentOfFilterMatch should not return I0988 on PrivateProxyDb
+        because the outer filter itself iterates through the proxy.
+        """
+        seed = HasIdOf([self.CHILD_OF_PRIVATE_ID])
+        rule = IsParentOfFilterMatch(["Base"])
+
+        private_handle = self.db.get_person_from_gramps_id(
+            self.PRIVATE_PERSON_ID
+        ).handle
+
+        # Normal db: I0988 is a parent of I0092, so they appear in results.
+        full_result = self._apply_rule_on(rule, self.db, seed)
+        self.assertIn(private_handle, full_result)
+
+        # Proxy db: I0988 is hidden from the outer iteration, so they must
+        # not appear in results even though they are in selected_handles.
+        proxy_result = self._apply_rule_on(rule, self.proxy_db, seed)
+        self.assertNotIn(private_handle, proxy_result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR replaces this construct when using a filter inside a filter:

```python
for person in db.iter_people():
    if self.filt.apply_to_one(db, person):
        ...
```

with the better:

```python
for handle in self.filt.find_filter().apply(db):
    person = db.get_raw_person_data(handle)
```

This has possible speed increases in two ways:

1. The filter.apply() can use the filter optimizer
2. The selected_handles are then used rather than the whole database 

This could be consider a bug in Gramps 6.0, but I think it makes sense as part of a set of optimizations for the next version of Gramps.