### PR TITLE
Optimizer: skip loop when all rules are optimized

### DIFF
--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -180,24 +180,37 @@ class GenericFilter:
 
         # use the Optimizer to refine the set of possible_handles
         optimizer = Optimizer(self)
-        handles_in, handles_out = optimizer.compute_potential_handles_for_filter(self)
+        handles_in, handles_out, all_optimized = (
+            optimizer.compute_potential_handles_for_filter(self)
+        )
 
-        # LOG.debug(
-        #    "Optimizer possible_handles: %s",
-        #    len(possible_handles),
-        # )
+        # Intersect optimizer results with possible_handles to ensure we only
+        # consider handles in the subset being filtered (important when id_list
+        # is provided and rules computed selected_handles from all handles)
+        if handles_in is not None:
+            possible_handles = possible_handles & handles_in
 
-        # if user:
-        #    user.begin_progress(_("Filter"), _("Applying ..."), len(possible_handles))
+        if handles_out is not None:
+            possible_handles = possible_handles - handles_out
 
-        # test each value in possible_handles to compute the final_list
+        LOG.debug(
+            "After optimization possible_handles: %s",
+            len(possible_handles),
+        )
+
+        # If all rules are optimized, we can skip the loop and return the optimized set directly
+        if all_optimized:
+            LOG.debug("All rules optimized, skipping loop")
+            return list(possible_handles)
+
+        # It is necessary to go through all possible handles because there
+        # may be non-optimized rules that will further reduce the set:
+        if user:
+            user.begin_progress(_("Filter"), _("Applying ..."), len(possible_handles))
+
         final_list = []
+        loop_time = time.time()
         for handle in possible_handles:
-            if handles_in is not None and handle not in handles_in:
-                continue
-            if handles_out is not None and handle in handles_out:
-                continue
-
             if user:
                 user.step_progress()
 
@@ -205,6 +218,8 @@ class GenericFilter:
 
             if apply_logical_op(db, obj, self.flist) != self.invert:
                 final_list.append(obj.handle)
+
+        LOG.debug("Loop select time: %s seconds", time.time() - loop_time)
 
         if user:
             user.end_progress()
@@ -291,8 +306,7 @@ class GenericFilter:
         else:
             raise Exception("invalid operator: %r" % self.logical_op)
 
-        start_time = time.time()
-
+        pre_process_time = time.time()
         # build the starting set of possible_handles to be filtered
         possible_handles: Set[PrimaryObjectHandle]
         if id_list is not None:
@@ -311,21 +325,33 @@ class GenericFilter:
             possible_handles = set(tree_handles)
         else:
             possible_handles = set(self.get_all_handles(db))
+        LOG.debug("Pre process time: %s seconds", time.time() - pre_process_time)
 
+        start_time = time.time()
         res = self.apply_logical_op_to_all(db, possible_handles, apply_logical_op, user)
+        LOG.debug("Apply time: %s seconds", time.time() - start_time)
 
+        post_process_time = time.time()
         # convert the filtered set of handles to the correct result type
         if id_list is not None and tupleind is not None:
             # convert the final_list of handles back to the corresponding final_list of tuples
+            # Create a dictionary mapping handles to their indices for O(1) lookup
+            # (handles are hashable, unlike tuples which may contain unhashable objects)
+            handle_to_index = {
+                cast(List[Tuple], id_list)[i][tupleind]: i for i in range(len(id_list))
+            }
             res = sorted(
-                [handle_tuple[handle] for handle in res],
-                key=lambda x: id_list.index(x),
+                res,
+                key=lambda handle: handle_to_index[handle],
             )
+            # Convert handles to tuples after sorting
+            res = [handle_tuple[handle] for handle in res]
         elif tree:
             # sort final_list into the same order as traversed by get_tree_cursor
-            res = sorted(res, key=lambda x: tree_handles.index(x))
-
-        LOG.debug("Apply time: %s seconds", time.time() - start_time)
+            # Create a dictionary mapping handles to their indices for O(1) lookup
+            handle_to_index = {handle: idx for idx, handle in enumerate(tree_handles)}
+            res = sorted(res, key=lambda x: handle_to_index[x])
+        LOG.debug("Post process time: %s seconds", time.time() - post_process_time)
 
         for rule in self.flist:
             rule.requestreset()

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -46,46 +46,60 @@ class Optimizer:
 
     def compute_potential_handles_for_filter(
         self, filter: GenericFilter
-    ) -> Tuple[Set[PrimaryObjectHandle] | None, Set[PrimaryObjectHandle] | None]:
+    ) -> Tuple[Set[PrimaryObjectHandle] | None, Set[PrimaryObjectHandle] | None, bool]:
         if len(filter.flist) == 0:
-            return (None, None)
+            # Empty filters need to apply logical operation logic (and/or/one),
+            # so we can't skip the loop - return False for all_optimized
+            return (None, None, False)
 
         handles_in = None
         handles_out = None
-        for rule in filter.flist:
-            if filter.logical_op == "and" or len(filter.flist) == 1:
-                rule_in, rule_out = self.compute_potential_handles_for_rule(rule)
-                if rule_in is not None:
-                    if handles_in is None:
-                        handles_in = rule_in
-                    else:
-                        handles_in = handles_in.intersection(rule_in)
-                if rule_out is not None:
-                    if handles_out is None:
-                        handles_out = rule_out
-                    else:
-                        handles_out = handles_out.union(rule_out)
+        all_optimized = True
+
+        # For "or" and "one" operations with multiple rules, we can't fully optimize
+        if filter.logical_op in ("or", "one") and len(filter.flist) > 1:
+            all_optimized = False
+        else:
+            # For "and" operations or single rule, check if all rules are optimized
+            for rule in filter.flist:
+                if filter.logical_op == "and" or len(filter.flist) == 1:
+                    rule_in, rule_out, rule_optimized = (
+                        self.compute_potential_handles_for_rule(rule)
+                    )
+                    if not rule_optimized:
+                        all_optimized = False
+                    if rule_in is not None:
+                        if handles_in is None:
+                            handles_in = rule_in
+                        else:
+                            handles_in = handles_in.intersection(rule_in)
+                    if rule_out is not None:
+                        if handles_out is None:
+                            handles_out = rule_out
+                        else:
+                            handles_out = handles_out.union(rule_out)
 
         if filter.invert:
             handles_in, handles_out = handles_out, handles_in
+            # all_optimized flag remains unchanged after inversion
 
-        return handles_in, handles_out
+        return handles_in, handles_out, all_optimized
 
     def compute_potential_handles_for_rule(
         self,
         rule: Rule,
-    ) -> Tuple[Set[PrimaryObjectHandle] | None, Set[PrimaryObjectHandle] | None]:
+    ) -> Tuple[Set[PrimaryObjectHandle] | None, Set[PrimaryObjectHandle] | None, bool]:
         """
         Find the the handles for a particular rule.
         """
         # Has to be of the appropriate type
         if hasattr(rule, "selected_handles"):
-            return (rule.selected_handles, None)
+            return (rule.selected_handles, None, True)
         if hasattr(rule, "find_filter"):
             filter = rule.find_filter()
             if filter and self.is_same_namespace(filter):
                 return self.compute_potential_handles_for_filter(filter)
-        return (None, None)
+        return (None, None, False)
 
     def is_same_namespace(self, filter):
         """

--- a/gramps/gen/filters/rules/test/person_rules_test.py
+++ b/gramps/gen/filters/rules/test/person_rules_test.py
@@ -1135,7 +1135,8 @@ class BaseTest(unittest.TestCase):
                 ),
             )
             # This used the optimizer, so it didn't loop through DB
-            self.assertEqual(get_call_count(), 1)
+            # With full optimization, apply_to_one is never called since we use selected_handles directly
+            self.assertEqual(get_call_count(), 0)
 
     def test_isfemale_not_optimized(self):
         """


### PR DESCRIPTION
Before:

We needed to loop over all optimized handles, in case there was a non-optimized rule (a rule that didn't have `selected_handles`)

After:

We now detected if there are non-optimized rules, and only loop in that case. Otherwise we can return the optimized handles directly.