### PR TITLE
Fail build if no artifact; disable AIO compression; component update

### DIFF
--- a/.github/workflows/windows-aio-pyinstaller.yml
+++ b/.github/workflows/windows-aio-pyinstaller.yml
@@ -54,4 +54,5 @@ jobs:
         name: GrampsAIO-PyInstaller
         path: D:\a\gramps\gramps\aio-pyinstaller\dist\grampsaio\src\GrampsAIO-*.exe
         if-no-files-found: error
+        compression-level: 0 # no compression
         retention-days: 7

--- a/.github/workflows/windows-aio-pyinstaller.yml
+++ b/.github/workflows/windows-aio-pyinstaller.yml
@@ -49,8 +49,9 @@ jobs:
       run: |
         cd aio-pyinstaller
         ./build.sh ${{ inputs.cleanup }} ${{ inputs.build-number }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: GrampsAIO-PyInstaller
         path: D:\a\gramps\gramps\aio-pyinstaller\dist\grampsaio\src\GrampsAIO-*.exe
+        if-no-files-found: error
         retention-days: 7

--- a/.github/workflows/windows-aio.yml
+++ b/.github/workflows/windows-aio.yml
@@ -53,4 +53,5 @@ jobs:
       with:
         name: GrampsAIO
         path: D:\a\gramps\gramps\aio\mingw64\src\GrampsAIO-*.exe
+        if-no-files-found: error
         retention-days: 7

--- a/.github/workflows/windows-aio.yml
+++ b/.github/workflows/windows-aio.yml
@@ -54,4 +54,5 @@ jobs:
         name: GrampsAIO
         path: D:\a\gramps\gramps\aio\mingw64\src\GrampsAIO-*.exe
         if-no-files-found: error
+        compression-level: 0 # no compression
         retention-days: 7


### PR DESCRIPTION
When a build artifact is not generated the upload step defaults to a warning which leaves the build as passed (green). Now it's set to report a failure so the build should go red and catch someone's attention.

Based on @stevenyoungs' suggestion, compression of output artifact has been disabled.

Also updated the upload component in both AIO builds to match at v6.

These were left over tasks from fixing the AIO 6.0.7 build (#2190). BTW, the MSYS2 workflow component v2 was updated to use Node 24, so it no longer reports a build warning. No change required in our workflow file.