### PR TITLE
Unit Tests for Windows [was Invariant unittest environment]

### DIFF
--- a/.github/workflows/windows-aio.yml
+++ b/.github/workflows/windows-aio.yml
@@ -49,6 +49,10 @@ jobs:
       run: |
         cd aio
         ./build.sh ${{ inputs.cleanup }} ${{ inputs.build-number }}
+    - name: Run unit test suite
+      run: |
+        export GRAMPS_RESOURCES=build/share
+        python3 -m unittest discover -p "*_test.py"
     - uses: actions/upload-artifact@v6
       with:
         name: GrampsAIO

--- a/gramps/gen/config.py
+++ b/gramps/gen/config.py
@@ -35,6 +35,7 @@ This package implements access to Gramps configuration.
 import os
 import re
 import logging
+import sys
 
 # ---------------------------------------------------------------
 #
@@ -458,7 +459,8 @@ if not os.path.exists(CONFIGMAN.filename):
 # Now, load the settings from the config file, if one
 #
 # ---------------------------------------------------------------
-CONFIGMAN.load()
+if not "unittest" in sys.modules.keys():
+    CONFIGMAN.load()
 
 config = CONFIGMAN
 if config.get("database.backend") == "bsddb":

--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -865,6 +865,8 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
                 clear_lock_file(self.get_save_path())
             except IOError:
                 pass
+        else:
+            self._close()
 
         self.db_is_open = False
         self._directory = None

--- a/gramps/gen/utils/test/file_test.py
+++ b/gramps/gen/utils/test/file_test.py
@@ -60,87 +60,96 @@ class FileTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdirname:
             # Create database
             db = make_database("sqlite")
-            path = os.path.join(tmpdirname, "utils_file_test")
-            os.makedirs(path)
-            db.load(path)
+            old_env = None
+            try:
+                path = os.path.join(tmpdirname, "utils_file_test")
+                os.makedirs(path)
+                db.load(path)
 
-            # Test without db.mediapath set
-            self.assertEqual(
-                media_path(db),
-                os.path.normcase(os.path.normpath(os.path.abspath(USER_PICTURES))),
-            )
+                # Test without db.mediapath set
+                self.assertEqual(
+                    media_path(db),
+                    os.path.normcase(os.path.normpath(os.path.abspath(USER_PICTURES))),
+                )
 
-            # Test with absolute db.mediapath
-            db.set_mediapath(os.path.abspath(USER_HOME) + "/test_abs")
-            self.assertEqual(
-                media_path(db),
-                os.path.normcase(
-                    os.path.normpath(os.path.abspath(USER_HOME + "/test_abs"))
-                ),
-            )
+                # Test with absolute db.mediapath
+                db.set_mediapath(os.path.abspath(USER_HOME) + "/test_abs")
+                self.assertEqual(
+                    media_path(db),
+                    os.path.normcase(
+                        os.path.normpath(os.path.abspath(USER_HOME + "/test_abs"))
+                    ),
+                )
 
-            # Test with relative db.mediapath
-            db.set_mediapath("test_rel")
-            self.assertEqual(
-                media_path(db),
-                os.path.normcase(
-                    os.path.normpath(
-                        os.path.abspath(tmpdirname + "/utils_file_test/test_rel")
-                    )
-                ),
-            )
-
-            # Test with environment variable
-            db.set_mediapath("/test/{VERSION}/test_var")
-            self.assertEqual(
-                media_path(db),
-                os.path.normcase(
-                    os.path.normpath(os.path.abspath("/test/" + VERSION + "/test_var"))
-                ),
-            )
-            db.set_mediapath("{USER_PLUGINS}/test_var")
-            self.assertEqual(
-                media_path(db),
-                os.path.normcase(
-                    os.path.normpath(os.path.abspath(USER_PLUGINS + "/test_var"))
-                ),
-            )
-            db.set_mediapath("{VERSION}/test_var")
-            self.assertEqual(
-                media_path(db),
-                os.path.normcase(
-                    os.path.normpath(
-                        os.path.abspath(
-                            tmpdirname + "/utils_file_test/" + VERSION + "/test_var"
+                # Test with relative db.mediapath
+                db.set_mediapath("test_rel")
+                self.assertEqual(
+                    media_path(db),
+                    os.path.normcase(
+                        os.path.normpath(
+                            os.path.abspath(tmpdirname + "/utils_file_test/test_rel")
                         )
-                    )
-                ),
-            )
+                    ),
+                )
 
-            # Test with $GRAMPSHOME environment variable not set
-            old_env = os.environ.copy()
-            if "GRAMPSHOME" in os.environ:
-                del os.environ["GRAMPSHOME"]
-            db.set_mediapath("{GRAMPSHOME}/test_var")
-            self.assertEqual(
-                media_path(db),
-                os.path.normcase(
-                    os.path.normpath(os.path.abspath(USER_HOME + "/test_var"))
-                ),
-            )
+                # Test with environment variable
+                db.set_mediapath("/test/{VERSION}/test_var")
+                self.assertEqual(
+                    media_path(db),
+                    os.path.normcase(
+                        os.path.normpath(
+                            os.path.abspath("/test/" + VERSION + "/test_var")
+                        )
+                    ),
+                )
+                db.set_mediapath("{USER_PLUGINS}/test_var")
+                self.assertEqual(
+                    media_path(db),
+                    os.path.normcase(
+                        os.path.normpath(os.path.abspath(USER_PLUGINS + "/test_var"))
+                    ),
+                )
+                db.set_mediapath("{VERSION}/test_var")
+                self.assertEqual(
+                    media_path(db),
+                    os.path.normcase(
+                        os.path.normpath(
+                            os.path.abspath(
+                                tmpdirname + "/utils_file_test/" + VERSION + "/test_var"
+                            )
+                        )
+                    ),
+                )
 
-            # Test with $GRAMPSHOME environment variable set
-            os.environ["GRAMPSHOME"] = "/this/is/a/test"
-            db.set_mediapath("{GRAMPSHOME}/test_var")
-            self.assertEqual(
-                media_path(db),
-                os.path.normcase(
-                    os.path.normpath(os.path.abspath("/this/is/a/test/test_var"))
-                ),
-            )
+                # Test with $GRAMPSHOME environment variable not set
+                old_env = os.environ.copy()
+                if "GRAMPSHOME" in os.environ:
+                    del os.environ["GRAMPSHOME"]
+                db.set_mediapath("{GRAMPSHOME}/test_var")
+                self.assertEqual(
+                    media_path(db),
+                    os.path.normcase(
+                        os.path.normpath(os.path.abspath(USER_HOME + "/test_var"))
+                    ),
+                )
 
-            # Restore environment
-            os.environ = old_env
+                # Test with $GRAMPSHOME environment variable set
+                os.environ["GRAMPSHOME"] = "/this/is/a/test"
+                db.set_mediapath("{GRAMPSHOME}/test_var")
+                self.assertEqual(
+                    media_path(db),
+                    os.path.normcase(
+                        os.path.normpath(os.path.abspath("/this/is/a/test/test_var"))
+                    ),
+                )
+
+            finally:
+                # Restore environment
+                if old_env:
+                    os.environ = old_env
+                # close db so that temporary directory can be removed
+                db.close()
+                db = None
 
 
 # -------------------------------------------------------------------------

--- a/gramps/gui/editors/test/editreference_test.py
+++ b/gramps/gui/editors/test/editreference_test.py
@@ -19,6 +19,7 @@
 
 """Unittest for editreference.py"""
 
+import tempfile
 import unittest
 from unittest.mock import Mock, patch
 import os
@@ -68,24 +69,29 @@ class TestEditReference(unittest.TestCase):
     def test_editreference(self):
         dbstate = DbState()
         db = make_database("sqlite")
-        path = "/tmp/edit_ref_test"
-        try:
-            os.mkdir(path)
-        except:
-            pass
-        db.load(path)
-        dbstate.change_database(db)
-        source = Place()
-        source.gramps_id = "P0001"
-        with DbTxn("test place", dbstate.db) as trans:
-            dbstate.db.add_place(source, trans)
-        editor = MockEditReference(
-            dbstate, uistate=None, track=[], source=source, source_ref=None, update=None
-        )
-        with patch("gramps.gui.editors.editreference.ErrorDialog") as MockED:
-            editor.check_for_duplicate_id("Place")
-            self.assertTrue(MockED.called)
-        db.close()
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            try:
+                os.mkdir(tmpdirname)
+            except:
+                pass
+            db.load(tmpdirname)
+            dbstate.change_database(db)
+            source = Place()
+            source.gramps_id = "P0001"
+            with DbTxn("test place", dbstate.db) as trans:
+                dbstate.db.add_place(source, trans)
+            editor = MockEditReference(
+                dbstate,
+                uistate=None,
+                track=[],
+                source=source,
+                source_ref=None,
+                update=None,
+            )
+            with patch("gramps.gui.editors.editreference.ErrorDialog") as MockED:
+                editor.check_for_duplicate_id("Place")
+                self.assertTrue(MockED.called)
+            db.close()
 
 
 if __name__ == "__main__":

--- a/gramps/plugins/db/dbapi/test/db_test.py
+++ b/gramps/plugins/db/dbapi/test/db_test.py
@@ -122,6 +122,10 @@ class DbRandomTest(unittest.TestCase):
             for handle in self.handles["Tag"]:
                 self.db.remove_tag(handle, trans)
 
+    @classmethod
+    def tearDownClass(cls):
+        cls.db.close()
+
     def __add_object(self, obj_class, add_func, trans):
         obj = obj_class()
         if obj_class == Tag:
@@ -746,6 +750,10 @@ class DbEmptyTest(unittest.TestCase):
         cls.db = make_database("sqlite")
         cls.db.load(":memory:")
 
+    @classmethod
+    def tearDownClass(cls):
+        cls.db.close()
+
     ################################################################
     #
     # Test metadata methods
@@ -873,6 +881,10 @@ class DbPersonTest(unittest.TestCase):
         with DbTxn("Remove test objects", self.db) as trans:
             for handle in self.db.get_person_handles():
                 self.db.remove_person(handle, trans)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.db.close()
 
     ################################################################
     #

--- a/gramps/plugins/test/imports_test.py
+++ b/gramps/plugins/test/imports_test.py
@@ -31,6 +31,7 @@ import sys
 import re
 import locale
 from time import localtime, strptime
+from unittest import SkipTest
 from unittest.mock import patch
 import zipfile
 import shutil
@@ -40,6 +41,7 @@ import shutil
 from gramps.gen.utils.config import config
 
 config.set("preferences.date-format", 0)
+from gramps.gen.constfunc import win
 from gramps.gen.const import GRAMPS_LOCALE as glocale, TEST_DIR, TEST_RANDOM
 from gramps.gen.constfunc import win
 from gramps.gen.db.utils import import_as_dict
@@ -239,6 +241,10 @@ def db_load(zipfn, self):
             else:
                 dbid = "bsddb"
 
+            # skip if the bsddb backend is not available
+            if dbid == "bsddb" and win():
+                self.skipTest("bsddb not supported on Windows")
+
             db = make_database(dbid)
             db.disable_signals()
 
@@ -254,6 +260,9 @@ def db_load(zipfn, self):
                 continue
         return db
     # Get here is there is an exception the while loop does not handle
+    except SkipTest:
+        # SkipTest, so raise upwards for test framework to handle
+        raise
     except (
         DbVersionError,
         DbPythonError,

--- a/gramps/plugins/test/imports_test.py
+++ b/gramps/plugins/test/imports_test.py
@@ -40,6 +40,8 @@ import shutil
 from gramps.gen.utils.config import config
 
 config.set("preferences.date-format", 0)
+from gramps.gen.const import GRAMPS_LOCALE as glocale, TEST_DIR, TEST_RANDOM
+from gramps.gen.constfunc import win
 from gramps.gen.db.utils import import_as_dict
 from gramps.gen.merge.diff import diff_dbs
 from gramps.gen.lib.json_utils import object_to_dict
@@ -86,22 +88,6 @@ def mock_localtime(*args):
     return strptime("25 Dec 1999", "%d %b %Y")
 
 
-# These tests assume a US date and time format.
-# If the locale is not available on the
-# build host, skip these tests.
-en_US_locale_available = False
-try:
-    locale.setlocale(locale.LC_ALL, "en_US.utf8")
-    en_US_locale_available = True
-except locale.Error:  # seems to fail on Windows system for some reason
-    try:
-        locale.setlocale(locale.LC_ALL, "English_United States")
-        en_US_locale_available = True
-    except locale.Error:
-        pass
-
-
-@unittest.skipUnless(en_US_locale_available, "en_US locale is not avaiable")
 class TestImports(unittest.TestCase):
     """The test class cases will be dynamically created at import time from
     files to be tested.  The following defs are used by the test cases
@@ -290,6 +276,16 @@ def make_tst_function(tstfile, file_name):
     @patch("gramps.gen.utils.unknown.localtime")
     @patch("gramps.gen.utils.unknown.time")
     @patch("time.localtime")
+    # Some tests assume a US date and time format.
+    @unittest.skipUnless(
+        (glocale.lang == "en_US")
+        or (win() and (glocale.lang == "en"))
+        or not (
+            tstfile in ["imp_MediaTest.ged", "imp_notetest_dfs.ged", "imp_sample.ged"]
+        ),
+        "skipping TestImports test case %s. en_US.utf-8 locale is required."
+        % (tstfile),
+    )
     def tst(self, mockptime, mocktime, mockltime, mockdtime):
         """This compares the import file with the expected result '.gramps'
         file.

--- a/gramps/plugins/test/tools_test.py
+++ b/gramps/plugins/test/tools_test.py
@@ -26,7 +26,8 @@ import unittest
 import random
 
 from gramps.test.test_util import Gramps
-from gramps.gen.const import TEST_DIR, TEST_RANDOM
+from gramps.gen.const import GRAMPS_LOCALE as glocale, TEST_DIR, TEST_RANDOM
+from gramps.gen.constfunc import win
 from gramps.gen.user import User
 from gramps.gen.utils.id import set_det_id
 from gramps.gen import const
@@ -86,6 +87,10 @@ class ToolControl(unittest.TestCase):
         config.set("database.backend", self.db_backend)
         call("-y", "-q", "--remove", TREE_NAME)
 
+    @unittest.skipUnless(
+        (glocale.lang == "en_US") or (win() and (glocale.lang == "en")),
+        "skipping tcg_and_check_and_repair test. en_US locale is required.",
+    )
     def test_tcg_and_check_and_repair(self):
         """
         Run a 'Test Case Generator' and 'Check & Repair Database' test.


### PR DESCRIPTION
Update 2026-03-29: this PR has broadened into allowing unit tests to run correctly on Windows. Some of the changes are not Windows specific.

Do not load the user config file when running unittests.

Previously the user config settings were used to set db prefixes which could cause tests to fail. For example an iprefix of "I%05d" would cause the imported gramps_id to be I00044 rather than the default of I0044

To reproduce locally

1. Configure gramps to use a person ID pattern of I%05d
Start gramps
Edit > Preferences > ID Formats
Change the value for Person to I%05d
2. run the unittest `gramps.gen.filters.rules.test.person_rules_test.BaseTest.test_hasidof_matching` using the command `python -m unittest gramps.gen.filters.rules.test.person_rules_test.BaseTest.test_hasidof_matching`

Observe that the test fails with
```
AssertionError: Items in the second set but not the first:
'GNUJQCL9MD64AM56OH'
```
This [test](https://github.com/gramps-project/gramps/blob/eff3f9ae63110a6ac239467ae8c75f7c978fe544/gramps/gen/filters/rules/test/person_rules_test.py#L1096-L1108) is running a filter with the rule `HasIdOf(["I0044"])` which is failing because internally the `gramps_id` of the Person is "I00044"
This is just an example. There are many tests in the full suite that fail.