### PR TITLE
Improved Manage Family Trees behavior when deleting trees: preserve sort column and better next item selection

### DIFF
--- a/gramps/gui/dbman.py
+++ b/gramps/gui/dbman.py
@@ -446,6 +446,11 @@ class DbManager(CLIDbManager, ManagedWindow):
         """
         Builds the display model.
         """
+        # Store current sort order before rebuilding model
+        current_sort_column, current_sort_order = None, None
+        if self.model is not None:
+            current_sort_column, current_sort_order = self.model.get_sort_column_id()
+        
         self.model = Gtk.TreeStore(str, str, str, str, int, bool, str, str)
 
         # use current names to set up the model
@@ -476,7 +481,12 @@ class DbManager(CLIDbManager, ManagedWindow):
                 self.model.append(node, data)
         if self._current_node is None:
             self._current_node = last_accessed_node
-        self.model.set_sort_column_id(NAME_COL, Gtk.SortType.ASCENDING)
+        
+        # Restore the previous sort order, or default to NAME_COL ascending if no previous sort
+        if current_sort_column is not None and current_sort_order is not None:
+            self.model.set_sort_column_id(current_sort_column, current_sort_order)
+        else:
+            self.model.set_sort_column_id(NAME_COL, Gtk.SortType.ASCENDING)
         self.dblist.set_model(self.model)
 
     def existing_name(self, name, skippath=None):

--- a/gramps/gui/dbman.py
+++ b/gramps/gui/dbman.py
@@ -237,13 +237,13 @@ class DbManager(CLIDbManager, ManagedWindow):
     def _select_next_after_deletion(self, next_item_name):
         """
         Select the item that would have been next after deletion.
-        
+
         Args:
             next_item_name: The name of the item that should be selected
         """
         if self.model is None or not next_item_name:
             return
-            
+
         # Find the item with the matching name in the rebuilt model
         iter = self.model.get_iter_first()
         while iter:
@@ -471,7 +471,7 @@ class DbManager(CLIDbManager, ManagedWindow):
         current_sort_column, current_sort_order = None, None
         if self.model is not None:
             current_sort_column, current_sort_order = self.model.get_sort_column_id()
-        
+
         self.model = Gtk.TreeStore(str, str, str, str, int, bool, str, str)
 
         # use current names to set up the model
@@ -502,7 +502,7 @@ class DbManager(CLIDbManager, ManagedWindow):
                 self.model.append(node, data)
         if self._current_node is None:
             self._current_node = last_accessed_node
-        
+
         # Restore the previous sort order, or default to NAME_COL ascending if no previous sort
         if current_sort_column is not None and current_sort_order is not None:
             self.model.set_sort_column_id(current_sort_column, current_sort_order)
@@ -808,7 +808,7 @@ class DbManager(CLIDbManager, ManagedWindow):
         path = store.get_path(node)
         node = self.model.get_iter(path)
         filename = self.model.get_value(node, FILE_COL)
-        
+
         # Remember what should be selected next (the item after the deleted one)
         next_iter = self.model.iter_next(node)
         next_item_name = None
@@ -819,7 +819,7 @@ class DbManager(CLIDbManager, ManagedWindow):
             prev_iter = store.iter_previous(node)
             if prev_iter is not None:
                 next_item_name = self.model.get_value(prev_iter, NAME_COL)
-        
+
         try:
             with open(filename, "r", encoding="utf-8") as name_file:
                 file_name_to_delete = name_file.read()

--- a/gramps/gui/dbman.py
+++ b/gramps/gui/dbman.py
@@ -234,26 +234,26 @@ class DbManager(CLIDbManager, ManagedWindow):
             self.selection.select_path(tree_path)
             self.dblist.scroll_to_cell(tree_path, None, 1, 0.5, 0)
 
-    def _select_next_after_deletion(self, next_item_name):
+    def _select_next_after_deletion(self, next_item_name: str | None) -> None:
         """
         Select the item that would have been next after deletion.
 
-        Args:
-            next_item_name: The name of the item that should be selected
+        :param next_item_name: The name of the item that should be selected.
+        :type next_item_name: str | None
         """
         if self.model is None or not next_item_name:
             return
 
         # Find the item with the matching name in the rebuilt model
-        iter = self.model.get_iter_first()
-        while iter:
-            name = self.model.get_value(iter, NAME_COL)
+        tree_iter = self.model.get_iter_first()
+        while tree_iter:
+            name = self.model.get_value(tree_iter, NAME_COL)
             if name == next_item_name:
-                path = self.model.get_path(iter)
+                path = self.model.get_path(tree_iter)
                 self.selection.select_path(path)
                 self.dblist.scroll_to_cell(path, None, 1, 0.5, 0)
                 break
-            iter = self.model.iter_next(iter)
+            tree_iter = self.model.iter_next(tree_iter)
 
     def __connect_signals(self):
         """

--- a/gramps/gui/dbman.py
+++ b/gramps/gui/dbman.py
@@ -816,7 +816,7 @@ class DbManager(CLIDbManager, ManagedWindow):
             next_item_name = self.model.get_value(next_iter, NAME_COL)
         else:
             # If no next item, try previous item
-            prev_iter = store.iter_previous(node)
+            prev_iter = self.model.iter_previous(node)
             if prev_iter is not None:
                 next_item_name = self.model.get_value(prev_iter, NAME_COL)
 

--- a/gramps/gui/test/dbman_selection_test.py
+++ b/gramps/gui/test/dbman_selection_test.py
@@ -1,7 +1,6 @@
 #
 # Gramps - a GTK+/GNOME based genealogy program
 #
-# Copyright (C) 2026  GitHub Copilot
 # Copyright (C) 2026  Himanshu Gohel
 #
 # This program is free software; you can redistribute it and/or modify

--- a/gramps/gui/test/dbman_selection_test.py
+++ b/gramps/gui/test/dbman_selection_test.py
@@ -21,7 +21,6 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-
 # Patch Gdk.Cursor.new_for_display before importing DbManager, because
 # DbManager defines BUSY_CURSOR as a class attribute using
 # Gdk.Cursor.new_for_display(Gdk.Display.get_default(), ...). When no

--- a/gramps/gui/test/dbman_selection_test.py
+++ b/gramps/gui/test/dbman_selection_test.py
@@ -20,8 +20,17 @@
 
 import unittest
 from unittest.mock import MagicMock, patch
-from gi.repository import Gtk
-from gramps.gui.dbman import DbManager, NAME_COL
+
+
+# Patch Gdk.Cursor.new_for_display before importing DbManager, because
+# DbManager defines BUSY_CURSOR as a class attribute using
+# Gdk.Cursor.new_for_display(Gdk.Display.get_default(), ...). When no
+# display is available (e.g. headless/CI), get_default() returns None and
+# new_for_display raises TypeError. This patch prevents the crash at import
+# time.
+with patch("gi.repository.Gdk.Cursor.new_for_display", return_value=MagicMock()):
+    from gi.repository import Gtk
+    from gramps.gui.dbman import DbManager, NAME_COL
 
 
 class TestDbManSelection(unittest.TestCase):

--- a/gramps/gui/test/test_dbman_selection.py
+++ b/gramps/gui/test/test_dbman_selection.py
@@ -1,0 +1,99 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  GitHub Copilot
+# Copyright (C) 2026  Himanshu Gohel
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+import unittest
+from unittest.mock import MagicMock, patch
+from gi.repository import Gtk
+from gramps.gui.dbman import DbManager, NAME_COL
+
+class TestDbManSelection(unittest.TestCase):
+    def setUp(self):
+        # Mocking the dependencies of DbManager to avoid initializing the full GUI
+        self.uistate = MagicMock()
+        self.uistate.gwm = MagicMock()
+        self.uistate.gwm.get_item_from_id.return_value = None
+        self.uistate.gwm.add_item.return_value = []
+        self.uistate.pulse_progressbar = MagicMock()
+        self.dbstate = MagicMock()
+        self.viewmanager = MagicMock()
+        
+        # Patch Glade and PersistentTreeView to avoid GTK errors during init
+        with patch('gramps.gui.dbman.Glade'), \
+             patch('gramps.gui.dbman.PersistentTreeView'), \
+             patch('gramps.gui.dbman.User'), \
+             patch('gramps.gui.dbman.ManagedWindow.setup_configs'), \
+             patch('gramps.gui.dbman.DbManager._select_default'):
+            self.dbman = DbManager(self.uistate, self.dbstate, self.viewmanager)
+            
+        # Mock the model and selection
+        self.dbman.model = MagicMock(spec=Gtk.TreeStore)
+        self.dbman.selection = MagicMock()
+        self.dbman.selection.get_selected.return_value = (None, None)
+        self.dbman.dblist = MagicMock()
+
+    def test_select_next_after_deletion_happy_path(self):
+        """
+        Test that the correct item is selected when a successor exists.
+        """
+        # Setup model: Item A, Item B, Item C
+        # We simulate the model's behavior with a list of values
+        mock_iters = [MagicMock(), MagicMock(), MagicMock()]
+        self.dbman.model.get_iter_first.return_value = mock_iters[0]
+        self.dbman.model.iter_next.side_effect = [mock_iters[1], mock_iters[2], None]
+        
+        # Mock get_value for NAME_COL
+        self.dbman.model.get_value.side_effect = lambda it, col: {
+            mock_iters[0]: "Tree A",
+            mock_iters[1]: "Tree B",
+            mock_iters[2]: "Tree C"
+        }[it] if col == NAME_COL else None
+        
+        # Mock get_path with deterministic strings
+        path_map = {
+            mock_iters[0]: "path_a",
+            mock_iters[1]: "path_b",
+            mock_iters[2]: "path_c",
+        }
+        self.dbman.model.get_path.side_effect = lambda it: path_map[it]
+
+        # Act: Select "Tree B"
+        self.dbman._select_next_after_deletion("Tree B")
+
+        # Assert
+        self.dbman.selection.select_path.assert_called_with("path_b")
+
+    def test_select_next_after_deletion_only_item(self):
+        """
+        Test that nothing is selected when next_item_name is None.
+        """
+        self.dbman._select_next_after_deletion(None)
+        self.dbman.selection.select_path.assert_not_called()
+
+    def test_select_next_after_deletion_model_none(self):
+        """
+        Test that the method returns gracefully when self.model is None.
+        """
+        self.dbman.model = None
+        self.dbman._select_next_after_deletion("Some Tree")
+        self.dbman.selection.select_path.assert_not_called()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gui/test/test_dbman_selection.py
+++ b/gramps/gui/test/test_dbman_selection.py
@@ -24,6 +24,7 @@ from unittest.mock import MagicMock, patch
 from gi.repository import Gtk
 from gramps.gui.dbman import DbManager, NAME_COL
 
+
 class TestDbManSelection(unittest.TestCase):
     def setUp(self):
         # Mocking the dependencies of DbManager to avoid initializing the full GUI
@@ -34,15 +35,17 @@ class TestDbManSelection(unittest.TestCase):
         self.uistate.pulse_progressbar = MagicMock()
         self.dbstate = MagicMock()
         self.viewmanager = MagicMock()
-        
+
         # Patch Glade and PersistentTreeView to avoid GTK errors during init
-        with patch('gramps.gui.dbman.Glade'), \
-             patch('gramps.gui.dbman.PersistentTreeView'), \
-             patch('gramps.gui.dbman.User'), \
-             patch('gramps.gui.dbman.ManagedWindow.setup_configs'), \
-             patch('gramps.gui.dbman.DbManager._select_default'):
+        with (
+            patch("gramps.gui.dbman.Glade"),
+            patch("gramps.gui.dbman.PersistentTreeView"),
+            patch("gramps.gui.dbman.User"),
+            patch("gramps.gui.dbman.ManagedWindow.setup_configs"),
+            patch("gramps.gui.dbman.DbManager._select_default"),
+        ):
             self.dbman = DbManager(self.uistate, self.dbstate, self.viewmanager)
-            
+
         # Mock the model and selection
         self.dbman.model = MagicMock(spec=Gtk.TreeStore)
         self.dbman.selection = MagicMock()
@@ -58,14 +61,16 @@ class TestDbManSelection(unittest.TestCase):
         mock_iters = [MagicMock(), MagicMock(), MagicMock()]
         self.dbman.model.get_iter_first.return_value = mock_iters[0]
         self.dbman.model.iter_next.side_effect = [mock_iters[1], mock_iters[2], None]
-        
+
         # Mock get_value for NAME_COL
-        self.dbman.model.get_value.side_effect = lambda it, col: {
-            mock_iters[0]: "Tree A",
-            mock_iters[1]: "Tree B",
-            mock_iters[2]: "Tree C"
-        }[it] if col == NAME_COL else None
-        
+        self.dbman.model.get_value.side_effect = lambda it, col: (
+            {mock_iters[0]: "Tree A", mock_iters[1]: "Tree B", mock_iters[2]: "Tree C"}[
+                it
+            ]
+            if col == NAME_COL
+            else None
+        )
+
         # Mock get_path with deterministic strings
         path_map = {
             mock_iters[0]: "path_a",
@@ -94,6 +99,7 @@ class TestDbManSelection(unittest.TestCase):
         self.dbman.model = None
         self.dbman._select_next_after_deletion("Some Tree")
         self.dbman.selection.select_path.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Manage Family Trees list unexpectedly (1) reverts the sort column selection to Name when a tree is deleted from the list and (2) always selects the most recently accessed tree as the current selection after a tree is deleted, rather than the next/previous item.

There are two commits in this PR for easy review:
1. 68bb59880369addb4e4117004090844d79742c19 will preserve the sort order when the list is rebuilt after a tree is deleted
2. 0057cd0a4ad873b89ed392598443e29bc8dc0370 will remember the item that was next after an item that has been deleted (or previous item if there's no next), and selects that after the list is rebuilt.

Testing performed:
With sort order set to name, last accessed etc., repeat each step below and verify that the selection after delete is reasonable, i.e. next item, previous item, or none if there are no more items in family tree list.

- delete item at top of list
- delete item at bottom of list
- delete item in middle of list

Fixes [#12187](https://gramps-project.org/bugs/view.php?id=12187)

To execute three new unit tests:

`python -m unittest gramps.gui.test.dbman_selection_test.TestDbManSelection`

AI Usage: KwaiKAT's KAT-Coder-Pro V1 used within Cline host to fix the bugs, with manual tweaking before commit. Further changes and unit tests by GitHub Copilot.