### PR TITLE
Spousal labels in the Relationships view based on family type

### DIFF
--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -2069,11 +2069,11 @@ def spouse_label_from_gender(spouse,fam_type):
     # MARRIED and CIVIL_UNION handled separately if translators need to use different labels
     elif fam_type == FamilyRelType.CIVIL_UNION:
         if spouse == Person.MALE:
-            label = _("Husband X")
+            label = _("Husband")
         elif spouse == Person.FEMALE:
-            label = _("Wife X")
+            label = _("Wife")
         else:
-            label = _("Spouse X")
+            label = _("Spouse")
     else:
         label = _("Partner")
 

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -1105,6 +1105,7 @@ class RelationshipView(NavigationView):
             if family:
                 father_gen = mother_gen = None
                 father_rel = mother_rel = ""
+                parent1 = parent2 = ""
                 child_handle = person.get_handle()
                 child_ref_list = family.get_child_ref_list()
                 for child_ref in child_ref_list:
@@ -1114,12 +1115,12 @@ class RelationshipView(NavigationView):
                 hd21 = family.get_father_handle()
                 if hd21:
                     father_gen = self.dbstate.db.get_person_from_handle(hd21).gender
+                    parent1 = parent_label_from_gender(father_gen, father_rel)
+
                 hd22 = family.get_mother_handle()
                 if hd22:
                     mother_gen = self.dbstate.db.get_person_from_handle(hd22).gender
-
-                parent1 = parent_label_from_gender(father_gen, father_rel)
-                parent2 = parent_label_from_gender(mother_gen, mother_rel)
+                    parent2 = parent_label_from_gender(mother_gen, mother_rel)
 
                 self.write_label(_("%s:") % _("Parents"), family, True, person)
                 self.write_person(parent1, family.get_father_handle())

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -2079,7 +2079,7 @@ def parent_label_from_gender(gender, rel_type):
             label = _("Guardian")
         elif gender == Person.FEMALE:
             label = _("Guardian")
-		else
+		else:
             label = _("Guardian")
     else:
     # Masculine, feminine and other gender entries needed for translations
@@ -2087,7 +2087,7 @@ def parent_label_from_gender(gender, rel_type):
             label = _("Parent")
         elif gender == Person.FEMALE:
             label = _("Parent")
-        else        
+        else:        
             label = _("Parent")
 
     return label

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -2080,7 +2080,7 @@ def parent_label_from_gender(gender, rel_type):
             label = _("Foster Mother")
         else:
             label = _("Foster Parent")
-    elif rel_type == "Sponsored"":
+    elif rel_type == "Sponsored":
         # Masculine, feminine and other gender entries needed for translations
         if gender == Person.MALE:
             label = _("Sponsor")

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -1244,8 +1244,8 @@ class RelationshipView(NavigationView):
 
     def write_person(self, title, handle):
         """
-        Create and show a person cell with a "Father/Mother/Parent/Adoptive/Step/Guardian" in the case 
-		of the child and "Husband/Wife/Spouse/Partner" for a spouse label in the GUI at the current row
+        Create and show a person cell with a "Father/Mother/Parent/Adoptive/Step/Guardian" in the case
+        of the child and "Husband/Wife/Spouse/Partner" for a spouse label in the GUI at the current row
         @param title: left column label ("Father/Mother/Parent/Adoptive/Step/Guardian" or "Husband/Wife/Spouse/Partner")
         @param handle: person handle
         """
@@ -1671,7 +1671,6 @@ class RelationshipView(NavigationView):
             self.write_label(_("%s:") % _("Family"), family, False, person)
 
             fam_type = family.get_relationship()
-			
             spouse_label = spouse_label_from_gender(spouse,fam_type)
 			
             box = self.write_person(spouse_label, handle)
@@ -2045,6 +2044,8 @@ def button_activated(event, mouse_button):
         return True
     else:
         return False
+
+
 def parent_label_from_gender(gender):
     if gender == Person.MALE:
         label = _("Father")
@@ -2054,6 +2055,7 @@ def parent_label_from_gender(gender):
         label = _("Parent")
 
     return label
+
 
 def spouse_label_from_gender(spouse,fam_type):
     if fam_type == FamilyRelType.MARRIED:

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -2074,7 +2074,7 @@ def parent_label_from_gender(gender, rel_type):
         else:
             label = _("Adoptive Parent")
     elif rel_type == "Sponsored" or rel_type == "Foster":
-    # Masculine, feminine and other gender entries needed for translations
+        # Masculine, feminine and other gender entries needed for translations
         if gender == Person.MALE:
             label = _("Guardian")
         elif gender == Person.FEMALE:
@@ -2082,7 +2082,7 @@ def parent_label_from_gender(gender, rel_type):
         else:
             label = _("Guardian")
     else:
-    # Masculine, feminine and other gender entries needed for translations
+        # Masculine, feminine and other gender entries needed for translations
         if gender == Person.MALE:
             label = _("Parent")
         elif gender == Person.FEMALE:

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -1671,7 +1671,7 @@ class RelationshipView(NavigationView):
             self.write_label(_("%s:") % _("Family"), family, False, person)
 
             fam_type = family.get_relationship()
-            spouse_label = spouse_label_from_gender(spouse,fam_type)
+            spouse_label = spouse_label_from_gender(spouse, fam_type)
 
             box = self.write_person(spouse_label, handle)
 

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -1256,8 +1256,9 @@ class RelationshipView(NavigationView):
 
     def write_person(self, title, handle):
         """
-        Create and show a person cell with a "Father/Mother/Spouse" label in the GUI at the current row
-        @param title: left column label ("Father/Mother/Spouse")
+        Create and show a person cell with a "Father/Mother/Parent/Adoptive/Step/Guardian" in the case 
+		of the child and "Husband/Wife/Spouse/Partner" for a spouse label in the GUI at the current row
+        @param title: left column label ("Father/Mother/Parent/Adoptive/Step/Guardian" or "Husband/Wife/Spouse/Partner")
         @param handle: person handle
         """
         if title:

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -2058,7 +2058,7 @@ def parent_label_from_gender(gender, rel_type):
         if gender == Person.MALE:
             label = _("Father")
         if gender == Person.FEMALE:
-                label = _("Mother")
+            label = _("Mother")
     elif rel_type == "Stepchild":
         if gender == Person.MALE:
             label = _("Stepfather")

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -2079,7 +2079,7 @@ def parent_label_from_gender(gender, rel_type):
             label = _("Guardian")
         elif gender == Person.FEMALE:
             label = _("Guardian")
-		else:
+        else:
             label = _("Guardian")
     else:
     # Masculine, feminine and other gender entries needed for translations

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -2073,14 +2073,21 @@ def parent_label_from_gender(gender, rel_type):
             label = _("Adoptive Mother")
         else:
             label = _("Adoptive Parent")
-    elif rel_type == "Sponsored" or rel_type == "Foster":
+    elif rel_type == "Foster":
+        if gender == Person.MALE:
+            label = _("Foster Father")
+        elif gender == Person.FEMALE:
+            label = _("Foster Mother")
+        else:
+            label = _("Foster Parent")
+    elif rel_type == "Sponsored"":
         # Masculine, feminine and other gender entries needed for translations
         if gender == Person.MALE:
-            label = _("Guardian")
+            label = _("Sponsor")
         elif gender == Person.FEMALE:
-            label = _("Guardian")
+            label = _("Sponsor")
         else:
-            label = _("Guardian")
+            label = _("Sponsor")
     else:
         # Masculine, feminine and other gender entries needed for translations
         if gender == Person.MALE:

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -1688,7 +1688,7 @@ class RelationshipView(NavigationView):
                     box = self.write_person(_("Wife"), handle)
                 else:
                     box = self.write_person(_("Spouse"), handle)
-            #MARRIED and CIVIL_UNION handled separately if translators need to use different labels
+            # MARRIED and CIVIL_UNION handled separately if translators need to use different labels
             elif family.get_relationship() == FamilyRelType.CIVIL_UNION:
                 if spouse == Person.MALE:
                     box = self.write_person(_("Husband"), handle)
@@ -1698,7 +1698,7 @@ class RelationshipView(NavigationView):
                     box = self.write_person(_("Spouse"), handle)
             else:
                 box = self.write_person(_("Partner"), handle)
-				
+
             if not self.write_relationship_events(box, family):
                 self.write_relationship(box, family)
 

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -1106,25 +1106,13 @@ class RelationshipView(NavigationView):
                 father = mother = None
                 hd21 = family.get_father_handle()
                 if hd21:
-                    father = self.dbstate.db.get_person_from_handle(hd21).gender
+                    father_gen = self.dbstate.db.get_person_from_handle(hd21).gender
                 hd22 = family.get_mother_handle()
                 if hd22:
-                    mother = self.dbstate.db.get_person_from_handle(hd22).gender
+                    mother_gen = self.dbstate.db.get_person_from_handle(hd22).gender
 
-                parent1 = parent2 = ""
-                if father == Person.MALE:
-                    parent1 = _("Father")
-                elif father == Person.FEMALE:
-                    parent1 = _("Mother")
-                else:
-                    parent1 = _("Parent")
-
-                if mother == Person.FEMALE:
-                    parent2 = _("Mother")
-                elif mother == Person.MALE:
-                    parent2 = _("Father")
-                else:
-                    parent2 = _("Parent")
+                parent1 = parent_label_from_gender(father_gen)
+                parent2 = parent_label_from_gender(mother_gen)
 
                 self.write_label(_("%s:") % _("Parents"), family, True, person)
                 self.write_person(parent1, family.get_father_handle())
@@ -2057,6 +2045,15 @@ def button_activated(event, mouse_button):
         return True
     else:
         return False
+def parent_label_from_gender(gender):
+    if gender == Person.MALE:
+        label = _("Father")
+    elif gender == Person.FEMALE:
+        label = _("Mother")
+    else:
+        label = _("Parent")
+
+    return label
 
 def spouse_label_from_gender(spouse,fam_type):
     if fam_type == FamilyRelType.MARRIED:

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -2117,6 +2117,34 @@ def spouse_label_from_gender(spouse, fam_type):
             label = _("Wife")
         else:
             label = _("Spouse")
+    elif fam_type == FamilyRelType.ENGAGED:
+        if spouse == Person.MALE:
+            label = _("Fiancé")
+        elif spouse == Person.FEMALE:
+            label = _("Fiancée")
+        else:
+            label = _("Future Spouse")
+    elif fam_type == FamilyRelType.DIVORCED or fam_type == FamilyRelType.ANNULLED:
+        if spouse == Person.MALE:
+            label = _("Former Husband")
+        elif spouse == Person.FEMALE:
+            label = _("Former Wife")
+        else:
+            label = _("Former Spouse")
+    elif fam_type == FamilyRelType.SEPARATED:
+        if spouse == Person.MALE:
+            label = _("Husband (separated)")
+        elif spouse == Person.FEMALE:
+            label = _("Wife (separated)")
+        else:
+            label = _("Spouse (separated)")
+    elif fam_type == FamilyRelType.POLY_MARR:
+        if spouse == Person.MALE:
+            label = _("Polygamous Husband")
+        elif spouse == Person.FEMALE:
+            label = _("Polygamous Wife")
+        else:
+            label = _("Polygamous Spouse")
     else:
         label = _("Partner")
 

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -1672,7 +1672,7 @@ class RelationshipView(NavigationView):
 
             fam_type = family.get_relationship()
             spouse_label = spouse_label_from_gender(spouse,fam_type)
-			
+
             box = self.write_person(spouse_label, handle)
 
             if not self.write_relationship_events(box, family):
@@ -2057,7 +2057,7 @@ def parent_label_from_gender(gender):
     return label
 
 
-def spouse_label_from_gender(spouse,fam_type):
+def spouse_label_from_gender(spouse, fam_type):
     if fam_type == FamilyRelType.MARRIED:
         if spouse == Person.MALE:
             label = _("Husband")

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -1103,7 +1103,14 @@ class RelationshipView(NavigationView):
             self.row += 1  # now advance it
         else:
             if family:
-                father = mother = None
+                father_gen = mother_gen = None
+                father_rel = mother_rel = ""
+                child_handle = person.get_handle()
+                child_ref_list = family.get_child_ref_list()
+                for child_ref in child_ref_list:
+                    if child_ref.ref == child_handle:
+                        father_rel = str(child_ref.get_father_relation())
+                        mother_rel = str(child_ref.get_mother_relation())
                 hd21 = family.get_father_handle()
                 if hd21:
                     father_gen = self.dbstate.db.get_person_from_handle(hd21).gender
@@ -1111,8 +1118,8 @@ class RelationshipView(NavigationView):
                 if hd22:
                     mother_gen = self.dbstate.db.get_person_from_handle(hd22).gender
 
-                parent1 = parent_label_from_gender(father_gen)
-                parent2 = parent_label_from_gender(mother_gen)
+                parent1 = parent_label_from_gender(father_gen, father_rel)
+                parent2 = parent_label_from_gender(mother_gen, mother_rel)
 
                 self.write_label(_("%s:") % _("Parents"), family, True, person)
                 self.write_person(parent1, family.get_father_handle())
@@ -2046,11 +2053,28 @@ def button_activated(event, mouse_button):
         return False
 
 
-def parent_label_from_gender(gender):
-    if gender == Person.MALE:
-        label = _("Father")
-    elif gender == Person.FEMALE:
-        label = _("Mother")
+def parent_label_from_gender(gender, rel_type):
+    if rel_type == "Birth":
+        if gender == Person.MALE:
+            label = _("Father")
+        if gender == Person.FEMALE:
+                label = _("Mother")
+    elif rel_type == "Stepchild":
+        if gender == Person.MALE:
+            label = _("Stepfather")
+        elif gender == Person.FEMALE:
+            label = _("Stepmother")
+        else:
+            label = _("Step-Parent")
+    elif rel_type == "Adopted":
+        if gender == Person.MALE:
+            label = _("Adoptive Father")
+        elif gender == Person.FEMALE:
+            label = _("Adoptive Mother")
+        else:
+            label = _("Adoptive Parent")
+    elif rel_type == "Sponsored" or rel_type == "Foster":
+        label = _("Guardian")
     else:
         label = _("Parent")
 

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -2074,9 +2074,21 @@ def parent_label_from_gender(gender, rel_type):
         else:
             label = _("Adoptive Parent")
     elif rel_type == "Sponsored" or rel_type == "Foster":
-        label = _("Guardian")
+    # Masculine, feminine and other gender entries needed for translations
+        if gender == Person.MALE:
+            label = _("Guardian")
+        elif gender == Person.FEMALE:
+            label = _("Guardian")
+		else
+            label = _("Guardian")
     else:
-        label = _("Parent")
+    # Masculine, feminine and other gender entries needed for translations
+        if gender == Person.MALE:
+            label = _("Parent")
+        elif gender == Person.FEMALE:
+            label = _("Parent")
+        else        
+            label = _("Parent")
 
     return label
 

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -2094,7 +2094,7 @@ def parent_label_from_gender(gender, rel_type):
             label = _("Parent")
         elif gender == Person.FEMALE:
             label = _("Parent")
-        else:        
+        else:
             label = _("Parent")
 
     return label

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -1681,23 +1681,12 @@ class RelationshipView(NavigationView):
         else:
             # show "V Family: ..." and the rest
             self.write_label(_("%s:") % _("Family"), family, False, person)
-            if family.get_relationship() == FamilyRelType.MARRIED:
-                if spouse == Person.MALE:
-                    box = self.write_person(_("Husband"), handle)
-                elif spouse == Person.FEMALE:
-                    box = self.write_person(_("Wife"), handle)
-                else:
-                    box = self.write_person(_("Spouse"), handle)
-            # MARRIED and CIVIL_UNION handled separately if translators need to use different labels
-            elif family.get_relationship() == FamilyRelType.CIVIL_UNION:
-                if spouse == Person.MALE:
-                    box = self.write_person(_("Husband"), handle)
-                elif spouse == Person.FEMALE:
-                    box = self.write_person(_("Wife"), handle)
-                else:
-                    box = self.write_person(_("Spouse"), handle)
-            else:
-                box = self.write_person(_("Partner"), handle)
+
+            fam_type = family.get_relationship()
+			
+            spouse_label = spouse_label_from_gender(spouse,fam_type)
+			
+            box = self.write_person(spouse_label, handle)
 
             if not self.write_relationship_events(box, family):
                 self.write_relationship(box, family)
@@ -2068,3 +2057,24 @@ def button_activated(event, mouse_button):
         return True
     else:
         return False
+
+def spouse_label_from_gender(spouse,fam_type):
+    if fam_type == FamilyRelType.MARRIED:
+        if spouse == Person.MALE:
+            label = _("Husband")
+        elif spouse == Person.FEMALE:
+            label = _("Wife")
+        else:
+            label = _("Spouse")
+    # MARRIED and CIVIL_UNION handled separately if translators need to use different labels
+    elif fam_type == FamilyRelType.CIVIL_UNION:
+        if spouse == Person.MALE:
+            label = _("Husband X")
+        elif spouse == Person.FEMALE:
+            label = _("Wife X")
+        else:
+            label = _("Spouse X")
+    else:
+        label = _("Partner")
+
+    return label

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -1102,9 +1102,34 @@ class RelationshipView(NavigationView):
             )
             self.row += 1  # now advance it
         else:
-            self.write_label(_("%s:") % _("Parents"), family, True, person)
-            self.write_person(_("Father"), family.get_father_handle())
-            self.write_person(_("Mother"), family.get_mother_handle())
+            if family:
+                father = mother = None
+                hd21 = family.get_father_handle()
+                if hd21:
+                    father = self.dbstate.db.get_person_from_handle(hd21).gender
+                hd22 = family.get_mother_handle()
+                if hd22:
+                    mother = self.dbstate.db.get_person_from_handle(hd22).gender
+
+                parent1 = parent2 = ""
+                if father == Person.MALE:
+                    parent1 = _("Father")
+                elif father == Person.FEMALE:
+                    parent1 = _("Mother")
+                else:
+                    parent1 = _("Parent")
+
+
+                if mother == Person.FEMALE:
+                    parent2 = _("Mother")
+                elif mother == Person.MALE:
+                    parent2 = _("Father")
+                else:
+                    parent2 = _("Parent")
+
+                self.write_label(_("%s:") % _("Parents"), family, True, person)
+                self.write_person(parent1, family.get_father_handle())
+                self.write_person(parent2, family.get_mother_handle())
 
             if self.show_siblings:
                 active = self.get_active()
@@ -1613,10 +1638,20 @@ class RelationshipView(NavigationView):
 
         father_handle = family.get_father_handle()
         mother_handle = family.get_mother_handle()
+        spouse = spouse1 = spouse2 = None
+        hd21 = family.get_father_handle()
+        if hd21:
+            spouse1 = self.dbstate.db.get_person_from_handle(hd21).gender
+        hd22 = family.get_mother_handle()
+        if hd22:
+            spouse2 = self.dbstate.db.get_person_from_handle(hd22).gender
+
         if self.get_active() == father_handle:
             handle = mother_handle
+            spouse = spouse2
         else:
             handle = father_handle
+            spouse = spouse1
 
         # collapse button
         if self.check_collapsed(person.handle, family_handle):
@@ -1646,11 +1681,26 @@ class RelationshipView(NavigationView):
         else:
             # show "V Family: ..." and the rest
             self.write_label(_("%s:") % _("Family"), family, False, person)
-            if handle or family.get_relationship() != FamilyRelType.UNKNOWN:
-                box = self.write_person(_("Spouse"), handle)
-
-                if not self.write_relationship_events(box, family):
-                    self.write_relationship(box, family)
+            if family.get_relationship() == FamilyRelType.MARRIED:
+                if spouse == Person.MALE:
+                    box = self.write_person(_("Husband"), handle)
+                elif spouse == Person.FEMALE:
+                    box = self.write_person(_("Wife"), handle)
+                else:
+                    box = self.write_person(_("Spouse"), handle)
+            #MARRIED and CIVIL_UNION handled separately if translators need to use different labels
+            elif family.get_relationship() == FamilyRelType.CIVIL_UNION:
+                if spouse == Person.MALE:
+                    box = self.write_person(_("Husband"), handle)
+                elif spouse == Person.FEMALE:
+                    box = self.write_person(_("Wife"), handle)
+                else:
+                    box = self.write_person(_("Spouse"), handle)
+            else:
+                box = self.write_person(_("Partner"), handle)
+				
+            if not self.write_relationship_events(box, family):
+                self.write_relationship(box, family)
 
             hbox = Gtk.Box()
             if self.check_collapsed(family.handle, "CHILDREN"):

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -1119,7 +1119,6 @@ class RelationshipView(NavigationView):
                 else:
                     parent1 = _("Parent")
 
-
                 if mother == Person.FEMALE:
                     parent2 = _("Mother")
                 elif mother == Person.MALE:


### PR DESCRIPTION
Create spouse labels in the Relationships view based upon the nature of the Family type

This is a Feature request to enhance the Relationships view

Replaces PR https://github.com/gramps-project/gramps/pull/1843

Mantis #0013554

I still have the desire to change the Parent labels of a child but having difficulty integrating the mrel and frel into the code. (I am not a coder and can only tweak what someone dreams up)

@stevenyoungs indicates this may be better used as a function so it can be used in other places. Again, I do know how to go about making that a reality.