### PR TITLE
Better default Tag colors

### DIFF
--- a/data/tests/SAMPLE.gramps
+++ b/data/tests/SAMPLE.gramps
@@ -8,13 +8,13 @@
     </researcher>
   </header>
   <tags>
-    <tag handle="_0000000100000001" change="1501068556" name="Person Pro-Gen Import (SAMPLE.DEF) 1999-12-25" color="#000000000000" priority="0"/>
-    <tag handle="_0000000200000002" change="1501068556" name="Family Pro-Gen Import (SAMPLE.DEF) 1999-12-25" color="#000000000000" priority="0"/>
-    <tag handle="_0000000300000003" change="1501068556" name="Event Pro-Gen Import (SAMPLE.DEF) 1999-12-25" color="#000000000000" priority="0"/>
-    <tag handle="_0000000400000004" change="1501068556" name="Place Pro-Gen Import (SAMPLE.DEF) 1999-12-25" color="#000000000000" priority="0"/>
-    <tag handle="_0000000500000005" change="1501068556" name="Source Pro-Gen Import (SAMPLE.DEF) 1999-12-25" color="#000000000000" priority="0"/>
-    <tag handle="_0000000600000006" change="1501068556" name="Citation Pro-Gen Import (SAMPLE.DEF) 1999-12-25" color="#000000000000" priority="0"/>
-    <tag handle="_0000000700000007" change="1501068556" name="Note Pro-Gen Import (SAMPLE.DEF) 1999-12-25" color="#000000000000" priority="0"/>
+    <tag handle="_0000000100000001" change="1501068556" name="Person Pro-Gen Import (SAMPLE.DEF) 1999-12-25" color="#3584e4" priority="0"/>
+    <tag handle="_0000000200000002" change="1501068556" name="Family Pro-Gen Import (SAMPLE.DEF) 1999-12-25" color="#3584e4" priority="0"/>
+    <tag handle="_0000000300000003" change="1501068556" name="Event Pro-Gen Import (SAMPLE.DEF) 1999-12-25" color="#3584e4" priority="0"/>
+    <tag handle="_0000000400000004" change="1501068556" name="Place Pro-Gen Import (SAMPLE.DEF) 1999-12-25" color="#3584e4" priority="0"/>
+    <tag handle="_0000000500000005" change="1501068556" name="Source Pro-Gen Import (SAMPLE.DEF) 1999-12-25" color="#3584e4" priority="0"/>
+    <tag handle="_0000000600000006" change="1501068556" name="Citation Pro-Gen Import (SAMPLE.DEF) 1999-12-25" color="#3584e4" priority="0"/>
+    <tag handle="_0000000700000007" change="1501068556" name="Note Pro-Gen Import (SAMPLE.DEF) 1999-12-25" color="#3584e4" priority="0"/>
   </tags>
   <events>
     <event handle="_0000000b0000000b" change="1501068556" id="E0000">

--- a/data/tests/imp_PhonFax_dfs.gramps
+++ b/data/tests/imp_PhonFax_dfs.gramps
@@ -15,7 +15,7 @@
     </researcher>
   </header>
   <tags>
-    <tag handle="_0000000200000002" change="1" name="Imported" color="#000000000000" priority="0"/>
+    <tag handle="_0000000200000002" change="1" name="Imported" color="#3584e4" priority="0"/>
   </tags>
   <events>
     <event handle="_0000000800000008" change="1" id="E0000">

--- a/data/tests/imp_notetest_dfs.gramps
+++ b/data/tests/imp_notetest_dfs.gramps
@@ -9,7 +9,7 @@
     </researcher>
   </header>
   <tags>
-    <tag handle="_0000000200000002" change="1" name="Imported" color="#000000000000" priority="0"/>
+    <tag handle="_0000000200000002" change="1" name="Imported" color="#3584e4" priority="0"/>
   </tags>
   <events>
     <event handle="_0000000f0000000f" change="1" id="E0000">

--- a/gramps/gen/lib/tag.py
+++ b/gramps/gen/lib/tag.py
@@ -35,6 +35,77 @@ _ = glocale.translation.gettext
 
 # -------------------------------------------------------------------------
 #
+# Default Tag Color Palette
+#
+# -------------------------------------------------------------------------
+# Color palette designed to work well on both light and dark GTK themes.
+# These are medium-saturation colors that provide good contrast and are
+# visually distinct from each other.
+DEFAULT_TAG_COLORS = [
+    "#3584e4",  # Blue - GTK Adwaita blue
+    "#c64600",  # Orange/Red
+    "#26a269",  # Green - GTK Adwaita green
+    "#986803",  # Brown/Yellow
+    "#813d9c",  # Purple
+    "#1c71d8",  # Bright Blue
+    "#e66100",  # Orange
+    "#2ec27e",  # Teal/Green
+    "#a51d2d",  # Red
+    "#1a5fb4",  # Dark Blue
+    "#c2185b",  # Pink/Magenta
+    "#0d52bf",  # Deep Blue
+    "#ff7800",  # Bright Orange
+    "#33d17a",  # Light Green
+    "#9141ac",  # Purple
+]
+
+
+def get_default_tag_color(db=None, index=None):
+    """
+    Get a default color for a new tag that minimizes collisions.
+
+    This function provides colors that work well on both light and dark
+    GTK themes. Colors are selected from a predefined palette in a
+    rotating fashion to minimize collisions with existing tags.
+
+    :param db: Optional database to check existing tag colors
+    :type db: DbBase
+    :param index: Optional index to use for color selection (defaults to
+                  number of existing tags)
+    :type index: int
+    :returns: A hex color string in format #RRGGBB
+    :rtype: str
+    """
+    if index is None:
+        if db:
+            index = db.get_number_of_tags()
+        else:
+            index = 0
+
+    # Rotate through the color palette
+    color = DEFAULT_TAG_COLORS[index % len(DEFAULT_TAG_COLORS)]
+
+    # If database is provided, try to find a color that's not already used
+    if db:
+        existing_colors = set()
+        for tag_handle in db.get_tag_handles():
+            tag = db.get_tag_from_handle(tag_handle)
+            if tag:
+                existing_colors.add(tag.get_color())
+
+        # If the selected color is already used, try the next available one
+        if color in existing_colors:
+            for i in range(len(DEFAULT_TAG_COLORS)):
+                candidate = DEFAULT_TAG_COLORS[(index + i) % len(DEFAULT_TAG_COLORS)]
+                if candidate not in existing_colors:
+                    color = candidate
+                    break
+
+    return color
+
+
+# -------------------------------------------------------------------------
+#
 # Tag
 #
 # -------------------------------------------------------------------------
@@ -44,12 +115,14 @@ class Tag(TableObject):
     attached to a primary object.
     """
 
-    def __init__(self, source=None):
+    def __init__(self, source=None, db=None):
         """
         Create a new Tag instance, copying from the source if present.
 
         :param source: A tag used to initialize the new tag
         :type source: Tag
+        :param db: Optional database to get default color based on existing tags
+        :type db: DbBase
         """
 
         TableObject.__init__(self, source)
@@ -60,7 +133,8 @@ class Tag(TableObject):
             self.__priority = source.priority
         else:
             self.__name = ""
-            self.__color = "#000000000000"  # Black
+            # Use a default color from the palette instead of black
+            self.__color = get_default_tag_color(db)
             self.__priority = 0
 
     def serialize(self):

--- a/gramps/gen/lib/tag.py
+++ b/gramps/gen/lib/tag.py
@@ -60,27 +60,26 @@ DEFAULT_TAG_COLORS = [
 ]
 
 
-def get_default_tag_color(db=None, index=None):
+def get_default_tag_color(db=None):
     """
     Get a default color for a new tag that minimizes collisions.
 
     This function provides colors that work well on both light and dark
-    GTK themes. Colors are selected from a predefined palette in a
-    rotating fashion to minimize collisions with existing tags.
+    GTK themes. Colors are selected from a predefined palette, rotating
+    by the number of existing tags and skipping colors already in use.
+
+    Colors are stored as #RRGGBB (6-digit hex). Note: older Gramps data
+    and XML imports may use the legacy #RRRRGGGGBBBB (12-digit) format.
 
     :param db: Optional database to check existing tag colors
     :type db: DbBase
-    :param index: Optional index to use for color selection (defaults to
-                  number of existing tags)
-    :type index: int
     :returns: A hex color string in format #RRGGBB
     :rtype: str
     """
-    if index is None:
-        if db:
-            index = db.get_number_of_tags()
-        else:
-            index = 0
+    if db:
+        index = db.get_number_of_tags()
+    else:
+        index = 0
 
     # Rotate through the color palette
     color = DEFAULT_TAG_COLORS[index % len(DEFAULT_TAG_COLORS)]

--- a/gramps/gui/views/tags.py
+++ b/gramps/gui/views/tags.py
@@ -304,7 +304,7 @@ class Tags(DbGUIElement):
         """
         Create a new tag and tag the selected objects.
         """
-        tag = Tag()
+        tag = Tag(db=self.db)
         tag.set_priority(self.db.get_number_of_tags())
         EditTag(self.db, self.uistate, [], tag)
 
@@ -528,7 +528,7 @@ class OrganizeTagsDialog(ManagedWindow):
         """
         Create a new tag.
         """
-        tag = Tag()
+        tag = Tag(db=self.db)
         tag.set_priority(self.db.get_number_of_tags())
         EditTag(self.db, self.uistate, self.track, tag)
 

--- a/gramps/plugins/importer/importxml.py
+++ b/gramps/plugins/importer/importxml.py
@@ -655,7 +655,7 @@ class GrampsParser(UpdateCallback):
             if tag:
                 self.default_tag = tag
             else:
-                self.default_tag = Tag()
+                self.default_tag = Tag(db=self.db)
                 self.default_tag.set_name(name)
         else:
             self.default_tag = None
@@ -3391,7 +3391,7 @@ class GrampsParser(UpdateCallback):
             tag_name = _(tag_name)
             tag = self.db.get_tag_from_name(tag_name)
             if tag is None:
-                tag = Tag()
+                tag = Tag(db=self.db)
                 tag.set_name(tag_name)
                 tag.set_priority(self.db.get_number_of_tags())
                 tag_handle = self.db.add_tag(tag, self.trans)

--- a/gramps/plugins/test/imports_test.py
+++ b/gramps/plugins/test/imports_test.py
@@ -198,6 +198,10 @@ def _report_details(path, diff1, diff2):
     # 'change' date is not significant for comparison
     if path.endswith(".change"):
         return ""
+    # tag colors may differ due to default color palette assignment
+    # we don't need to check for exact colors - ignore any color differences for tags
+    if ".color" in path and ("Tag" in path or path.startswith("Tag")):
+        return ""
     # the xml exporter edits the data base by converting media path
     # to unix '/' conventions, so we have to ignore these differences
     if path == "Media.path":

--- a/gramps/plugins/test/imports_test.py
+++ b/gramps/plugins/test/imports_test.py
@@ -198,10 +198,6 @@ def _report_details(path, diff1, diff2):
     # 'change' date is not significant for comparison
     if path.endswith(".change"):
         return ""
-    # tag colors may differ due to default color palette assignment
-    # we don't need to check for exact colors - ignore any color differences for tags
-    if ".color" in path and ("Tag" in path or path.startswith("Tag")):
-        return ""
     # the xml exporter edits the data base by converting media path
     # to unix '/' conventions, so we have to ignore these differences
     if path == "Media.path":


### PR DESCRIPTION
This PR uses better default colors for Tags. Previously the color was always black.

With this PR:

1. Create a palette of colors that work well with light or dark themes
2. Uses the assigned colors to find an unused color, if possible

<img width="361" height="147" alt="image" src="https://github.com/user-attachments/assets/16f153e1-d5e4-4e6a-921e-cc7b788e30d4" />

Resolves #0011974

This PR was written by me and Cursor, with the following prompt:

> Black is not a very good default color to show that the record is tagged. Can you come up with a set of colors to use for new Tags that minimizes collisions with existing tags, and that would work with either a dark or light palette. 
 