### PR TITLE
Add consistent method names in the DB public API

### DIFF
--- a/gramps/gen/db/base.py
+++ b/gramps/gen/db/base.py
@@ -28,7 +28,7 @@ from this class.
 
 # -------------------------------------------------------------------------
 #
-# Python modules
+# Standard Python modules
 #
 # -------------------------------------------------------------------------
 from collections.abc import Iterator

--- a/gramps/gen/db/base.py
+++ b/gramps/gen/db/base.py
@@ -250,11 +250,20 @@ class DbReadBase:
         """
         raise NotImplementedError
 
-    def get_repo_bookmarks(self):
+    def get_repository_bookmarks(self):
         """
         Return the list of Repository handles in the bookmarks.
         """
         raise NotImplementedError
+
+    def get_repo_bookmarks(self):
+        """
+        Deprecated alias for get_repository_bookmarks().
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`get_repository_bookmarks` instead.
+        """
+        return self.get_repository_bookmarks()
 
     def get_source_bookmarks(self):
         """

--- a/gramps/gen/db/base.py
+++ b/gramps/gen/db/base.py
@@ -5,6 +5,7 @@
 # Copyright (C) 2010       Nick Hall
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2026       Gabriel Rios
+# Copyright (C) 2026       Steve Youngs
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -30,6 +31,8 @@ from this class.
 # Python modules
 #
 # -------------------------------------------------------------------------
+from collections.abc import Iterator
+from typing import cast
 import logging
 
 # -------------------------------------------------------------------------
@@ -41,6 +44,49 @@ from ..const import GRAMPS_LOCALE as glocale
 from ..db.dbconst import DBLOGNAME
 from ..lib.childref import ChildRef
 from ..lib.childreftype import ChildRefType
+from ..lib.json_utils import DataDict
+from ..types import (
+    Person,
+    Family,
+    Event,
+    Place,
+    Source,
+    Repository,
+    Citation,
+    Media,
+    Note,
+    Tag,
+    PersonHandle,
+    FamilyHandle,
+    EventHandle,
+    PlaceHandle,
+    SourceHandle,
+    RepositoryHandle,
+    CitationHandle,
+    MediaHandle,
+    NoteHandle,
+    TagHandle,
+    PersonGrampsID,
+    FamilyGrampsID,
+    EventGrampsID,
+    PlaceGrampsID,
+    SourceGrampsID,
+    RepositoryGrampsID,
+    CitationGrampsID,
+    MediaGrampsID,
+    NoteGrampsID,
+    PersonDataDict,
+    EventDataDict,
+    FamilyDataDict,
+    PlaceDataDict,
+    SourceDataDict,
+    RepositoryDataDict,
+    CitationDataDict,
+    MediaDataDict,
+    NoteDataDict,
+    TagDataDict,
+    AnyDataDict,
+)
 from .exceptions import DbTransactionCancel
 from .txn import DbTxn
 
@@ -874,126 +920,96 @@ class DbReadBase:
     def get_number_of_citations(self):
         """
         Return the number of citations currently in the database.
+
+        .. version-deprecated:: 6.2
+           Use :py:meth:`count_citation` instead.
         """
         raise NotImplementedError
 
     def get_number_of_events(self):
         """
         Return the number of events currently in the database.
+
+        .. version-deprecated:: 6.2
+           Use :py:meth:`count_event` instead.
         """
         raise NotImplementedError
 
     def get_number_of_families(self):
         """
         Return the number of families currently in the database.
+
+        .. version-deprecated:: 6.2
+           Use :py:meth:`count_family` instead.
         """
         raise NotImplementedError
 
     def get_number_of_media(self):
         """
         Return the number of media objects currently in the database.
+
+        .. version-deprecated:: 6.2
+           Use :py:meth:`count_media` instead.
         """
         raise NotImplementedError
 
     def get_number_of_notes(self):
         """
         Return the number of notes currently in the database.
+
+        .. version-deprecated:: 6.2
+           Use :py:meth:`count_note` instead.
         """
         raise NotImplementedError
 
     def get_number_of_people(self):
         """
         Return the number of people currently in the database.
+
+        .. version-deprecated:: 6.2
+           Use :py:meth:`count_person` instead.
         """
         raise NotImplementedError
 
     def get_number_of_places(self):
         """
         Return the number of places currently in the database.
+
+        .. version-deprecated:: 6.2
+           Use :py:meth:`count_place` instead.
         """
         raise NotImplementedError
 
     def get_number_of_repositories(self):
         """
         Return the number of source repositories currently in the database.
+
+        .. version-deprecated:: 6.2
+           Use :py:meth:`count_repository` instead.
         """
         raise NotImplementedError
 
     def get_number_of_sources(self):
         """
         Return the number of sources currently in the database.
+
+        .. version-deprecated:: 6.2
+           Use :py:meth:`count_source` instead.
         """
         raise NotImplementedError
 
     def get_number_of_tags(self):
         """
         Return the number of tags currently in the database.
+
+        .. version-deprecated:: 6.2
+           Use :py:meth:`count_tag` instead.
         """
         raise NotImplementedError
 
     def get_person_event_types(self):
         """
         Deprecated:  Use get_event_types
-        """
-        raise NotImplementedError
-
-    def get_raw_citation_data(self, handle):
-        """
-        Return raw (serialized and pickled) Citation object from handle
-        """
-        raise NotImplementedError
-
-    def get_raw_event_data(self, handle):
-        """
-        Return raw (serialized and pickled) Event object from handle
-        """
-        raise NotImplementedError
-
-    def get_raw_family_data(self, handle):
-        """
-        Return raw (serialized and pickled) Family object from handle
-        """
-        raise NotImplementedError
-
-    def get_raw_media_data(self, handle):
-        """
-        Return raw (serialized and pickled) Media object from handle
-        """
-        raise NotImplementedError
-
-    def get_raw_note_data(self, handle):
-        """
-        Return raw (serialized and pickled) Note object from handle
-        """
-        raise NotImplementedError
-
-    def get_raw_person_data(self, handle):
-        """
-        Return raw (serialized and pickled) Person object from handle
-        """
-        raise NotImplementedError
-
-    def get_raw_place_data(self, handle):
-        """
-        Return raw (serialized and pickled) Place object from handle
-        """
-        raise NotImplementedError
-
-    def get_raw_repository_data(self, handle):
-        """
-        Return raw (serialized and pickled) Repository object from handle
-        """
-        raise NotImplementedError
-
-    def get_raw_source_data(self, handle):
-        """
-        Return raw (serialized and pickled) Source object from handle
-        """
-        raise NotImplementedError
-
-    def get_raw_tag_data(self, handle):
-        """
-        Return raw (serialized and pickled) Tag object from handle
         """
         raise NotImplementedError
 
@@ -1027,114 +1043,171 @@ class DbReadBase:
     def has_citation_gramps_id(self, gramps_id):
         """
         Return True if the Gramps ID exists in the Citation table.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`has_citation_from_gramps_id` instead.
         """
         raise NotImplementedError
 
     def has_event_gramps_id(self, gramps_id):
         """
         Return True if the Gramps ID exists in the Event table.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`has_event_from_gramps_id` instead.
         """
         raise NotImplementedError
 
     def has_family_gramps_id(self, gramps_id):
         """
         Return True if the Gramps ID exists in the Family table.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`has_family_from_gramps_id` instead.
         """
         raise NotImplementedError
 
     def has_media_gramps_id(self, gramps_id):
         """
         Return True if the Gramps ID exists in the Media table.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`has_media_from_gramps_id` instead.
         """
         raise NotImplementedError
 
     def has_note_gramps_id(self, gramps_id):
         """
         Return True if the Gramps ID exists in the Note table.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`has_note_from_gramps_id` instead.
         """
         raise NotImplementedError
 
     def has_person_gramps_id(self, gramps_id):
         """
         Return True if the Gramps ID exists in the Person table.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`has_person_from_gramps_id` instead.
         """
         raise NotImplementedError
 
     def has_place_gramps_id(self, gramps_id):
         """
         Return True if the Gramps ID exists in the Place table.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`has_place_from_gramps_id` instead.
         """
         raise NotImplementedError
 
     def has_repository_gramps_id(self, gramps_id):
         """
         Return True if the Gramps ID exists in the Repository table.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`has_repository_from_gramps_id` instead.
         """
         raise NotImplementedError
 
     def has_source_gramps_id(self, gramps_id):
         """
         Return True if the Gramps ID exists in the Source table.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`has_source_from_gramps_id` instead.
         """
         raise NotImplementedError
 
     def has_event_handle(self, handle):
         """
         Return True if the handle exists in the current Event database.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`has_event_from_handle` instead.
         """
         raise NotImplementedError
 
     def has_family_handle(self, handle):
         """
         Return True if the handle exists in the current Family database.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`has_family_from_handle` instead.
         """
         raise NotImplementedError
 
     def has_media_handle(self, handle):
         """
         Return True if the handle exists in the current Mediadatabase.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`has_media_from_handle` instead.
         """
         raise NotImplementedError
 
     def has_note_handle(self, handle):
         """
         Return True if the handle exists in the current Note database.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`has_note_from_handle` instead.
         """
         raise NotImplementedError
 
     def has_person_handle(self, handle):
         """
         Return True if the handle exists in the current Person database.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`has_person_from_handle` instead.
         """
         raise NotImplementedError
 
     def has_place_handle(self, handle):
         """
         Return True if the handle exists in the current Place database.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`has_place_from_handle` instead.
         """
         raise NotImplementedError
 
     def has_repository_handle(self, handle):
         """
         Return True if the handle exists in the current Repository database.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`has_repository_from_handle` instead.
         """
         raise NotImplementedError
 
     def has_source_handle(self, handle):
         """
         Return True if the handle exists in the current Source database.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`has_source_from_handle` instead.
         """
         raise NotImplementedError
 
     def has_citation_handle(self, handle):
         """
         Return True if the handle exists in the current Citation database.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`has_citation_from_handle` instead.
         """
         raise NotImplementedError
 
     def has_tag_handle(self, handle):
         """
         Return True if the handle exists in the current Tag database.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`has_tag_from_handle` instead.
         """
         raise NotImplementedError
 
@@ -1153,18 +1226,27 @@ class DbReadBase:
     def iter_citations(self):
         """
         Return an iterator over objects for Citations in the database
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`iter_citation` instead.
         """
         raise NotImplementedError
 
     def iter_events(self):
         """
         Return an iterator over objects for Events in the database
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`iter_event` instead.
         """
         raise NotImplementedError
 
     def iter_families(self):
         """
         Return an iterator over objects for Families in the database
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`iter_family` instead.
         """
         raise NotImplementedError
 
@@ -1177,36 +1259,54 @@ class DbReadBase:
     def iter_notes(self):
         """
         Return an iterator over objects for Notes in the database
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`iter_note` instead.
         """
         raise NotImplementedError
 
     def iter_people(self):
         """
         Return an iterator over objects for Persons in the database
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`iter_person` instead.
         """
         raise NotImplementedError
 
     def iter_places(self):
         """
         Return an iterator over objects for Places in the database
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`iter_place` instead.
         """
         raise NotImplementedError
 
     def iter_repositories(self):
         """
         Return an iterator over objects for Repositories in the database
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`iter_repository` instead.
         """
         raise NotImplementedError
 
     def iter_sources(self):
         """
         Return an iterator over objects for Sources in the database
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`iter_source` instead.
         """
         raise NotImplementedError
 
     def iter_tags(self):
         """
         Return an iterator over objects for Tags in the database
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`iter_tag` instead.
         """
         raise NotImplementedError
 
@@ -1488,6 +1588,868 @@ class DbReadBase:
             conflict
         """
         raise NotImplementedError
+
+    # add methods with consistent names for the public API
+    def get_person_data_from_handle(self, handle: PersonHandle) -> PersonDataDict:
+        """
+        Return raw (DataDict) Person object from handle
+
+        :param handle: handle of the object to search for.
+        :type handle: str or bytes
+        """
+        return self.get_raw_person_data(handle)
+
+    def get_family_data_from_handle(self, handle: FamilyHandle) -> FamilyDataDict:
+        """
+        Return raw (DataDict) Family object from handle
+
+        :param handle: handle of the object to search for.
+        :type handle: str or bytes
+        """
+        return self.get_raw_family_data(handle)
+
+    def get_source_data_from_handle(self, handle: SourceHandle) -> SourceDataDict:
+        """
+        Return raw (DataDict) Source object from handle
+
+        :param handle: handle of the object to search for.
+        :type handle: str or bytes
+        """
+        return self.get_raw_source_data(handle)
+
+    def get_citation_data_from_handle(self, handle: CitationHandle) -> CitationDataDict:
+        """
+        Return raw (DataDict) Citation object from handle
+
+        :param handle: handle of the object to search for.
+        :type handle: str or bytes
+        """
+        return self.get_raw_citation_data(handle)
+
+    def get_event_data_from_handle(self, handle: EventHandle) -> EventDataDict:
+        """
+        Return raw (DataDict) Event object from handle
+
+        :param handle: handle of the object to search for.
+        :type handle: str or bytes
+        """
+        return self.get_raw_event_data(handle)
+
+    def get_media_data_from_handle(self, handle: MediaHandle) -> MediaDataDict:
+        """
+        Return raw (DataDict) Media object from handle
+
+        :param handle: handle of the object to search for.
+        :type handle: str or bytes
+        """
+        return self.get_raw_media_data(handle)
+
+    def get_place_data_from_handle(self, handle: PlaceHandle) -> PlaceDataDict:
+        """
+        Return raw (DataDict) Place object from handle
+
+        :param handle: handle of the object to search for.
+        :type handle: str or bytes
+        """
+        return self.get_raw_place_data(handle)
+
+    def get_repository_data_from_handle(
+        self, handle: RepositoryHandle
+    ) -> RepositoryDataDict:
+        """
+        Return raw (DataDict) Repository object from handle
+
+        :param handle: handle of the object to search for.
+        :type handle: str or bytes
+        """
+        return self.get_raw_repository_data(handle)
+
+    def get_note_data_from_handle(self, handle: NoteHandle) -> NoteDataDict:
+        """
+        Return raw (DataDict) Note object from handle
+
+        :param handle: handle of the object to search for.
+        :type handle: str or bytes
+        """
+        return self.get_raw_note_data(handle)
+
+    def get_tag_data_from_handle(self, handle: TagHandle) -> TagDataDict:
+        """
+        Return raw (DataDict) Tag object from handle
+
+        :param handle: handle of the object to search for.
+        :type handle: str or bytes
+        """
+        return self.get_raw_tag_data(handle)
+
+    def count_person(self) -> int:
+        """
+        Return the number of Person objects currently in the database.
+        """
+        return self.get_number_of_people()
+
+    def count_family(self) -> int:
+        """
+        Return the number of Family objects currently in the database.
+        """
+        return self.get_number_of_families()
+
+    def count_source(self) -> int:
+        """
+        Return the number of Source objects currently in the database.
+        """
+        return self.get_number_of_sources()
+
+    def count_citation(self) -> int:
+        """
+        Return the number of Citation objects currently in the database.
+        """
+        return self.get_number_of_citations()
+
+    def count_event(self) -> int:
+        """
+        Return the number of Event objects currently in the database.
+        """
+        return self.get_number_of_events()
+
+    def count_media(self) -> int:
+        """
+        Return the number of Media objects currently in the database.
+        """
+        return self.get_number_of_media()
+
+    def count_place(self) -> int:
+        """
+        Return the number of Place objects currently in the database.
+        """
+        return self.get_number_of_places()
+
+    def count_repository(self) -> int:
+        """
+        Return the number of Repository objects currently in the database.
+        """
+        return self.get_number_of_repositories()
+
+    def count_note(self) -> int:
+        """
+        Return the number of Note objects currently in the database.
+        """
+        return self.get_number_of_notes()
+
+    def count_tag(self) -> int:
+        """
+        Return the number of Tag objects currently in the database.
+        """
+        return self.get_number_of_tags()
+
+    def iter_person(self) -> Iterator[Person]:
+        """
+        Return an iterator over Person objects in the database
+        """
+        return self.iter_people()
+
+    def iter_family(self) -> Iterator[Family]:
+        """
+        Return an iterator over Family objects in the database
+        """
+        return self.iter_families()
+
+    def iter_source(self) -> Iterator[Source]:
+        """
+        Return an iterator over Source objects in the database
+        """
+        return self.iter_sources()
+
+    def iter_citation(self) -> Iterator[Citation]:
+        """
+        Return an iterator over Citation objects in the database
+        """
+        return self.iter_citations()
+
+    def iter_event(self) -> Iterator[Event]:
+        """
+        Return an iterator over Event objects in the database
+        """
+        return self.iter_events()
+
+    # iter_media is already defined
+
+    def iter_place(self) -> Iterator[Place]:
+        """
+        Return an iterator over Place objects in the database
+        """
+        return self.iter_places()
+
+    def iter_repository(self) -> Iterator[Repository]:
+        """
+        Return an iterator over Repository objects in the database
+        """
+        return self.iter_repositories()
+
+    def iter_note(self) -> Iterator[Note]:
+        """
+        Return an iterator over Note objects in the database
+        """
+        return self.iter_notes()
+
+    def iter_tag(self) -> Iterator[Tag]:
+        """
+        Return an iterator over Tag objects in the database
+        """
+        return self.iter_tags()
+
+    def has_person_from_handle(self, handle: PersonHandle) -> bool:
+        """
+        Return True if the handle exists in the Person table.
+
+        :param handle: handle of the object to search for.
+        :type handle: PersonHandle
+        """
+        return self.has_person_handle(handle)
+
+    def has_family_from_handle(self, handle: FamilyHandle) -> bool:
+        """
+        Return True if the handle exists in the Family table.
+
+        :param handle: handle of the object to search for.
+        :type handle: FamilyHandle
+        """
+        return self.has_family_handle(handle)
+
+    def has_source_from_handle(self, handle: SourceHandle) -> bool:
+        """
+        Return True if the handle exists in the Source table.
+
+        :param handle: handle of the object to search for.
+        :type handle: SourceHandle
+        """
+        return self.has_source_handle(handle)
+
+    def has_citation_from_handle(self, handle: CitationHandle) -> bool:
+        """
+        Return True if the handle exists in the Citation table.
+
+        :param handle: handle of the object to search for.
+        :type handle: CitationHandle
+        """
+        return self.has_citation_handle(handle)
+
+    def has_event_from_handle(self, handle: EventHandle) -> bool:
+        """
+        Return True if the handle exists in the Event table.
+
+        :param handle: handle of the object to search for.
+        :type handle: EventHandle
+        """
+        return self.has_event_handle(handle)
+
+    def has_media_from_handle(self, handle: MediaHandle) -> bool:
+        """
+        Return True if the handle exists in the Media table.
+
+        :param handle: handle of the object to search for.
+        :type handle: MediaHandle
+        """
+        return self.has_media_handle(handle)
+
+    def has_place_from_handle(self, handle: PlaceHandle) -> bool:
+        """
+        Return True if the handle exists in the Place table.
+
+        :param handle: handle of the object to search for.
+        :type handle: PlaceHandle
+        """
+        return self.has_place_handle(handle)
+
+    def has_repository_from_handle(self, handle: RepositoryHandle) -> bool:
+        """
+        Return True if the handle exists in the Repository table.
+
+        :param handle: handle of the object to search for.
+        :type handle: RepositoryHandle
+        """
+        return self.has_repository_handle(handle)
+
+    def has_note_from_handle(self, handle: NoteHandle) -> bool:
+        """
+        Return True if the handle exists in the Note table.
+
+        :param handle: handle of the object to search for.
+        :type handle: NoteHandle
+        """
+        return self.has_note_handle(handle)
+
+    def has_tag_from_handle(self, handle: TagHandle) -> bool:
+        """
+        Return True if the handle exists in the Tag table.
+
+        :param handle: handle of the object to search for.
+        :type handle: TagHandle
+        """
+        return self.has_tag_handle(handle)
+
+    def has_person_from_gramps_id(self, gramps_id: PersonGrampsID) -> bool:
+        """
+        Return True if the Gramps ID exists in the Person table.
+
+        :param gramps_id: Gramps ID of the object to search for.
+        :type gramps_id: PersonGrampsID
+        """
+        return self.has_person_gramps_id(gramps_id)
+
+    def has_family_from_gramps_id(self, gramps_id: FamilyGrampsID) -> bool:
+        """
+        Return True if the Gramps ID exists in the Family table.
+
+        :param gramps_id: Gramps ID of the object to search for.
+        :type gramps_id: FamilyGrampsID
+        """
+        return self.has_family_gramps_id(gramps_id)
+
+    def has_source_from_gramps_id(self, gramps_id: SourceGrampsID) -> bool:
+        """
+        Return True if the Gramps ID exists in the Source table.
+
+        :param gramps_id: Gramps ID of the object to search for.
+        :type gramps_id: SourceGrampsID
+        """
+        return self.has_source_gramps_id(gramps_id)
+
+    def has_citation_from_gramps_id(self, gramps_id: CitationGrampsID) -> bool:
+        """
+        Return True if the Gramps ID exists in the Citation table.
+
+        :param gramps_id: Gramps ID of the object to search for.
+        :type gramps_id: CitationGrampsID
+        """
+        return self.has_citation_gramps_id(gramps_id)
+
+    def has_event_from_gramps_id(self, gramps_id: EventGrampsID) -> bool:
+        """
+        Return True if the Gramps ID exists in the Event table.
+
+        :param gramps_id: Gramps ID of the object to search for.
+        :type gramps_id: EventGrampsID
+        """
+        return self.has_event_gramps_id(gramps_id)
+
+    def has_media_from_gramps_id(self, gramps_id: MediaGrampsID) -> bool:
+        """
+        Return True if the Gramps ID exists in the Media table.
+
+        :param gramps_id: Gramps ID of the object to search for.
+        :type gramps_id: MediaGrampsID
+        """
+        return self.has_media_gramps_id(gramps_id)
+
+    def has_place_from_gramps_id(self, gramps_id: PlaceGrampsID) -> bool:
+        """
+        Return True if the Gramps ID exists in the Place table.
+
+        :param gramps_id: Gramps ID of the object to search for.
+        :type gramps_id: PlaceGrampsID
+        """
+        return self.has_place_gramps_id(gramps_id)
+
+    def has_repository_from_gramps_id(self, gramps_id: RepositoryGrampsID) -> bool:
+        """
+        Return True if the Gramps ID exists in the Repository table.
+
+        :param gramps_id: Gramps ID of the object to search for.
+        :type gramps_id: RepositoryGrampsID
+        """
+        return self.has_repository_gramps_id(gramps_id)
+
+    def has_note_from_gramps_id(self, gramps_id: NoteGrampsID) -> bool:
+        """
+        Return True if the Gramps ID exists in the Note table.
+
+        :param gramps_id: Gramps ID of the object to search for.
+        :type gramps_id: NoteGrampsID
+        """
+        return self.has_note_gramps_id(gramps_id)
+
+    ################################################################
+    #
+    # get_raw_*_data methods
+    #
+    ################################################################
+
+    def get_raw_person_data(self, handle):
+        """
+        .. version-deprecated:: 6.2
+            Use :py:meth:`get_person_data_from_handle` instead.
+        """
+        raise NotImplementedError
+
+    def get_raw_family_data(self, handle):
+        """
+        .. version-deprecated:: 6.2
+            Use :py:meth:`get_family_data_from_handle` instead.
+        """
+        raise NotImplementedError
+
+    def get_raw_source_data(self, handle):
+        """
+        .. version-deprecated:: 6.2
+            Use :py:meth:`get_source_data_from_handle` instead.
+        """
+        raise NotImplementedError
+
+    def get_raw_citation_data(self, handle):
+        """
+        .. version-deprecated:: 6.2
+            Use :py:meth:`get_citation_data_from_handle` instead.
+        """
+        raise NotImplementedError
+
+    def get_raw_event_data(self, handle):
+        """
+        .. version-deprecated:: 6.2
+            Use :py:meth:`get_event_data_from_handle` instead.
+        """
+        raise NotImplementedError
+
+    def get_raw_media_data(self, handle):
+        """
+        .. version-deprecated:: 6.2
+            Use :py:meth:`get_media_data_from_handle` instead.
+        """
+        raise NotImplementedError
+
+    def get_raw_place_data(self, handle):
+        """
+        .. version-deprecated:: 6.2
+            Use :py:meth:`get_place_data_from_handle` instead.
+        """
+        raise NotImplementedError
+
+    def get_raw_repository_data(self, handle):
+        """
+        .. version-deprecated:: 6.2
+            Use :py:meth:`get_repository_data_from_handle` instead.
+        """
+        raise NotImplementedError
+
+    def get_raw_note_data(self, handle):
+        """
+        .. version-deprecated:: 6.2
+            Use :py:meth:`get_note_data_from_handle` instead.
+        """
+        raise NotImplementedError
+
+    def get_raw_tag_data(self, handle):
+        """
+        .. version-deprecated:: 6.2
+            Use :py:meth:`get_tag_data_from_handle` instead.
+        """
+        raise NotImplementedError
+
+    ################################################################
+    #
+    # _iter_raw_*_data methods
+    #
+    ################################################################
+
+    def _iter_raw_person_data(self):
+        """
+        Return an iterator over raw Person data.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`iter_person_data` instead.
+        """
+        raise NotImplementedError
+
+    def _iter_raw_family_data(self):
+        """
+        Return an iterator over raw Family data.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`iter_family_data` instead.
+        """
+        raise NotImplementedError
+
+    def _iter_raw_event_data(self):
+        """
+        Return an iterator over raw Event data.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`iter_event_data` instead.
+        """
+        raise NotImplementedError
+
+    def _iter_raw_place_data(self):
+        """
+        Return an iterator over raw Place data.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`iter_place_data` instead.
+        """
+        raise NotImplementedError
+
+    def _iter_raw_repository_data(self):
+        """
+        Return an iterator over raw Repository data.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`iter_repository_data` instead.
+        """
+        raise NotImplementedError
+
+    def _iter_raw_source_data(self):
+        """
+        Return an iterator over raw Source data.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`iter_source_data` instead.
+        """
+        raise NotImplementedError
+
+    def _iter_raw_citation_data(self):
+        """
+        Return an iterator over raw Citation data.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`iter_citation_data` instead.
+        """
+        raise NotImplementedError
+
+    def _iter_raw_media_data(self):
+        """
+        Return an iterator over raw Media data.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`iter_media_data` instead.
+        """
+        raise NotImplementedError
+
+    def _iter_raw_note_data(self):
+        """
+        Return an iterator over raw Note data.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`iter_note_data` instead.
+        """
+        raise NotImplementedError
+
+    def _iter_raw_tag_data(self):
+        """
+        Return an iterator over raw Tag data.
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`iter_tag_data` instead.
+        """
+        raise NotImplementedError
+
+    ################################################################
+    #
+    # _get_raw_*_from_id_data methods
+    #
+    ################################################################
+
+    def _get_raw_person_from_id_data(self, gramps_id: PersonGrampsID):
+        """
+        .. version-deprecated:: 6.2
+             Use :py:meth:`get_person_data_from_gramps_id` instead.
+        """
+        raise NotImplementedError
+
+    def _get_raw_family_from_id_data(self, gramps_id: FamilyGrampsID):
+        """
+        .. version-deprecated:: 6.2
+             Use :py:meth:`get_family_data_from_gramps_id` instead.
+        """
+        raise NotImplementedError
+
+    def _get_raw_source_from_id_data(self, gramps_id: SourceGrampsID):
+        """
+        .. version-deprecated:: 6.2
+             Use :py:meth:`get_source_data_from_gramps_id` instead.
+        """
+        raise NotImplementedError
+
+    def _get_raw_citation_from_id_data(self, gramps_id: CitationGrampsID):
+        """
+        .. version-deprecated:: 6.2
+             Use :py:meth:`get_citation_data_from_gramps_id` instead.
+        """
+        raise NotImplementedError
+
+    def _get_raw_event_from_id_data(self, gramps_id: EventGrampsID):
+        """
+        .. version-deprecated:: 6.2
+             Use :py:meth:`get_event_data_from_gramps_id` instead.
+        """
+        raise NotImplementedError
+
+    def _get_raw_media_from_id_data(self, gramps_id: MediaGrampsID):
+        """
+        .. version-deprecated:: 6.2
+             Use :py:meth:`get_media_data_from_gramps_id` instead.
+        """
+        raise NotImplementedError
+
+    def _get_raw_place_from_id_data(self, gramps_id: PlaceGrampsID):
+        """
+        .. version-deprecated:: 6.2
+             Use :py:meth:`get_place_data_from_gramps_id` instead.
+        """
+        raise NotImplementedError
+
+    def _get_raw_repository_from_id_data(self, gramps_id: RepositoryGrampsID):
+        """
+        .. version-deprecated:: 6.2
+             Use :py:meth:`get_repository_data_from_gramps_id` instead.
+        """
+        raise NotImplementedError
+
+    def _get_raw_note_from_id_data(self, gramps_id: NoteGrampsID):
+        """
+        .. version-deprecated:: 6.2
+             Use :py:meth:`get_note_data_from_gramps_id` instead.
+        """
+        raise NotImplementedError
+
+    ################################################################
+    #
+    # get_*_data_from_gramps_id methods
+    #
+    ################################################################
+
+    # add consistent [public] method names for _get_raw_*_from_id_data
+    # and _iter_raw_*_data
+    def get_person_data_from_gramps_id(
+        self, gramps_id: PersonGrampsID
+    ) -> PersonDataDict:
+        """
+        Return the raw data for the Person with the specified Gramps ID.
+
+        :param gramps_id: The Gramps ID of the Person to retrieve.
+        :type gramps_id: PersonGrampsID
+        :returns: The raw data for the Person with the specified Gramps ID.
+        :rtype: PersonDataDict
+        """
+        return self._get_raw_person_from_id_data(gramps_id)
+
+    def get_family_data_from_gramps_id(
+        self, gramps_id: FamilyGrampsID
+    ) -> FamilyDataDict:
+        """
+        Return the raw data for the Family with the specified Gramps ID.
+
+        :param gramps_id: The Gramps ID of the Family to retrieve.
+        :type gramps_id: FamilyGrampsID
+        :returns: The raw data for the Family with the specified Gramps ID.
+        :rtype: FamilyDataDict
+        """
+        return self._get_raw_family_from_id_data(gramps_id)
+
+    def get_source_data_from_gramps_id(
+        self, gramps_id: SourceGrampsID
+    ) -> SourceDataDict:
+        """
+        Return the raw data for the Source with the specified Gramps ID.
+
+        :param gramps_id: The Gramps ID of the Source to retrieve.
+        :type gramps_id: SourceGrampsID
+        :returns: The raw data for the Source with the specified Gramps ID.
+        :rtype: SourceDataDict
+        """
+        return self._get_raw_source_from_id_data(gramps_id)
+
+    def get_citation_data_from_gramps_id(
+        self, gramps_id: CitationGrampsID
+    ) -> CitationDataDict:
+        """
+        Return the raw data for the Citation with the specified Gramps ID.
+
+        :param gramps_id: The Gramps ID of the Citation to retrieve.
+        :type gramps_id: CitationGrampsID
+        :returns: The raw data for the Citation with the specified Gramps ID.
+        :rtype: CitationDataDict
+        """
+        return self._get_raw_citation_from_id_data(gramps_id)
+
+    def get_event_data_from_gramps_id(self, gramps_id: EventGrampsID) -> EventDataDict:
+        """
+        Return the raw data for the Event with the specified Gramps ID.
+
+        :param gramps_id: The Gramps ID of the Event to retrieve.
+        :type gramps_id: EventGrampsID
+        :returns: The raw data for the Event with the specified Gramps ID.
+        :rtype: EventDataDict
+        """
+        return self._get_raw_event_from_id_data(gramps_id)
+
+    def get_media_data_from_gramps_id(self, gramps_id: MediaGrampsID) -> MediaDataDict:
+        """
+        Return the raw data for the Media with the specified Gramps ID.
+
+        :param gramps_id: The Gramps ID of the Media to retrieve.
+        :type gramps_id: MediaGrampsID
+        :returns: The raw data for the Media with the specified Gramps ID.
+        :rtype: MediaDataDict
+        """
+        return self._get_raw_media_from_id_data(gramps_id)
+
+    def get_place_data_from_gramps_id(self, gramps_id: PlaceGrampsID) -> PlaceDataDict:
+        """
+        Return the raw data for the Place with the specified Gramps ID.
+
+        :param gramps_id: The Gramps ID of the Place to retrieve.
+        :type gramps_id: PlaceGrampsID
+        :returns: The raw data for the Place with the specified Gramps ID.
+        :rtype: PlaceDataDict
+        """
+        return self._get_raw_place_from_id_data(gramps_id)
+
+    def get_repository_data_from_gramps_id(
+        self, gramps_id: RepositoryGrampsID
+    ) -> RepositoryDataDict:
+        """
+        Return the raw data for the Repository with the specified Gramps ID.
+
+        :param gramps_id: The Gramps ID of the Repository to retrieve.
+        :type gramps_id: RepositoryGrampsID
+        :returns: The raw data for the Repository with the specified Gramps ID.
+        :rtype: RepositoryDataDict
+        """
+        return self._get_raw_repository_from_id_data(gramps_id)
+
+    def get_note_data_from_gramps_id(self, gramps_id: NoteGrampsID) -> NoteDataDict:
+        """
+        Return the raw data for the Note with the specified Gramps ID.
+
+        :param gramps_id: The Gramps ID of the Note to retrieve.
+        :type gramps_id: NoteGrampsID
+        :returns: The raw data for the Note with the specified Gramps ID.
+        :rtype: NoteDataDict
+        """
+        return self._get_raw_note_from_id_data(gramps_id)
+
+    ################################################################
+    #
+    # iter_*_data methods
+    #
+    ################################################################
+
+    def iter_person_data(self) -> Iterator[PersonDataDict]:
+        """
+        Return an iterator over the raw data for all Person instances in the
+        database.
+
+        :returns: An iterator over the raw data for all Person instances in the
+            database.
+        :rtype: Iterator[PersonDataDict]
+        """
+        return cast(Iterator[PersonDataDict], self._iter_raw_person_data())
+
+    def iter_family_data(self) -> Iterator[FamilyDataDict]:
+        """
+        Return an iterator over the raw data for all Family instances in the
+        database.
+
+        :returns: An iterator over the raw data for all Family instances in the
+            database.
+        :rtype: Iterator[FamilyDataDict]
+        """
+        return cast(Iterator[FamilyDataDict], self._iter_raw_family_data())
+
+    def iter_source_data(self) -> Iterator[SourceDataDict]:
+        """
+        Return an iterator over the raw data for all Source instances in the
+        database.
+
+        :returns: An iterator over the raw data for all Source instances in the
+            database.
+        :rtype: Iterator[SourceDataDict]
+        """
+        return cast(Iterator[SourceDataDict], self._iter_raw_source_data())
+
+    def iter_citation_data(self) -> Iterator[CitationDataDict]:
+        """
+        Return an iterator over the raw data for all Citation instances in the
+        database.
+
+        :returns: An iterator over the raw data for all Citation instances in the
+            database.
+        :rtype: Iterator[CitationDataDict]
+        """
+        return cast(
+            Iterator[CitationDataDict],
+            self._iter_raw_citation_data(),
+        )
+
+    def iter_event_data(self) -> Iterator[EventDataDict]:
+        """
+        Return an iterator over the raw data for all Event instances in the
+        database.
+
+        :returns: An iterator over the raw data for all Event instances in the
+            database.
+        :rtype: Iterator[EventDataDict]
+        """
+        return cast(Iterator[EventDataDict], self._iter_raw_event_data())
+
+    def iter_media_data(self) -> Iterator[MediaDataDict]:
+        """
+        Return an iterator over the raw data for all Media instances in the
+        database.
+
+        :returns: An iterator over the raw data for all Media instances in the
+            database.
+        :rtype: Iterator[MediaDataDict]
+        """
+        return cast(Iterator[MediaDataDict], self._iter_raw_media_data())
+
+    def iter_place_data(self) -> Iterator[PlaceDataDict]:
+        """
+        Return an iterator over the raw data for all Place instances in the
+        database.
+
+        :returns: An iterator over the raw data for all Place instances in the
+            database.
+        :rtype: Iterator[PlaceDataDict]
+        """
+        return cast(Iterator[PlaceDataDict], self._iter_raw_place_data())
+
+    def iter_repository_data(
+        self,
+    ) -> Iterator[RepositoryDataDict]:
+        """
+        Return an iterator over the raw data for all Repository instances in the
+        database.
+
+        :returns: An iterator over the raw data for all Repository instances in
+            the database.
+        :rtype: Iterator[RepositoryDataDict]
+        """
+        return cast(
+            Iterator[RepositoryDataDict],
+            self._iter_raw_repository_data(),
+        )
+
+    def iter_note_data(self) -> Iterator[NoteDataDict]:
+        """
+        Return an iterator over the raw data for all Note instances in the
+        database.
+
+        :returns: An iterator over the raw data for all Note instances in the
+            database.
+        :rtype: Iterator[NoteDataDict]
+        """
+        return cast(Iterator[NoteDataDict], self._iter_raw_note_data())
+
+    def iter_tag_data(self) -> Iterator[TagDataDict]:
+        """
+        Return an iterator over the raw data for all Tag instances in the
+        database.
+
+        :returns: An iterator over the raw data for all Tag instances in the
+            database.
+        :rtype: Iterator[TagDataDict]
+        """
+        return cast(Iterator[TagDataDict], self._iter_raw_tag_data())
 
 
 # -------------------------------------------------------------------------

--- a/gramps/gen/db/base.py
+++ b/gramps/gen/db/base.py
@@ -307,7 +307,7 @@ class DbReadBase:
         Deprecated alias for get_repository_bookmarks().
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`get_repository_bookmarks` instead.
+        Use :py:meth:`get_repository_bookmarks` instead.
         """
         return self.get_repository_bookmarks()
 
@@ -922,7 +922,7 @@ class DbReadBase:
         Return the number of citations currently in the database.
 
         .. version-deprecated:: 6.2
-           Use :py:meth:`count_citation` instead.
+        Use :py:meth:`count_citation` instead.
         """
         raise NotImplementedError
 
@@ -931,7 +931,7 @@ class DbReadBase:
         Return the number of events currently in the database.
 
         .. version-deprecated:: 6.2
-           Use :py:meth:`count_event` instead.
+        Use :py:meth:`count_event` instead.
         """
         raise NotImplementedError
 
@@ -940,7 +940,7 @@ class DbReadBase:
         Return the number of families currently in the database.
 
         .. version-deprecated:: 6.2
-           Use :py:meth:`count_family` instead.
+        Use :py:meth:`count_family` instead.
         """
         raise NotImplementedError
 
@@ -949,7 +949,7 @@ class DbReadBase:
         Return the number of media objects currently in the database.
 
         .. version-deprecated:: 6.2
-           Use :py:meth:`count_media` instead.
+        Use :py:meth:`count_media` instead.
         """
         raise NotImplementedError
 
@@ -958,7 +958,7 @@ class DbReadBase:
         Return the number of notes currently in the database.
 
         .. version-deprecated:: 6.2
-           Use :py:meth:`count_note` instead.
+        Use :py:meth:`count_note` instead.
         """
         raise NotImplementedError
 
@@ -967,7 +967,7 @@ class DbReadBase:
         Return the number of people currently in the database.
 
         .. version-deprecated:: 6.2
-           Use :py:meth:`count_person` instead.
+        Use :py:meth:`count_person` instead.
         """
         raise NotImplementedError
 
@@ -976,7 +976,7 @@ class DbReadBase:
         Return the number of places currently in the database.
 
         .. version-deprecated:: 6.2
-           Use :py:meth:`count_place` instead.
+        Use :py:meth:`count_place` instead.
         """
         raise NotImplementedError
 
@@ -985,7 +985,7 @@ class DbReadBase:
         Return the number of source repositories currently in the database.
 
         .. version-deprecated:: 6.2
-           Use :py:meth:`count_repository` instead.
+        Use :py:meth:`count_repository` instead.
         """
         raise NotImplementedError
 
@@ -994,7 +994,7 @@ class DbReadBase:
         Return the number of sources currently in the database.
 
         .. version-deprecated:: 6.2
-           Use :py:meth:`count_source` instead.
+        Use :py:meth:`count_source` instead.
         """
         raise NotImplementedError
 
@@ -1003,7 +1003,7 @@ class DbReadBase:
         Return the number of tags currently in the database.
 
         .. version-deprecated:: 6.2
-           Use :py:meth:`count_tag` instead.
+        Use :py:meth:`count_tag` instead.
         """
         raise NotImplementedError
 
@@ -1045,7 +1045,7 @@ class DbReadBase:
         Return True if the Gramps ID exists in the Citation table.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`has_citation_from_gramps_id` instead.
+        Use :py:meth:`has_citation_from_gramps_id` instead.
         """
         raise NotImplementedError
 
@@ -1054,7 +1054,7 @@ class DbReadBase:
         Return True if the Gramps ID exists in the Event table.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`has_event_from_gramps_id` instead.
+        Use :py:meth:`has_event_from_gramps_id` instead.
         """
         raise NotImplementedError
 
@@ -1063,7 +1063,7 @@ class DbReadBase:
         Return True if the Gramps ID exists in the Family table.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`has_family_from_gramps_id` instead.
+        Use :py:meth:`has_family_from_gramps_id` instead.
         """
         raise NotImplementedError
 
@@ -1072,7 +1072,7 @@ class DbReadBase:
         Return True if the Gramps ID exists in the Media table.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`has_media_from_gramps_id` instead.
+        Use :py:meth:`has_media_from_gramps_id` instead.
         """
         raise NotImplementedError
 
@@ -1081,7 +1081,7 @@ class DbReadBase:
         Return True if the Gramps ID exists in the Note table.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`has_note_from_gramps_id` instead.
+        Use :py:meth:`has_note_from_gramps_id` instead.
         """
         raise NotImplementedError
 
@@ -1090,7 +1090,7 @@ class DbReadBase:
         Return True if the Gramps ID exists in the Person table.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`has_person_from_gramps_id` instead.
+        Use :py:meth:`has_person_from_gramps_id` instead.
         """
         raise NotImplementedError
 
@@ -1099,7 +1099,7 @@ class DbReadBase:
         Return True if the Gramps ID exists in the Place table.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`has_place_from_gramps_id` instead.
+        Use :py:meth:`has_place_from_gramps_id` instead.
         """
         raise NotImplementedError
 
@@ -1108,7 +1108,7 @@ class DbReadBase:
         Return True if the Gramps ID exists in the Repository table.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`has_repository_from_gramps_id` instead.
+        Use :py:meth:`has_repository_from_gramps_id` instead.
         """
         raise NotImplementedError
 
@@ -1117,7 +1117,7 @@ class DbReadBase:
         Return True if the Gramps ID exists in the Source table.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`has_source_from_gramps_id` instead.
+        Use :py:meth:`has_source_from_gramps_id` instead.
         """
         raise NotImplementedError
 
@@ -1126,7 +1126,7 @@ class DbReadBase:
         Return True if the handle exists in the current Event database.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`has_event_from_handle` instead.
+        Use :py:meth:`has_event_from_handle` instead.
         """
         raise NotImplementedError
 
@@ -1135,7 +1135,7 @@ class DbReadBase:
         Return True if the handle exists in the current Family database.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`has_family_from_handle` instead.
+        Use :py:meth:`has_family_from_handle` instead.
         """
         raise NotImplementedError
 
@@ -1144,7 +1144,7 @@ class DbReadBase:
         Return True if the handle exists in the current Mediadatabase.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`has_media_from_handle` instead.
+        Use :py:meth:`has_media_from_handle` instead.
         """
         raise NotImplementedError
 
@@ -1153,7 +1153,7 @@ class DbReadBase:
         Return True if the handle exists in the current Note database.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`has_note_from_handle` instead.
+        Use :py:meth:`has_note_from_handle` instead.
         """
         raise NotImplementedError
 
@@ -1162,7 +1162,7 @@ class DbReadBase:
         Return True if the handle exists in the current Person database.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`has_person_from_handle` instead.
+        Use :py:meth:`has_person_from_handle` instead.
         """
         raise NotImplementedError
 
@@ -1171,7 +1171,7 @@ class DbReadBase:
         Return True if the handle exists in the current Place database.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`has_place_from_handle` instead.
+        Use :py:meth:`has_place_from_handle` instead.
         """
         raise NotImplementedError
 
@@ -1180,7 +1180,7 @@ class DbReadBase:
         Return True if the handle exists in the current Repository database.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`has_repository_from_handle` instead.
+        Use :py:meth:`has_repository_from_handle` instead.
         """
         raise NotImplementedError
 
@@ -1189,7 +1189,7 @@ class DbReadBase:
         Return True if the handle exists in the current Source database.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`has_source_from_handle` instead.
+        Use :py:meth:`has_source_from_handle` instead.
         """
         raise NotImplementedError
 
@@ -1198,7 +1198,7 @@ class DbReadBase:
         Return True if the handle exists in the current Citation database.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`has_citation_from_handle` instead.
+        Use :py:meth:`has_citation_from_handle` instead.
         """
         raise NotImplementedError
 
@@ -1207,7 +1207,7 @@ class DbReadBase:
         Return True if the handle exists in the current Tag database.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`has_tag_from_handle` instead.
+        Use :py:meth:`has_tag_from_handle` instead.
         """
         raise NotImplementedError
 
@@ -1228,7 +1228,7 @@ class DbReadBase:
         Return an iterator over objects for Citations in the database
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`iter_citation` instead.
+        Use :py:meth:`iter_citation` instead.
         """
         raise NotImplementedError
 
@@ -1237,7 +1237,7 @@ class DbReadBase:
         Return an iterator over objects for Events in the database
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`iter_event` instead.
+        Use :py:meth:`iter_event` instead.
         """
         raise NotImplementedError
 
@@ -1246,7 +1246,7 @@ class DbReadBase:
         Return an iterator over objects for Families in the database
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`iter_family` instead.
+        Use :py:meth:`iter_family` instead.
         """
         raise NotImplementedError
 
@@ -1261,7 +1261,7 @@ class DbReadBase:
         Return an iterator over objects for Notes in the database
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`iter_note` instead.
+        Use :py:meth:`iter_note` instead.
         """
         raise NotImplementedError
 
@@ -1270,7 +1270,7 @@ class DbReadBase:
         Return an iterator over objects for Persons in the database
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`iter_person` instead.
+        Use :py:meth:`iter_person` instead.
         """
         raise NotImplementedError
 
@@ -1279,7 +1279,7 @@ class DbReadBase:
         Return an iterator over objects for Places in the database
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`iter_place` instead.
+        Use :py:meth:`iter_place` instead.
         """
         raise NotImplementedError
 
@@ -1288,7 +1288,7 @@ class DbReadBase:
         Return an iterator over objects for Repositories in the database
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`iter_repository` instead.
+        Use :py:meth:`iter_repository` instead.
         """
         raise NotImplementedError
 
@@ -1297,7 +1297,7 @@ class DbReadBase:
         Return an iterator over objects for Sources in the database
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`iter_source` instead.
+        Use :py:meth:`iter_source` instead.
         """
         raise NotImplementedError
 
@@ -1306,7 +1306,7 @@ class DbReadBase:
         Return an iterator over objects for Tags in the database
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`iter_tag` instead.
+        Use :py:meth:`iter_tag` instead.
         """
         raise NotImplementedError
 
@@ -1978,70 +1978,70 @@ class DbReadBase:
     def get_raw_person_data(self, handle):
         """
         .. version-deprecated:: 6.2
-            Use :py:meth:`get_person_data_from_handle` instead.
+        Use :py:meth:`get_person_data_from_handle` instead.
         """
         raise NotImplementedError
 
     def get_raw_family_data(self, handle):
         """
         .. version-deprecated:: 6.2
-            Use :py:meth:`get_family_data_from_handle` instead.
+        Use :py:meth:`get_family_data_from_handle` instead.
         """
         raise NotImplementedError
 
     def get_raw_source_data(self, handle):
         """
         .. version-deprecated:: 6.2
-            Use :py:meth:`get_source_data_from_handle` instead.
+        Use :py:meth:`get_source_data_from_handle` instead.
         """
         raise NotImplementedError
 
     def get_raw_citation_data(self, handle):
         """
         .. version-deprecated:: 6.2
-            Use :py:meth:`get_citation_data_from_handle` instead.
+        Use :py:meth:`get_citation_data_from_handle` instead.
         """
         raise NotImplementedError
 
     def get_raw_event_data(self, handle):
         """
         .. version-deprecated:: 6.2
-            Use :py:meth:`get_event_data_from_handle` instead.
+        Use :py:meth:`get_event_data_from_handle` instead.
         """
         raise NotImplementedError
 
     def get_raw_media_data(self, handle):
         """
         .. version-deprecated:: 6.2
-            Use :py:meth:`get_media_data_from_handle` instead.
+        Use :py:meth:`get_media_data_from_handle` instead.
         """
         raise NotImplementedError
 
     def get_raw_place_data(self, handle):
         """
         .. version-deprecated:: 6.2
-            Use :py:meth:`get_place_data_from_handle` instead.
+        Use :py:meth:`get_place_data_from_handle` instead.
         """
         raise NotImplementedError
 
     def get_raw_repository_data(self, handle):
         """
         .. version-deprecated:: 6.2
-            Use :py:meth:`get_repository_data_from_handle` instead.
+        Use :py:meth:`get_repository_data_from_handle` instead.
         """
         raise NotImplementedError
 
     def get_raw_note_data(self, handle):
         """
         .. version-deprecated:: 6.2
-            Use :py:meth:`get_note_data_from_handle` instead.
+        Use :py:meth:`get_note_data_from_handle` instead.
         """
         raise NotImplementedError
 
     def get_raw_tag_data(self, handle):
         """
         .. version-deprecated:: 6.2
-            Use :py:meth:`get_tag_data_from_handle` instead.
+        Use :py:meth:`get_tag_data_from_handle` instead.
         """
         raise NotImplementedError
 
@@ -2056,7 +2056,7 @@ class DbReadBase:
         Return an iterator over raw Person data.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`iter_person_data` instead.
+        Use :py:meth:`iter_person_data` instead.
         """
         raise NotImplementedError
 
@@ -2065,7 +2065,7 @@ class DbReadBase:
         Return an iterator over raw Family data.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`iter_family_data` instead.
+        Use :py:meth:`iter_family_data` instead.
         """
         raise NotImplementedError
 
@@ -2074,7 +2074,7 @@ class DbReadBase:
         Return an iterator over raw Event data.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`iter_event_data` instead.
+        Use :py:meth:`iter_event_data` instead.
         """
         raise NotImplementedError
 
@@ -2083,7 +2083,7 @@ class DbReadBase:
         Return an iterator over raw Place data.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`iter_place_data` instead.
+        Use :py:meth:`iter_place_data` instead.
         """
         raise NotImplementedError
 
@@ -2092,7 +2092,7 @@ class DbReadBase:
         Return an iterator over raw Repository data.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`iter_repository_data` instead.
+        Use :py:meth:`iter_repository_data` instead.
         """
         raise NotImplementedError
 
@@ -2101,7 +2101,7 @@ class DbReadBase:
         Return an iterator over raw Source data.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`iter_source_data` instead.
+        Use :py:meth:`iter_source_data` instead.
         """
         raise NotImplementedError
 
@@ -2110,7 +2110,7 @@ class DbReadBase:
         Return an iterator over raw Citation data.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`iter_citation_data` instead.
+        Use :py:meth:`iter_citation_data` instead.
         """
         raise NotImplementedError
 
@@ -2119,7 +2119,7 @@ class DbReadBase:
         Return an iterator over raw Media data.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`iter_media_data` instead.
+        Use :py:meth:`iter_media_data` instead.
         """
         raise NotImplementedError
 
@@ -2128,7 +2128,7 @@ class DbReadBase:
         Return an iterator over raw Note data.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`iter_note_data` instead.
+        Use :py:meth:`iter_note_data` instead.
         """
         raise NotImplementedError
 
@@ -2137,7 +2137,7 @@ class DbReadBase:
         Return an iterator over raw Tag data.
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`iter_tag_data` instead.
+        Use :py:meth:`iter_tag_data` instead.
         """
         raise NotImplementedError
 
@@ -2150,63 +2150,63 @@ class DbReadBase:
     def _get_raw_person_from_id_data(self, gramps_id: PersonGrampsID):
         """
         .. version-deprecated:: 6.2
-             Use :py:meth:`get_person_data_from_gramps_id` instead.
+        Use :py:meth:`get_person_data_from_gramps_id` instead.
         """
         raise NotImplementedError
 
     def _get_raw_family_from_id_data(self, gramps_id: FamilyGrampsID):
         """
         .. version-deprecated:: 6.2
-             Use :py:meth:`get_family_data_from_gramps_id` instead.
+        Use :py:meth:`get_family_data_from_gramps_id` instead.
         """
         raise NotImplementedError
 
     def _get_raw_source_from_id_data(self, gramps_id: SourceGrampsID):
         """
         .. version-deprecated:: 6.2
-             Use :py:meth:`get_source_data_from_gramps_id` instead.
+        Use :py:meth:`get_source_data_from_gramps_id` instead.
         """
         raise NotImplementedError
 
     def _get_raw_citation_from_id_data(self, gramps_id: CitationGrampsID):
         """
         .. version-deprecated:: 6.2
-             Use :py:meth:`get_citation_data_from_gramps_id` instead.
+        Use :py:meth:`get_citation_data_from_gramps_id` instead.
         """
         raise NotImplementedError
 
     def _get_raw_event_from_id_data(self, gramps_id: EventGrampsID):
         """
         .. version-deprecated:: 6.2
-             Use :py:meth:`get_event_data_from_gramps_id` instead.
+        Use :py:meth:`get_event_data_from_gramps_id` instead.
         """
         raise NotImplementedError
 
     def _get_raw_media_from_id_data(self, gramps_id: MediaGrampsID):
         """
         .. version-deprecated:: 6.2
-             Use :py:meth:`get_media_data_from_gramps_id` instead.
+        Use :py:meth:`get_media_data_from_gramps_id` instead.
         """
         raise NotImplementedError
 
     def _get_raw_place_from_id_data(self, gramps_id: PlaceGrampsID):
         """
         .. version-deprecated:: 6.2
-             Use :py:meth:`get_place_data_from_gramps_id` instead.
+        Use :py:meth:`get_place_data_from_gramps_id` instead.
         """
         raise NotImplementedError
 
     def _get_raw_repository_from_id_data(self, gramps_id: RepositoryGrampsID):
         """
         .. version-deprecated:: 6.2
-             Use :py:meth:`get_repository_data_from_gramps_id` instead.
+        Use :py:meth:`get_repository_data_from_gramps_id` instead.
         """
         raise NotImplementedError
 
     def _get_raw_note_from_id_data(self, gramps_id: NoteGrampsID):
         """
         .. version-deprecated:: 6.2
-             Use :py:meth:`get_note_data_from_gramps_id` instead.
+        Use :py:meth:`get_note_data_from_gramps_id` instead.
         """
         raise NotImplementedError
 

--- a/gramps/gen/db/dummydb.py
+++ b/gramps/gen/db/dummydb.py
@@ -956,7 +956,7 @@ class DummyDb(DbReadBase, Callback, object, metaclass=M_A_M_B):
         Deprecated alias for get_repository_bookmarks().
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`get_repository_bookmarks` instead.
+        Use :py:meth:`get_repository_bookmarks` instead.
         """
         return self.get_repository_bookmarks()
 

--- a/gramps/gen/db/dummydb.py
+++ b/gramps/gen/db/dummydb.py
@@ -174,7 +174,7 @@ class DummyDb(DbReadBase, Callback, object, metaclass=M_A_M_B):
         self.place_bookmarks = DbBookmarks()
         self.citation_bookmarks = DbBookmarks()
         self.source_bookmarks = DbBookmarks()
-        self.repo_bookmarks = DbBookmarks()
+        self.repository_bookmarks = DbBookmarks()
         self.media_bookmarks = DbBookmarks()
         self.note_bookmarks = DbBookmarks()
         self.owner = Researcher()
@@ -943,13 +943,22 @@ class DummyDb(DbReadBase, Callback, object, metaclass=M_A_M_B):
         LOG.warning("handle %s does not exist in the dummy database", handle)
         raise HandleError(f"Handle {handle} not found")
 
-    def get_repo_bookmarks(self):
+    def get_repository_bookmarks(self):
         """
         Return the list of Repository handles in the bookmarks.
         """
         if not self.db_is_open:
             LOG.debug("database is closed")
-        return self.repo_bookmarks
+        return self.repository_bookmarks
+
+    def get_repo_bookmarks(self):
+        """
+        Deprecated alias for get_repository_bookmarks().
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`get_repository_bookmarks` instead.
+        """
+        return self.get_repository_bookmarks()
 
     def get_repository_cursor(self):
         """

--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -608,7 +608,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         self.place_bookmarks = DbBookmarks()
         self.citation_bookmarks = DbBookmarks()
         self.source_bookmarks = DbBookmarks()
-        self.repo_bookmarks = DbBookmarks()
+        self.repository_bookmarks = DbBookmarks()
         self.media_bookmarks = DbBookmarks()
         self.note_bookmarks = DbBookmarks()
         self.set_person_id_prefix("I%05d")
@@ -753,7 +753,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         self.event_bookmarks.load(self._get_metadata("event_bookmarks"))
         self.source_bookmarks.load(self._get_metadata("source_bookmarks"))
         self.citation_bookmarks.load(self._get_metadata("citation_bookmarks"))
-        self.repo_bookmarks.load(self._get_metadata("repo_bookmarks"))
+        self.repository_bookmarks.load(self._get_metadata("repo_bookmarks"))
         self.media_bookmarks.load(self._get_metadata("media_bookmarks"))
         self.place_bookmarks.load(self._get_metadata("place_bookmarks"))
         self.note_bookmarks.load(self._get_metadata("note_bookmarks"))
@@ -886,7 +886,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         self._set_metadata("family_bookmarks", self.family_bookmarks.get())
         self._set_metadata("event_bookmarks", self.event_bookmarks.get())
         self._set_metadata("place_bookmarks", self.place_bookmarks.get())
-        self._set_metadata("repo_bookmarks", self.repo_bookmarks.get())
+        self._set_metadata("repo_bookmarks", self.repository_bookmarks.get())
         self._set_metadata("source_bookmarks", self.source_bookmarks.get())
         self._set_metadata("citation_bookmarks", self.citation_bookmarks.get())
         self._set_metadata("media_bookmarks", self.media_bookmarks.get())
@@ -2549,8 +2549,14 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
     def get_place_bookmarks(self):
         return self.place_bookmarks
 
-    def get_repo_bookmarks(self):
-        return self.repo_bookmarks
+    def get_repository_bookmarks(self):
+        """
+        Return the Repository bookmarks.
+
+        :returns: The Repository bookmarks object.
+        :rtype: :py:class:`DbBookmarks`
+        """
+        return self.repository_bookmarks
 
     def get_source_bookmarks(self):
         return self.source_bookmarks

--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -26,7 +26,7 @@ Gramps generic database handler
 
 # ------------------------------------------------------------------------
 #
-# Python modules
+# Standard Python modules
 #
 # ------------------------------------------------------------------------
 from __future__ import annotations

--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -4,7 +4,7 @@
 # Copyright (C) 2015-2016 Gramps Development Team
 # Copyright (C) 2016      Nick Hall
 # Copyright (C) 2024      Doug Blank
-# Copyright (C) 2024,2025 Steve Youngs <steve@youngs.cc>
+# Copyright (C) 2024-2026 Steve Youngs
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -30,6 +30,7 @@ Gramps generic database handler
 #
 # ------------------------------------------------------------------------
 from __future__ import annotations
+from abc import ABCMeta, abstractmethod
 import bisect
 import logging
 import os
@@ -37,6 +38,7 @@ import pickle
 import random
 import re
 import time
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, Generator, Type
 
@@ -142,7 +144,7 @@ SIGBASE = (
 # DbGenericUndo class
 #
 # ------------------------------------------------------------------------
-class DbGenericUndo(DbUndo):
+class DbGenericUndo(DbUndo, metaclass=ABCMeta):
     """
     Generic undo/redo handler
     """
@@ -341,8 +343,8 @@ class Cursor:
         return self
 
     def __iter__(self):
-        for handle, data in self.iterator():
-            yield (handle, data)
+        for data in self.iterator():
+            yield (data.handle, data)
 
     def __next__(self):
         try:
@@ -354,8 +356,8 @@ class Cursor:
         pass
 
     def iter(self):
-        for handle, data in self.iterator():
-            yield (handle, data)
+        for data in self.iterator():
+            yield (data.handle, data)
 
     def first(self):
         self._iter = self.__iter__()
@@ -1779,6 +1781,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
     #
     ################################################################
 
+    @abstractmethod
     def _iter_raw_data(self, obj_key):
         raise NotImplementedError
 
@@ -1854,6 +1857,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
     #
     ################################################################
 
+    @abstractmethod
     def _get_raw_data(self, obj_key, handle):
         """
         Return raw (serialized) object from handle.
@@ -1896,6 +1900,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
     #
     ################################################################
 
+    @abstractmethod
     def _get_raw_from_id_data(self, obj_key, gramps_id):
         raise NotImplementedError
 

--- a/gramps/gen/proxy/proxybase.py
+++ b/gramps/gen/proxy/proxybase.py
@@ -118,7 +118,7 @@ class ProxyDbBase(DbReadBase):
         self.place_bookmarks = db.place_bookmarks
         self.source_bookmarks = db.source_bookmarks
         self.citation_bookmarks = db.citation_bookmarks
-        self.repo_bookmarks = db.repo_bookmarks
+        self.repository_bookmarks = db.repository_bookmarks
         self.media_bookmarks = db.media_bookmarks
         self.note_bookmarks = db.note_bookmarks
 
@@ -958,9 +958,18 @@ class ProxyDbBase(DbReadBase):
         """returns the list of Media handles in the bookmarks"""
         return self.media_bookmarks
 
-    def get_repo_bookmarks(self):
+    def get_repository_bookmarks(self):
         """returns the list of Repository handles in the bookmarks"""
-        return self.repo_bookmarks
+        return self.repository_bookmarks
+
+    def get_repo_bookmarks(self):
+        """
+        returns the list of Repository handles in the bookmarks
+
+        .. version-deprecated:: 6.2
+            Use :py:meth:`get_repository_bookmarks` instead.
+        """
+        return self.get_repository_bookmarks()
 
     def get_note_bookmarks(self):
         """returns the list of Note handles in the bookmarks"""

--- a/gramps/gen/proxy/proxybase.py
+++ b/gramps/gen/proxy/proxybase.py
@@ -967,7 +967,7 @@ class ProxyDbBase(DbReadBase):
         returns the list of Repository handles in the bookmarks
 
         .. version-deprecated:: 6.2
-            Use :py:meth:`get_repository_bookmarks` instead.
+        Use :py:meth:`get_repository_bookmarks` instead.
         """
         return self.get_repository_bookmarks()
 

--- a/gramps/gen/types.py
+++ b/gramps/gen/types.py
@@ -2,7 +2,7 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
 # Copyright (C) 2025       David Straub
-# Copyright (C) 2025       Steve Youngs
+# Copyright (C) 2025-2026  Steve Youngs
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -37,6 +37,7 @@ from .lib import (
     Tag,
 )
 from .lib.tableobj import TableObject
+from .lib.json_utils import DataDict
 
 PersonHandle = NewType("PersonHandle", str)
 FamilyHandle = NewType("FamilyHandle", str)
@@ -84,3 +85,26 @@ PrimaryObjectGrampsID = Union[
     NoteGrampsID,
 ]
 AnyGrampsID = PrimaryObjectGrampsID  # No Tag IDs
+
+PersonDataDict = NewType("PersonDataDict", DataDict)
+FamilyDataDict = NewType("FamilyDataDict", DataDict)
+EventDataDict = NewType("EventDataDict", DataDict)
+PlaceDataDict = NewType("PlaceDataDict", DataDict)
+SourceDataDict = NewType("SourceDataDict", DataDict)
+RepositoryDataDict = NewType("RepositoryDataDict", DataDict)
+CitationDataDict = NewType("CitationDataDict", DataDict)
+MediaDataDict = NewType("MediaDataDict", DataDict)
+NoteDataDict = NewType("NoteDataDict", DataDict)
+TagDataDict = NewType("TagDataDict", DataDict)
+PrimaryObjectDataDict = (
+    PersonDataDict
+    | FamilyDataDict
+    | EventDataDict
+    | PlaceDataDict
+    | SourceDataDict
+    | RepositoryDataDict
+    | CitationDataDict
+    | MediaDataDict
+    | NoteDataDict
+)
+AnyDataDict = PrimaryObjectDataDict | TagDataDict

--- a/gramps/gui/views/bookmarks.py
+++ b/gramps/gui/views/bookmarks.py
@@ -561,7 +561,7 @@ class RepoBookmarks(ListBookmarks):
         self.dbstate.db.connect("repository-delete", self.remove_handles)
 
     def get_bookmarks(self):
-        return self.dbstate.db.get_repo_bookmarks()
+        return self.dbstate.db.get_repository_bookmarks()
 
     def get_config_name(self):
         return __name__

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -935,7 +935,7 @@ class DBAPI(DbGeneric):
             rows = cursor.fetchmany()
             while rows:
                 for row in rows:
-                    yield (row[0], self.serializer.string_to_data(row[1]))
+                    yield self.serializer.string_to_data(row[1])
                 rows = cursor.fetchmany()
 
     def _iter_raw_place_tree_data(self):
@@ -952,7 +952,7 @@ class DBAPI(DbGeneric):
             rows = self.dbapi.fetchall()
             for row in rows:
                 to_do.append(row[0])
-                yield (row[0], self.serializer.string_to_data(row[1]))
+                yield self.serializer.string_to_data(row[1])
 
     def reindex_reference_map(self, callback):
         """

--- a/gramps/plugins/db/dbapi/test/db_test.py
+++ b/gramps/plugins/db/dbapi/test/db_test.py
@@ -2,6 +2,7 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
 # Copyright (C) 2016      Nick Hall
+# Copyright (C) 2026      Steve Youngs
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -45,6 +46,7 @@ from gramps.gen.lib import (
     Researcher,
     Surname,
 )
+from gramps.gen.lib.json_utils import DataDict, data_to_object
 
 
 # -------------------------------------------------------------------------
@@ -137,39 +139,75 @@ class DbRandomTest(unittest.TestCase):
     #
     ################################################################
 
-    def test_number_of_people(self):
+    def test_get_number_of_people(self):
         self.assertEqual(self.db.get_number_of_people(), len(self.handles["Person"]))
 
-    def test_number_of_families(self):
+    def test_get_number_of_families(self):
         self.assertEqual(self.db.get_number_of_families(), len(self.handles["Family"]))
 
-    def test_number_of_events(self):
+    def test_get_number_of_events(self):
         self.assertEqual(self.db.get_number_of_events(), len(self.handles["Event"]))
 
-    def test_number_of_places(self):
+    def test_get_number_of_places(self):
         self.assertEqual(self.db.get_number_of_places(), len(self.handles["Place"]))
 
-    def test_number_of_repositories(self):
+    def test_get_number_of_repositories(self):
         self.assertEqual(
             self.db.get_number_of_repositories(), len(self.handles["Repository"])
         )
 
-    def test_number_of_sources(self):
+    def test_get_number_of_sources(self):
         self.assertEqual(self.db.get_number_of_sources(), len(self.handles["Source"]))
 
-    def test_number_of_citations(self):
+    def test_get_number_of_citations(self):
         self.assertEqual(
             self.db.get_number_of_citations(), len(self.handles["Citation"])
         )
 
-    def test_number_of_media(self):
+    def test_get_number_of_media(self):
         self.assertEqual(self.db.get_number_of_media(), len(self.handles["Media"]))
 
-    def test_number_of_notes(self):
+    def test_get_number_of_notes(self):
         self.assertEqual(self.db.get_number_of_notes(), len(self.handles["Note"]))
 
-    def test_number_of_tags(self):
+    def test_get_number_of_tags(self):
         self.assertEqual(self.db.get_number_of_tags(), len(self.handles["Tag"]))
+
+    ################################################################
+    #
+    # Test count_* methods
+    #
+    ################################################################
+
+    def test_count_person(self):
+        self.assertEqual(self.db.count_person(), len(self.handles["Person"]))
+
+    def test_count_family(self):
+        self.assertEqual(self.db.count_family(), len(self.handles["Family"]))
+
+    def test_count_event(self):
+        self.assertEqual(self.db.count_event(), len(self.handles["Event"]))
+
+    def test_count_place(self):
+        self.assertEqual(self.db.count_place(), len(self.handles["Place"]))
+
+    def test_count_repository(self):
+        self.assertEqual(self.db.count_repository(), len(self.handles["Repository"]))
+
+    def test_count_source(self):
+        self.assertEqual(self.db.count_source(), len(self.handles["Source"]))
+
+    def test_count_citation(self):
+        self.assertEqual(self.db.count_citation(), len(self.handles["Citation"]))
+
+    def test_count_media(self):
+        self.assertEqual(self.db.count_media(), len(self.handles["Media"]))
+
+    def test_count_note(self):
+        self.assertEqual(self.db.count_note(), len(self.handles["Note"]))
+
+    def test_count_tag(self):
+        self.assertEqual(self.db.count_tag(), len(self.handles["Tag"]))
 
     ################################################################
     #
@@ -419,6 +457,74 @@ class DbRandomTest(unittest.TestCase):
 
     ################################################################
     #
+    # Test get_*_data_from_handle methods
+    #
+    ################################################################
+
+    def __get_data_from_handle_test(self, obj_class, handles_func, get_func):
+        for handle in handles_func():
+            data = get_func(handle)
+            self.assertIsInstance(data, DataDict)
+            obj = data_to_object(data)
+            self.assertIsInstance(obj, obj_class)
+            self.assertEqual(obj.handle, handle)
+
+    def test_get_person_data_from_handle(self):
+        self.__get_data_from_handle_test(
+            Person, self.db.get_person_handles, self.db.get_person_data_from_handle
+        )
+
+    def test_get_family_data_from_handle(self):
+        self.__get_data_from_handle_test(
+            Family, self.db.get_family_handles, self.db.get_family_data_from_handle
+        )
+
+    def test_get_event_data_from_handle(self):
+        self.__get_data_from_handle_test(
+            Event, self.db.get_event_handles, self.db.get_event_data_from_handle
+        )
+
+    def test_get_place_data_from_handle(self):
+        self.__get_data_from_handle_test(
+            Place, self.db.get_place_handles, self.db.get_place_data_from_handle
+        )
+
+    def test_get_repository_data_from_handle(self):
+        self.__get_data_from_handle_test(
+            Repository,
+            self.db.get_repository_handles,
+            self.db.get_repository_data_from_handle,
+        )
+
+    def test_get_source_data_from_handle(self):
+        self.__get_data_from_handle_test(
+            Source, self.db.get_source_handles, self.db.get_source_data_from_handle
+        )
+
+    def test_get_citation_data_from_handle(self):
+        self.__get_data_from_handle_test(
+            Citation,
+            self.db.get_citation_handles,
+            self.db.get_citation_data_from_handle,
+        )
+
+    def test_get_media_data_from_handle(self):
+        self.__get_data_from_handle_test(
+            Media, self.db.get_media_handles, self.db.get_media_data_from_handle
+        )
+
+    def test_get_note_data_from_handle(self):
+        self.__get_data_from_handle_test(
+            Note, self.db.get_note_handles, self.db.get_note_data_from_handle
+        )
+
+    def test_get_tag_data_from_handle(self):
+        self.__get_data_from_handle_test(
+            Tag, self.db.get_tag_handles, self.db.get_tag_data_from_handle
+        )
+
+    ################################################################
+    #
     # Test get_*_from_gramps_id methods
     #
     ################################################################
@@ -484,6 +590,75 @@ class DbRandomTest(unittest.TestCase):
 
     ################################################################
     #
+    # Test get_*_data_from_gramps_id methods
+    #
+    ################################################################
+
+    def __get_data_from_gid_test(self, obj_class, gids_func, get_func):
+        for gid in gids_func():
+            data = get_func(gid)
+            self.assertIsInstance(data, DataDict)
+            obj = data_to_object(data)
+            self.assertIsInstance(obj, obj_class)
+            self.assertEqual(obj.gramps_id, gid)
+
+    def test_get_person_data_from_gid(self):
+        self.__get_data_from_gid_test(
+            Person,
+            self.db.get_person_gramps_ids,
+            self.db.get_person_data_from_gramps_id,
+        )
+
+    def test_get_family_data_from_gid(self):
+        self.__get_data_from_gid_test(
+            Family,
+            self.db.get_family_gramps_ids,
+            self.db.get_family_data_from_gramps_id,
+        )
+
+    def test_get_event_data_from_gid(self):
+        self.__get_data_from_gid_test(
+            Event, self.db.get_event_gramps_ids, self.db.get_event_data_from_gramps_id
+        )
+
+    def test_get_place_data_from_gid(self):
+        self.__get_data_from_gid_test(
+            Place, self.db.get_place_gramps_ids, self.db.get_place_data_from_gramps_id
+        )
+
+    def test_get_repository_data_from_gid(self):
+        self.__get_data_from_gid_test(
+            Repository,
+            self.db.get_repository_gramps_ids,
+            self.db.get_repository_data_from_gramps_id,
+        )
+
+    def test_get_source_data_from_gid(self):
+        self.__get_data_from_gid_test(
+            Source,
+            self.db.get_source_gramps_ids,
+            self.db.get_source_data_from_gramps_id,
+        )
+
+    def test_get_citation_data_from_gid(self):
+        self.__get_data_from_gid_test(
+            Citation,
+            self.db.get_citation_gramps_ids,
+            self.db.get_citation_data_from_gramps_id,
+        )
+
+    def test_get_media_data_from_gid(self):
+        self.__get_data_from_gid_test(
+            Media, self.db.get_media_gramps_ids, self.db.get_media_data_from_gramps_id
+        )
+
+    def test_get_note_data_from_gid(self):
+        self.__get_data_from_gid_test(
+            Note, self.db.get_note_gramps_ids, self.db.get_note_data_from_gramps_id
+        )
+
+    ################################################################
+    #
     # Test has_*_handle methods
     #
     ################################################################
@@ -529,6 +704,51 @@ class DbRandomTest(unittest.TestCase):
 
     ################################################################
     #
+    # Test has_*_from_handle methods
+    #
+    ################################################################
+    def test_has_person_from_handle(self):
+        for handle in self.handles["Person"]:
+            self.assertTrue(self.db.has_person_from_handle(handle))
+
+    def test_has_family_from_handle(self):
+        for handle in self.handles["Family"]:
+            self.assertTrue(self.db.has_family_from_handle(handle))
+
+    def test_has_event_from_handle(self):
+        for handle in self.handles["Event"]:
+            self.assertTrue(self.db.has_event_from_handle(handle))
+
+    def test_has_place_from_handle(self):
+        for handle in self.handles["Place"]:
+            self.assertTrue(self.db.has_place_from_handle(handle))
+
+    def test_has_repository_from_handle(self):
+        for handle in self.handles["Repository"]:
+            self.assertTrue(self.db.has_repository_from_handle(handle))
+
+    def test_has_source_from_handle(self):
+        for handle in self.handles["Source"]:
+            self.assertTrue(self.db.has_source_from_handle(handle))
+
+    def test_has_citation_from_handle(self):
+        for handle in self.handles["Citation"]:
+            self.assertTrue(self.db.has_citation_from_handle(handle))
+
+    def test_has_media_from_handle(self):
+        for handle in self.handles["Media"]:
+            self.assertTrue(self.db.has_media_from_handle(handle))
+
+    def test_has_note_from_handle(self):
+        for handle in self.handles["Note"]:
+            self.assertTrue(self.db.has_note_from_handle(handle))
+
+    def test_has_tag_from_handle(self):
+        for handle in self.handles["Tag"]:
+            self.assertTrue(self.db.has_tag_from_handle(handle))
+
+    ################################################################
+    #
     # Test has_*_gramps_id methods
     #
     ################################################################
@@ -567,6 +787,47 @@ class DbRandomTest(unittest.TestCase):
     def test_has_note_gramps_id(self):
         for gramps_id in self.gids["Note"]:
             self.assertTrue(self.db.has_note_gramps_id(gramps_id))
+
+    ################################################################
+    #
+    # Test has_*_from_gramps_id methods
+    #
+    ################################################################
+    def test_has_person_from_gramps_id(self):
+        for gramps_id in self.gids["Person"]:
+            self.assertTrue(self.db.has_person_from_gramps_id(gramps_id))
+
+    def test_has_family_from_gramps_id(self):
+        for gramps_id in self.gids["Family"]:
+            self.assertTrue(self.db.has_family_from_gramps_id(gramps_id))
+
+    def test_has_event_from_gramps_id(self):
+        for gramps_id in self.gids["Event"]:
+            self.assertTrue(self.db.has_event_from_gramps_id(gramps_id))
+
+    def test_has_place_from_gramps_id(self):
+        for gramps_id in self.gids["Place"]:
+            self.assertTrue(self.db.has_place_from_gramps_id(gramps_id))
+
+    def test_has_repository_from_gramps_id(self):
+        for gramps_id in self.gids["Repository"]:
+            self.assertTrue(self.db.has_repository_from_gramps_id(gramps_id))
+
+    def test_has_source_from_gramps_id(self):
+        for gramps_id in self.gids["Source"]:
+            self.assertTrue(self.db.has_source_from_gramps_id(gramps_id))
+
+    def test_has_citation_from_gramps_id(self):
+        for gramps_id in self.gids["Citation"]:
+            self.assertTrue(self.db.has_citation_from_gramps_id(gramps_id))
+
+    def test_has_media_from_gramps_id(self):
+        for gramps_id in self.gids["Media"]:
+            self.assertTrue(self.db.has_media_from_gramps_id(gramps_id))
+
+    def test_has_note_from_gramps_id(self):
+        for gramps_id in self.gids["Note"]:
+            self.assertTrue(self.db.has_note_from_gramps_id(gramps_id))
 
     ################################################################
     #
@@ -695,6 +956,84 @@ class DbRandomTest(unittest.TestCase):
 
     def test_iter_tags(self):
         self.__iter_objects_test(Tag, self.db.iter_tags)
+
+    ################################################################
+    #
+    # Test iter_*_data methods
+    #
+    ################################################################
+
+    def __iter_data_test(self, obj_class, iter_func):
+        for data in iter_func():
+            self.assertIsInstance(data, DataDict)
+            obj = data_to_object(data)
+            self.assertIsInstance(obj, obj_class)
+            self.assertEqual(obj.handle, data.handle)
+
+    def test_iter_person_data(self):
+        self.__iter_data_test(Person, self.db.iter_person_data)
+
+    def test_iter_family_data(self):
+        self.__iter_data_test(Family, self.db.iter_family_data)
+
+    def test_iter_event_data(self):
+        self.__iter_data_test(Event, self.db.iter_event_data)
+
+    def test_iter_place_data(self):
+        self.__iter_data_test(Place, self.db.iter_place_data)
+
+    def test_iter_repository_data(self):
+        self.__iter_data_test(Repository, self.db.iter_repository_data)
+
+    def test_iter_source_data(self):
+        self.__iter_data_test(Source, self.db.iter_source_data)
+
+    def test_iter_citation_data(self):
+        self.__iter_data_test(Citation, self.db.iter_citation_data)
+
+    def test_iter_media_data(self):
+        self.__iter_data_test(Media, self.db.iter_media_data)
+
+    def test_iter_note_data(self):
+        self.__iter_data_test(Note, self.db.iter_note_data)
+
+    def test_iter_tag_data(self):
+        self.__iter_data_test(Tag, self.db.iter_tag_data)
+
+    ################################################################
+    #
+    # Test iter_* methods
+    #
+    ################################################################
+
+    def test_iter_person(self):
+        self.__iter_objects_test(Person, self.db.iter_person)
+
+    def test_iter_family(self):
+        self.__iter_objects_test(Family, self.db.iter_family)
+
+    def test_iter_event(self):
+        self.__iter_objects_test(Event, self.db.iter_event)
+
+    def test_iter_place(self):
+        self.__iter_objects_test(Place, self.db.iter_place)
+
+    def test_iter_repository(self):
+        self.__iter_objects_test(Repository, self.db.iter_repository)
+
+    def test_iter_source(self):
+        self.__iter_objects_test(Source, self.db.iter_source)
+
+    def test_iter_citation(self):
+        self.__iter_objects_test(Citation, self.db.iter_citation)
+
+    # test_iter_media already tested
+
+    def test_iter_note(self):
+        self.__iter_objects_test(Note, self.db.iter_note)
+
+    def test_iter_tag(self):
+        self.__iter_objects_test(Tag, self.db.iter_tag)
 
     ################################################################
     #

--- a/gramps/plugins/export/exportxml.py
+++ b/gramps/plugins/export/exportxml.py
@@ -421,7 +421,7 @@ class GrampsXmlWriter(UpdateCallback):
         bm_source_len = len(self.db.source_bookmarks.get())
         bm_citation_len = len(self.db.citation_bookmarks.get())
         bm_place_len = len(self.db.place_bookmarks.get())
-        bm_repo_len = len(self.db.repo_bookmarks.get())
+        bm_repo_len = len(self.db.repository_bookmarks.get())
         bm_obj_len = len(self.db.media_bookmarks.get())
         bm_note_len = len(self.db.note_bookmarks.get())
 
@@ -454,7 +454,7 @@ class GrampsXmlWriter(UpdateCallback):
                 self.g.write('    <bookmark target="place" hlink="_%s"/>\n' % handle)
             for handle in self.db.get_media_bookmarks().get():
                 self.g.write('    <bookmark target="media" hlink="_%s"/>\n' % handle)
-            for handle in self.db.get_repo_bookmarks().get():
+            for handle in self.db.get_repository_bookmarks().get():
                 self.g.write(
                     '    <bookmark target="repository" hlink="_%s"/>\n' % handle
                 )

--- a/gramps/plugins/importer/importxml.py
+++ b/gramps/plugins/importer/importxml.py
@@ -1585,9 +1585,9 @@ class GrampsParser(UpdateCallback):
         elif target == "repository":
             if (
                 self.db.get_repository_from_handle(handle) is not None
-                and handle not in self.db.repo_bookmarks.get()
+                and handle not in self.db.repository_bookmarks.get()
             ):
-                self.db.repo_bookmarks.append(handle)
+                self.db.repository_bookmarks.append(handle)
         elif target == "note":
             if (
                 self.db.get_note_from_handle(handle) is not None


### PR DESCRIPTION
Gramps has a number of methods for getting data from the database. The available methods are a combination of:

Record identifier
- handle
- gramps_id

Result type
- object
- DataDict
- iterator of object, handle or data 

but there is little consistency in the naming of these methods.

This PR seeks to add a consistent set of method names.
Further discussion in the [forum post](https://gramps.discourse.group/t/consistent-database-method-names/9315)

For the Person object, the full set of methods is:

|New method|Old method|
|---|---|
| get_person_from_handle| - |
| get_person_data_from_handle| get_raw_person_data |
| get_person_from_gramps_id| - |
| get_person_data_from_gramps_id| _get_raw_person_from_id_data |
| get_person_handles| - |
| get_person_cursor | - |
| iter_person_handles| - |
| iter_person| - |
| iter_person_data| _iter_raw_person_data |
| has_person_from_handle| has_person_handle |
| has_person_from_gramps_id| has_person_gramps_id |
| get_person_count| get_number_of_people |



with similar methods for other primary object types. Tags follow the same pattern but as tags do not have Gramps IDs, those methods are not provided.
