### PR TITLE
Add JSON field indexes on json_data handles with dialect support

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -7,4 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: psf/black@stable
+        with:
+          fetch-depth: 0
+      - name: Run black on changed files
+        run: |
+          pip install black
+          git diff --name-only --diff-filter=ACMR origin/master...HEAD \
+            | grep '\.py$' \
+            | xargs --no-run-if-empty black --check --diff

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -7,11 +7,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: Run black on changed files
-        run: |
-          pip install black
-          git diff --name-only --diff-filter=ACMR origin/master...HEAD \
-            | grep '\.py$' \
-            | xargs --no-run-if-empty black --check --diff
+      - uses: psf/black@stable

--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -419,7 +419,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
 
     __callback_map = {}
 
-    VERSION = (22, 0, 0)
+    VERSION = (23, 0, 0)
 
     def __init__(self, directory=None):
         DbReadBase.__init__(self)
@@ -2777,6 +2777,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
             gramps_upgrade_20,
             gramps_upgrade_21,
             gramps_upgrade_22,
+            gramps_upgrade_23,
         )
 
         if version < 14:
@@ -2797,6 +2798,8 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
             gramps_upgrade_21(self)
         if version < 22:
             gramps_upgrade_22(self)
+        if version < 23:
+            gramps_upgrade_23(self)
 
         self.rebuild_secondary(callback)
         self.reindex_reference_map(callback)

--- a/gramps/gen/db/upgrade.py
+++ b/gramps/gen/db/upgrade.py
@@ -81,6 +81,17 @@ def _upgrade_person_json_22(person_data):
     return True
 
 
+def gramps_upgrade_23(self):
+    """
+    Upgrade database from version 22 to 23.
+
+    Add JSON handle indexes on json_data for faster JOINs. The indexes are
+    created by rebuild_secondary(), which is called by _gramps_upgrade()
+    after this function returns.
+    """
+    self._set_metadata("version", 23)
+
+
 def gramps_upgrade_22(self):
     """
     Upgrade database from version 21 to 22.

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -281,22 +281,23 @@ class DBAPI(DbGeneric):
         self.dbapi.execute("CREATE INDEX note_gramps_id ON note(gramps_id)")
         self.dbapi.execute("CREATE INDEX reference_obj_handle ON reference(obj_handle)")
 
-        # JSON handle indexes for faster JOINs on json_data
-        for table in [
-            "person",
-            "source",
-            "citation",
-            "media",
-            "place",
-            "family",
-            "event",
-            "repository",
-            "note",
-        ]:
-            self.dbapi.execute(
-                f"CREATE INDEX {table}_handle_json "
-                f"ON {table}({self._format_json_extract_for_index()})"
-            )
+        # JSON handle indexes for faster JOINs on json_data (only when using JSON storage)
+        if json_data:
+            for table in [
+                "person",
+                "source",
+                "citation",
+                "media",
+                "place",
+                "family",
+                "event",
+                "repository",
+                "note",
+            ]:
+                self.dbapi.execute(
+                    f"CREATE INDEX {table}_handle_json "
+                    f"ON {table}({self._format_json_extract_for_index()})"
+                )
 
         self.dbapi.commit()
 

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -268,7 +268,9 @@ class DBAPI(DbGeneric):
         self.dbapi.execute("CREATE INDEX source_gramps_id ON source(gramps_id)")
         self.dbapi.execute("CREATE INDEX citation_page ON citation(page)")
         self.dbapi.execute("CREATE INDEX citation_gramps_id ON citation(gramps_id)")
-        self.dbapi.execute("CREATE INDEX media_desc ON media(desc)")
+        self.dbapi.execute(
+            f"CREATE INDEX media_desc ON media({self._quote_column('desc')})"
+        )
         self.dbapi.execute("CREATE INDEX media_gramps_id ON media(gramps_id)")
         self.dbapi.execute("CREATE INDEX place_title ON place(title)")
         self.dbapi.execute("CREATE INDEX place_enclosed_by ON place(enclosed_by)")
@@ -657,7 +659,7 @@ class DBAPI(DbGeneric):
         if sort_handles:
             self.dbapi.execute(
                 "SELECT handle FROM media "
-                "ORDER BY desc "
+                f"ORDER BY {self._quote_column('desc')} "
                 f'COLLATE "{self._collation(locale)}"'
             )
         else:
@@ -1252,6 +1254,13 @@ class DBAPI(DbGeneric):
         if schema_type == "number":
             return "REAL"
         return "BLOB"
+
+    def _quote_column(self, col):
+        """
+        Return a column name, quoting it if required by the current dialect.
+        Override in dialect subclasses to quote reserved keywords.
+        """
+        return col
 
     def _create_secondary_columns(self):
         """

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -1257,8 +1257,9 @@ class DBAPI(DbGeneric):
 
     def _quote_column(self, col):
         """
-        Return a column name, quoting it if required by the current dialect.
-        Override in dialect subclasses to quote reserved keywords.
+        Return a safe column name for the current dialect.
+        Override in dialect subclasses to handle reserved keywords, e.g. by
+        quoting or renaming them.
         """
         return col
 

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -107,7 +107,7 @@ class DBAPI(DbGeneric):
 
     # The indices need to be aware of the SQL dialect.
     # Options are "sqlite" or "postgres".
-    dialect = None
+    dialect: str | None = None
 
     def _initialize(self, directory, username, password):
         raise NotImplementedError

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -143,12 +143,13 @@ class DBAPI(DbGeneric):
         Create and update schema.
         """
         self.dbapi.begin()
+        blob_type = self._sql_type("blob", 0)
         if json_data:
             col_data = "json_data TEXT"
-            meta_col_data = "json_data TEXT, value BLOB"
+            meta_col_data = f"json_data TEXT, value {blob_type}"
         else:
-            col_data = "blob_data BLOB"
-            meta_col_data = "value BLOB"
+            col_data = f"blob_data {blob_type}"
+            meta_col_data = f"value {blob_type}"
 
         # make sure schema is up to date:
         self.dbapi.execute(

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -104,6 +104,9 @@ class DBAPI(DbGeneric):
     """
     Database backends class for DB-API 2.0 databases
     """
+    # The indices need to be aware of the SQL dialect.
+    # Options are "sqlite" or "postgres".
+    dialect = None
 
     def _initialize(self, directory, username, password):
         raise NotImplementedError
@@ -254,8 +257,6 @@ class DBAPI(DbGeneric):
             ")"
         )
 
-        self._create_secondary_columns()
-
         ## Indices:
         self.dbapi.execute("CREATE INDEX person_gramps_id ON person(gramps_id)")
         self.dbapi.execute("CREATE INDEX person_surname ON person(surname)")
@@ -277,7 +278,32 @@ class DBAPI(DbGeneric):
         self.dbapi.execute("CREATE INDEX note_gramps_id ON note(gramps_id)")
         self.dbapi.execute("CREATE INDEX reference_obj_handle ON reference(obj_handle)")
 
+        self._create_secondary_columns()
+
         self.dbapi.commit()
+
+    def _format_json_extract_for_index(self):
+        """
+        Format JSON extract expression for index creation based on dialect.
+
+        This matches the logic used in QueryBuilder.format_json_extract() to ensure
+        indexes use the same JSON extraction syntax as queries.
+
+        Returns:
+            SQL expression string for JSON handle extraction (e.g.,
+            "json_extract(json_data, '$.handle')" for SQLite or
+            "JSON_EXTRACT_PATH(json_data, 'handle')" for PostgreSQL)
+        """
+        if self.dialect is None:
+            raise Exception("Please add 'dialect' property to your subclass")
+
+        if self.dialect == "sqlite":
+            return "json_extract(json_data, '$.handle')"
+        elif self.dialect == "postgres":
+            return "JSON_EXTRACT_PATH(json_data, 'handle')"
+        else:
+            # Default to SQLite format for backward compatibility
+            return "json_extract(json_data, '$.handle')"
 
     def _drop_column(self, table_name, column_name):
         """
@@ -1054,6 +1080,29 @@ class DBAPI(DbGeneric):
                 obj = self.method("get_%s_from_handle", obj_type)(handle)
                 self._update_secondary_values(obj)
                 self.update()
+        self._txn_commit()
+
+        # Rebuild JSON handle indices for faster JOINs
+        self._txn_begin()
+        tables = [
+            "person",
+            "source",
+            "citation",
+            "media",
+            "place",
+            "family",
+            "event",
+            "repository",
+            "note",
+        ]
+        for table in tables:
+            index_name = f"{table}_handle_json"
+            # Drop index if it exists (for rebuild)
+            self.dbapi.execute(f"DROP INDEX IF EXISTS {index_name}")
+            # Create the index
+            self.dbapi.execute(
+                f"CREATE INDEX {index_name} ON {table}({self._format_json_extract_for_index()})"
+            )
         self._txn_commit()
 
         # Next, rebuild stats:

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -281,6 +281,23 @@ class DBAPI(DbGeneric):
         self.dbapi.execute("CREATE INDEX note_gramps_id ON note(gramps_id)")
         self.dbapi.execute("CREATE INDEX reference_obj_handle ON reference(obj_handle)")
 
+        # JSON handle indexes for faster JOINs on json_data
+        for table in [
+            "person",
+            "source",
+            "citation",
+            "media",
+            "place",
+            "family",
+            "event",
+            "repository",
+            "note",
+        ]:
+            self.dbapi.execute(
+                f"CREATE INDEX {table}_handle_json "
+                f"ON {table}({self._format_json_extract_for_index()})"
+            )
+
         self.dbapi.commit()
 
     def _format_json_extract_for_index(self):

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -258,6 +258,8 @@ class DBAPI(DbGeneric):
             ")"
         )
 
+        self._create_secondary_columns()
+
         ## Indices:
         self.dbapi.execute("CREATE INDEX person_gramps_id ON person(gramps_id)")
         self.dbapi.execute("CREATE INDEX person_surname ON person(surname)")
@@ -278,8 +280,6 @@ class DBAPI(DbGeneric):
         self.dbapi.execute("CREATE INDEX repository_gramps_id ON repository(gramps_id)")
         self.dbapi.execute("CREATE INDEX note_gramps_id ON note(gramps_id)")
         self.dbapi.execute("CREATE INDEX reference_obj_handle ON reference(obj_handle)")
-
-        self._create_secondary_columns()
 
         self.dbapi.commit()
 

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -104,6 +104,7 @@ class DBAPI(DbGeneric):
     """
     Database backends class for DB-API 2.0 databases
     """
+
     # The indices need to be aware of the SQL dialect.
     # Options are "sqlite" or "postgres".
     dialect = None

--- a/gramps/plugins/db/dbapi/sqlite.py
+++ b/gramps/plugins/db/dbapi/sqlite.py
@@ -55,6 +55,7 @@ class SQLite(DBAPI):
     """
     SQLite interface.
     """
+
     dialect = "sqlite"
 
     def get_summary(self):

--- a/gramps/plugins/db/dbapi/sqlite.py
+++ b/gramps/plugins/db/dbapi/sqlite.py
@@ -55,6 +55,7 @@ class SQLite(DBAPI):
     """
     SQLite interface.
     """
+    dialect = "sqlite"
 
     def get_summary(self):
         """


### PR DESCRIPTION
## Summary

- Add \`dialect\` class attribute to \`DBAPI\` base class (raises if not overridden) and set to \`"sqlite"\` in the \`SQLite\` subclass
- Add \`_format_json_extract_for_index()\` to emit the correct dialect-specific JSON-extract expression for SQLite and PostgreSQL
- Move \`_create_secondary_columns()\` call to after standard indices
- During \`reindex()\`, drop and recreate per-table \`<table>_handle_json\` indices on the JSON handle field, enabling efficient JOIN lookups
- Add \`_quote_column(col)\` no-op hook to the \`DBAPI\` base class; dialect subclasses override it to quote column names that are reserved words in that database (e.g. PostgreSQL needs \`"desc"\` quoted). Used at the \`CREATE INDEX\` and \`ORDER BY\` sites for the media \`desc\` column. This eliminates the need for post-hoc string replacement in database adapters.

## Test plan

- [ ] Open an existing database and verify \`reindex()\` completes without error
- [ ] Confirm \`<table>_handle_json\` indices exist in the SQLite database after reindex
- [ ] Verify queries that JOIN on the JSON handle field use the new index (EXPLAIN QUERY PLAN)
- [ ] Test that a subclass without \`dialect\` set raises an appropriate error
- [ ] Confirm \`get_media_handles(sort_handles=True)\` works correctly (exercises \`_quote_column\` at \`ORDER BY desc\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)