### PR TITLE
Reduce number of db queries on open/close

### DIFF
--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -744,6 +744,10 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         if need_to_set_metadata:
             self._set_metadata("version", str(self.VERSION[0]))
 
+        # Load all metadata in one batch query where possible, then
+        # populate individual attributes via the (possibly cached) getter.
+        self._prime_metadata_cache()
+
         # Load metadata
         self.name_formats = self._get_metadata("name_formats")
         self.owner = self._get_metadata("researcher", default=Researcher())
@@ -805,12 +809,16 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         self.rmap_index = self._get_metadata("rmap_index", 0)
         self.nmap_index = self._get_metadata("nmap_index", 0)
 
+        # Discard the batch cache; subsequent _get_metadata() calls
+        # (e.g. for default-person-handle) must always hit the database.
+        self._clear_metadata_cache()
+
         if need_to_set_metadata:
             # for new db we always need blob metadata to allow prior Gramps versions
             # to make it to the downgrade version check
             # Note: downgrade check only works from v5.1.2 and later on sqlite
             self.set_serializer("blob")
-            self.has_changed = 1  # to make sure genderstats gets saved
+            self.save_gender_stats(self.genderStats)
             self._set_all_metadata()
             if self.use_json_data():
                 self.set_serializer("json")
@@ -858,6 +866,8 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
                 # the database for gramps.cli.clidbman:
                 filename = os.path.join(self._directory, "meta_data.db")
                 Path(filename).touch()
+                if self.has_changed:
+                    self.save_gender_stats(self.genderStats)
                 self._set_all_metadata()
 
             self._close()
@@ -873,59 +883,76 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
     def is_open(self):
         return self.db_is_open
 
-    def _set_all_metadata(self):
+    def _set_all_metadata(self, use_txn: bool = True) -> None:
         """
-        sets all the metadata
+        Persist all in-memory metadata to the database.
+
+        :param use_txn: Whether each :meth:`_set_metadata` call should
+            manage its own transaction.  Pass ``False`` when the caller has
+            already opened an enclosing transaction.
+        :type use_txn: bool
+
+        .. note::
+            Gender statistics are *not* saved here; callers are responsible
+            for calling :meth:`save_gender_stats` separately when needed.
         """
         # Save metadata
-        self._set_metadata("version", str(self.VERSION[0]))
-        self._set_metadata("name_formats", self.name_formats)
-        self._set_metadata("researcher", self.owner)
+        self._set_metadata("version", str(self.VERSION[0]), use_txn=use_txn)
+        self._set_metadata("name_formats", self.name_formats, use_txn=use_txn)
+        self._set_metadata("researcher", self.owner, use_txn=use_txn)
 
         # Bookmarks
-        self._set_metadata("bookmarks", self.bookmarks.get())
-        self._set_metadata("family_bookmarks", self.family_bookmarks.get())
-        self._set_metadata("event_bookmarks", self.event_bookmarks.get())
-        self._set_metadata("place_bookmarks", self.place_bookmarks.get())
-        self._set_metadata("repo_bookmarks", self.repo_bookmarks.get())
-        self._set_metadata("source_bookmarks", self.source_bookmarks.get())
-        self._set_metadata("citation_bookmarks", self.citation_bookmarks.get())
-        self._set_metadata("media_bookmarks", self.media_bookmarks.get())
-        self._set_metadata("note_bookmarks", self.note_bookmarks.get())
+        self._set_metadata("bookmarks", self.bookmarks.get(), use_txn=use_txn)
+        self._set_metadata(
+            "family_bookmarks", self.family_bookmarks.get(), use_txn=use_txn
+        )
+        self._set_metadata(
+            "event_bookmarks", self.event_bookmarks.get(), use_txn=use_txn
+        )
+        self._set_metadata(
+            "place_bookmarks", self.place_bookmarks.get(), use_txn=use_txn
+        )
+        self._set_metadata("repo_bookmarks", self.repo_bookmarks.get(), use_txn=use_txn)
+        self._set_metadata(
+            "source_bookmarks", self.source_bookmarks.get(), use_txn=use_txn
+        )
+        self._set_metadata(
+            "citation_bookmarks", self.citation_bookmarks.get(), use_txn=use_txn
+        )
+        self._set_metadata(
+            "media_bookmarks", self.media_bookmarks.get(), use_txn=use_txn
+        )
+        self._set_metadata("note_bookmarks", self.note_bookmarks.get(), use_txn=use_txn)
 
         # Custom type values, sets
-        self._set_metadata("event_names", self.event_names)
-        self._set_metadata("fattr_names", self.family_attributes)
-        self._set_metadata("pattr_names", self.individual_attributes)
-        self._set_metadata("sattr_names", self.source_attributes)
-        self._set_metadata("marker_names", self.marker_names)
-        self._set_metadata("child_refs", self.child_ref_types)
-        self._set_metadata("family_rels", self.family_rel_types)
-        self._set_metadata("event_roles", self.event_role_names)
-        self._set_metadata("name_types", self.name_types)
-        self._set_metadata("origin_types", self.origin_types)
-        self._set_metadata("repo_types", self.repository_types)
-        self._set_metadata("note_types", self.note_types)
-        self._set_metadata("sm_types", self.source_media_types)
-        self._set_metadata("url_types", self.url_types)
-        self._set_metadata("mattr_names", self.media_attributes)
-        self._set_metadata("eattr_names", self.event_attributes)
-        self._set_metadata("place_types", self.place_types)
-
-        # Save misc items:
-        if self.has_changed:
-            self.save_gender_stats(self.genderStats)
+        self._set_metadata("event_names", self.event_names, use_txn=use_txn)
+        self._set_metadata("fattr_names", self.family_attributes, use_txn=use_txn)
+        self._set_metadata("pattr_names", self.individual_attributes, use_txn=use_txn)
+        self._set_metadata("sattr_names", self.source_attributes, use_txn=use_txn)
+        self._set_metadata("marker_names", self.marker_names, use_txn=use_txn)
+        self._set_metadata("child_refs", self.child_ref_types, use_txn=use_txn)
+        self._set_metadata("family_rels", self.family_rel_types, use_txn=use_txn)
+        self._set_metadata("event_roles", self.event_role_names, use_txn=use_txn)
+        self._set_metadata("name_types", self.name_types, use_txn=use_txn)
+        self._set_metadata("origin_types", self.origin_types, use_txn=use_txn)
+        self._set_metadata("repo_types", self.repository_types, use_txn=use_txn)
+        self._set_metadata("note_types", self.note_types, use_txn=use_txn)
+        self._set_metadata("sm_types", self.source_media_types, use_txn=use_txn)
+        self._set_metadata("url_types", self.url_types, use_txn=use_txn)
+        self._set_metadata("mattr_names", self.media_attributes, use_txn=use_txn)
+        self._set_metadata("eattr_names", self.event_attributes, use_txn=use_txn)
+        self._set_metadata("place_types", self.place_types, use_txn=use_txn)
 
         # Indexes:
-        self._set_metadata("cmap_index", self.cmap_index)
-        self._set_metadata("smap_index", self.smap_index)
-        self._set_metadata("emap_index", self.emap_index)
-        self._set_metadata("pmap_index", self.pmap_index)
-        self._set_metadata("fmap_index", self.fmap_index)
-        self._set_metadata("lmap_index", self.lmap_index)
-        self._set_metadata("omap_index", self.omap_index)
-        self._set_metadata("rmap_index", self.rmap_index)
-        self._set_metadata("nmap_index", self.nmap_index)
+        self._set_metadata("cmap_index", self.cmap_index, use_txn=use_txn)
+        self._set_metadata("smap_index", self.smap_index, use_txn=use_txn)
+        self._set_metadata("emap_index", self.emap_index, use_txn=use_txn)
+        self._set_metadata("pmap_index", self.pmap_index, use_txn=use_txn)
+        self._set_metadata("fmap_index", self.fmap_index, use_txn=use_txn)
+        self._set_metadata("lmap_index", self.lmap_index, use_txn=use_txn)
+        self._set_metadata("omap_index", self.omap_index, use_txn=use_txn)
+        self._set_metadata("rmap_index", self.rmap_index, use_txn=use_txn)
+        self._set_metadata("nmap_index", self.nmap_index, use_txn=use_txn)
 
     def get_dbid(self):
         """
@@ -1016,6 +1043,29 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         Note: if use_txn, then begin/commit txn
         """
         raise NotImplementedError
+
+    def _prime_metadata_cache(self) -> None:
+        """
+        Pre-fetch all metadata rows into a temporary in-memory cache so that
+        subsequent :meth:`_get_metadata` calls can be served without
+        additional queries.  Called once at the start of :meth:`load` before
+        the individual :meth:`_get_metadata` calls.
+
+        The default is a no-op.  DBAPI backends override this to issue a
+        single ``SELECT setting, <field> FROM metadata`` and store the raw
+        rows in ``self._metadata_cache``.
+        """
+
+    def _clear_metadata_cache(self) -> None:
+        """
+        Discard any cache built by :meth:`_prime_metadata_cache`.  Called
+        once at the end of the metadata-loading phase in :meth:`load` so
+        that later :meth:`_get_metadata` calls (e.g. for
+        ``default-person-handle`` or ``media-path``) always go to the
+        database.
+
+        The default is a no-op.
+        """
 
     ################################################################
     #

--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -743,6 +743,10 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         if need_to_set_metadata:
             self._set_metadata("version", str(self.VERSION[0]))
 
+        # Load all metadata in one batch query where possible, then
+        # populate individual attributes via the (possibly cached) getter.
+        self._prime_metadata_cache()
+
         # Load metadata
         self.name_formats = self._get_metadata("name_formats")
         self.owner = self._get_metadata("researcher", default=Researcher())
@@ -804,12 +808,16 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         self.rmap_index = self._get_metadata("rmap_index", 0)
         self.nmap_index = self._get_metadata("nmap_index", 0)
 
+        # Discard the batch cache; subsequent _get_metadata() calls
+        # (e.g. for default-person-handle) must always hit the database.
+        self._clear_metadata_cache()
+
         if need_to_set_metadata:
             # for new db we always need blob metadata to allow prior Gramps versions
             # to make it to the downgrade version check
             # Note: downgrade check only works from v5.1.2 and later on sqlite
             self.set_serializer("blob")
-            self.has_changed = 1  # to make sure genderstats gets saved
+            self.save_gender_stats(self.genderStats)
             self._set_all_metadata()
             if self.use_json_data():
                 self.set_serializer("json")
@@ -857,6 +865,8 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
                 # the database for gramps.cli.clidbman:
                 filename = os.path.join(self._directory, "meta_data.db")
                 Path(filename).touch()
+                if self.has_changed:
+                    self.save_gender_stats(self.genderStats)
                 self._set_all_metadata()
 
             self._close()
@@ -874,59 +884,76 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
     def is_open(self):
         return self.db_is_open
 
-    def _set_all_metadata(self):
+    def _set_all_metadata(self, use_txn: bool = True) -> None:
         """
-        sets all the metadata
+        Persist all in-memory metadata to the database.
+
+        :param use_txn: Whether each :meth:`_set_metadata` call should
+            manage its own transaction.  Pass ``False`` when the caller has
+            already opened an enclosing transaction.
+        :type use_txn: bool
+
+        .. note::
+            Gender statistics are *not* saved here; callers are responsible
+            for calling :meth:`save_gender_stats` separately when needed.
         """
         # Save metadata
-        self._set_metadata("version", str(self.VERSION[0]))
-        self._set_metadata("name_formats", self.name_formats)
-        self._set_metadata("researcher", self.owner)
+        self._set_metadata("version", str(self.VERSION[0]), use_txn=use_txn)
+        self._set_metadata("name_formats", self.name_formats, use_txn=use_txn)
+        self._set_metadata("researcher", self.owner, use_txn=use_txn)
 
         # Bookmarks
-        self._set_metadata("bookmarks", self.bookmarks.get())
-        self._set_metadata("family_bookmarks", self.family_bookmarks.get())
-        self._set_metadata("event_bookmarks", self.event_bookmarks.get())
-        self._set_metadata("place_bookmarks", self.place_bookmarks.get())
-        self._set_metadata("repo_bookmarks", self.repo_bookmarks.get())
-        self._set_metadata("source_bookmarks", self.source_bookmarks.get())
-        self._set_metadata("citation_bookmarks", self.citation_bookmarks.get())
-        self._set_metadata("media_bookmarks", self.media_bookmarks.get())
-        self._set_metadata("note_bookmarks", self.note_bookmarks.get())
+        self._set_metadata("bookmarks", self.bookmarks.get(), use_txn=use_txn)
+        self._set_metadata(
+            "family_bookmarks", self.family_bookmarks.get(), use_txn=use_txn
+        )
+        self._set_metadata(
+            "event_bookmarks", self.event_bookmarks.get(), use_txn=use_txn
+        )
+        self._set_metadata(
+            "place_bookmarks", self.place_bookmarks.get(), use_txn=use_txn
+        )
+        self._set_metadata("repo_bookmarks", self.repo_bookmarks.get(), use_txn=use_txn)
+        self._set_metadata(
+            "source_bookmarks", self.source_bookmarks.get(), use_txn=use_txn
+        )
+        self._set_metadata(
+            "citation_bookmarks", self.citation_bookmarks.get(), use_txn=use_txn
+        )
+        self._set_metadata(
+            "media_bookmarks", self.media_bookmarks.get(), use_txn=use_txn
+        )
+        self._set_metadata("note_bookmarks", self.note_bookmarks.get(), use_txn=use_txn)
 
         # Custom type values, sets
-        self._set_metadata("event_names", self.event_names)
-        self._set_metadata("fattr_names", self.family_attributes)
-        self._set_metadata("pattr_names", self.individual_attributes)
-        self._set_metadata("sattr_names", self.source_attributes)
-        self._set_metadata("marker_names", self.marker_names)
-        self._set_metadata("child_refs", self.child_ref_types)
-        self._set_metadata("family_rels", self.family_rel_types)
-        self._set_metadata("event_roles", self.event_role_names)
-        self._set_metadata("name_types", self.name_types)
-        self._set_metadata("origin_types", self.origin_types)
-        self._set_metadata("repo_types", self.repository_types)
-        self._set_metadata("note_types", self.note_types)
-        self._set_metadata("sm_types", self.source_media_types)
-        self._set_metadata("url_types", self.url_types)
-        self._set_metadata("mattr_names", self.media_attributes)
-        self._set_metadata("eattr_names", self.event_attributes)
-        self._set_metadata("place_types", self.place_types)
-
-        # Save misc items:
-        if self.has_changed:
-            self.save_gender_stats(self.genderStats)
+        self._set_metadata("event_names", self.event_names, use_txn=use_txn)
+        self._set_metadata("fattr_names", self.family_attributes, use_txn=use_txn)
+        self._set_metadata("pattr_names", self.individual_attributes, use_txn=use_txn)
+        self._set_metadata("sattr_names", self.source_attributes, use_txn=use_txn)
+        self._set_metadata("marker_names", self.marker_names, use_txn=use_txn)
+        self._set_metadata("child_refs", self.child_ref_types, use_txn=use_txn)
+        self._set_metadata("family_rels", self.family_rel_types, use_txn=use_txn)
+        self._set_metadata("event_roles", self.event_role_names, use_txn=use_txn)
+        self._set_metadata("name_types", self.name_types, use_txn=use_txn)
+        self._set_metadata("origin_types", self.origin_types, use_txn=use_txn)
+        self._set_metadata("repo_types", self.repository_types, use_txn=use_txn)
+        self._set_metadata("note_types", self.note_types, use_txn=use_txn)
+        self._set_metadata("sm_types", self.source_media_types, use_txn=use_txn)
+        self._set_metadata("url_types", self.url_types, use_txn=use_txn)
+        self._set_metadata("mattr_names", self.media_attributes, use_txn=use_txn)
+        self._set_metadata("eattr_names", self.event_attributes, use_txn=use_txn)
+        self._set_metadata("place_types", self.place_types, use_txn=use_txn)
 
         # Indexes:
-        self._set_metadata("cmap_index", self.cmap_index)
-        self._set_metadata("smap_index", self.smap_index)
-        self._set_metadata("emap_index", self.emap_index)
-        self._set_metadata("pmap_index", self.pmap_index)
-        self._set_metadata("fmap_index", self.fmap_index)
-        self._set_metadata("lmap_index", self.lmap_index)
-        self._set_metadata("omap_index", self.omap_index)
-        self._set_metadata("rmap_index", self.rmap_index)
-        self._set_metadata("nmap_index", self.nmap_index)
+        self._set_metadata("cmap_index", self.cmap_index, use_txn=use_txn)
+        self._set_metadata("smap_index", self.smap_index, use_txn=use_txn)
+        self._set_metadata("emap_index", self.emap_index, use_txn=use_txn)
+        self._set_metadata("pmap_index", self.pmap_index, use_txn=use_txn)
+        self._set_metadata("fmap_index", self.fmap_index, use_txn=use_txn)
+        self._set_metadata("lmap_index", self.lmap_index, use_txn=use_txn)
+        self._set_metadata("omap_index", self.omap_index, use_txn=use_txn)
+        self._set_metadata("rmap_index", self.rmap_index, use_txn=use_txn)
+        self._set_metadata("nmap_index", self.nmap_index, use_txn=use_txn)
 
     def get_dbid(self):
         """
@@ -1017,6 +1044,29 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         Note: if use_txn, then begin/commit txn
         """
         raise NotImplementedError
+
+    def _prime_metadata_cache(self) -> None:
+        """
+        Pre-fetch all metadata rows into a temporary in-memory cache so that
+        subsequent :meth:`_get_metadata` calls can be served without
+        additional queries.  Called once at the start of :meth:`load` before
+        the individual :meth:`_get_metadata` calls.
+
+        The default is a no-op.  DBAPI backends override this to issue a
+        single ``SELECT setting, <field> FROM metadata`` and store the raw
+        rows in ``self._metadata_cache``.
+        """
+
+    def _clear_metadata_cache(self) -> None:
+        """
+        Discard any cache built by :meth:`_prime_metadata_cache`.  Called
+        once at the end of the metadata-loading phase in :meth:`load` so
+        that later :meth:`_get_metadata` calls (e.g. for
+        ``default-person-handle`` or ``media-path``) always go to the
+        database.
+
+        The default is a no-op.
+        """
 
     ################################################################
     #

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -30,6 +30,7 @@ Database API interface
 import logging
 import json
 import time
+from typing import Any
 
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 
@@ -76,6 +77,11 @@ class DBAPI(DbGeneric):
     """
     Database backends class for DB-API 2.0 databases
     """
+
+    # Set by _initialize() in concrete subclasses (e.g. SQLite).  Typed as
+    # Any because each backend provides its own connection class and there
+    # is no shared interface type in the codebase.
+    dbapi: Any
 
     # Populated by _prime_metadata_cache(); None when no cache is active.
     _metadata_cache: dict | None = None
@@ -467,12 +473,18 @@ class DBAPI(DbGeneric):
         """
         self._metadata_cache = None
 
-    def _set_all_metadata(self) -> None:
+    def _set_all_metadata(self, use_txn: bool = True) -> None:
         """
         Persist all in-memory metadata to the database in a single
         transaction, reducing the number of round-trips from one per key
         to one for the entire batch.
 
+        The *use_txn* parameter is accepted for LSP compatibility with
+        :meth:`DbGeneric._set_all_metadata` but is ignored: DBAPI always
+        wraps the batch in one ``BEGIN``/``COMMIT`` pair.
+
+        :param use_txn: Ignored; present for interface compatibility only.
+        :type use_txn: bool
         :rtype: None
         """
         self.dbapi.begin()

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -77,6 +77,9 @@ class DBAPI(DbGeneric):
     Database backends class for DB-API 2.0 databases
     """
 
+    # Populated by _prime_metadata_cache(); None when no cache is active.
+    _metadata_cache: dict | None = None
+
     def _initialize(self, directory, username, password):
         raise NotImplementedError
 
@@ -386,8 +389,26 @@ class DBAPI(DbGeneric):
         """
         Get an item from the database.
 
+        When a metadata cache is active (populated by
+        :meth:`_prime_metadata_cache`) the value is returned from memory
+        without any database query.
+
         Note we reserve and use _ to denote default value of []
+
+        :param key: The metadata key to retrieve.
+        :type key: str
+        :param default: Value to return when the key is absent.  The
+            sentinel ``"_"`` causes an empty list to be returned.
+        :returns: The deserialized metadata value, or *default*.
         """
+        if self._metadata_cache is not None:
+            raw = self._metadata_cache.get(key)
+            if raw is not None:
+                return self.serializer.metadata_to_object(raw)
+            if default == "_":
+                return []
+            return default
+
         self.dbapi.execute(
             f"SELECT {self.serializer.metadata_field} FROM metadata WHERE setting = ?",
             [key],
@@ -423,6 +444,40 @@ class DBAPI(DbGeneric):
             )
         if use_txn:
             self._txn_commit()
+
+    def _prime_metadata_cache(self) -> None:
+        """
+        Fetch all metadata rows in a single query and store them in
+        ``self._metadata_cache`` so that the subsequent per-key
+        :meth:`_get_metadata` calls issued during :meth:`load` are served
+        from memory rather than from the database.
+
+        :rtype: None
+        """
+        self.dbapi.execute(
+            f"SELECT setting, {self.serializer.metadata_field} FROM metadata"
+        )
+        self._metadata_cache = dict(self.dbapi.fetchall())
+
+    def _clear_metadata_cache(self) -> None:
+        """
+        Discard the metadata cache populated by :meth:`_prime_metadata_cache`.
+
+        :rtype: None
+        """
+        self._metadata_cache = None
+
+    def _set_all_metadata(self) -> None:
+        """
+        Persist all in-memory metadata to the database in a single
+        transaction, reducing the number of round-trips from one per key
+        to one for the entire batch.
+
+        :rtype: None
+        """
+        self.dbapi.begin()
+        super()._set_all_metadata(use_txn=False)
+        self.dbapi.commit()
 
     def get_name_group_keys(self):
         """

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -408,12 +408,9 @@ class DBAPI(DbGeneric):
         :returns: The deserialized metadata value, or *default*.
         """
         if self._metadata_cache is not None:
-            raw = self._metadata_cache.get(key)
-            if raw is not None:
-                return self.serializer.metadata_to_object(raw)
-            if default == "_":
-                return []
-            return default
+            if key not in self._metadata_cache:
+                return [] if default == "_" else default
+            return self.serializer.metadata_to_object(self._metadata_cache[key])
 
         self.dbapi.execute(
             f"SELECT {self.serializer.metadata_field} FROM metadata WHERE setting = ?",

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -31,6 +31,7 @@ Database API interface
 import logging
 import time
 import copy
+from typing import Any
 
 # ------------------------------------------------------------------------
 #
@@ -104,6 +105,11 @@ class DBAPI(DbGeneric):
     """
     Database backends class for DB-API 2.0 databases
     """
+
+    # Set by _initialize() in concrete subclasses (e.g. SQLite).  Typed as
+    # Any because each backend provides its own connection class and there
+    # is no shared interface type in the codebase.
+    dbapi: Any
 
     # Populated by _prime_metadata_cache(); None when no cache is active.
     _metadata_cache: dict | None = None
@@ -495,12 +501,18 @@ class DBAPI(DbGeneric):
         """
         self._metadata_cache = None
 
-    def _set_all_metadata(self) -> None:
+    def _set_all_metadata(self, use_txn: bool = True) -> None:
         """
         Persist all in-memory metadata to the database in a single
         transaction, reducing the number of round-trips from one per key
         to one for the entire batch.
 
+        The *use_txn* parameter is accepted for LSP compatibility with
+        :meth:`DbGeneric._set_all_metadata` but is ignored: DBAPI always
+        wraps the batch in one ``BEGIN``/``COMMIT`` pair.
+
+        :param use_txn: Ignored; present for interface compatibility only.
+        :type use_txn: bool
         :rtype: None
         """
         self.dbapi.begin()

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -105,6 +105,9 @@ class DBAPI(DbGeneric):
     Database backends class for DB-API 2.0 databases
     """
 
+    # Populated by _prime_metadata_cache(); None when no cache is active.
+    _metadata_cache: dict | None = None
+
     def _initialize(self, directory, username, password):
         raise NotImplementedError
 
@@ -414,8 +417,26 @@ class DBAPI(DbGeneric):
         """
         Get an item from the database.
 
+        When a metadata cache is active (populated by
+        :meth:`_prime_metadata_cache`) the value is returned from memory
+        without any database query.
+
         Note we reserve and use _ to denote default value of []
+
+        :param key: The metadata key to retrieve.
+        :type key: str
+        :param default: Value to return when the key is absent.  The
+            sentinel ``"_"`` causes an empty list to be returned.
+        :returns: The deserialized metadata value, or *default*.
         """
+        if self._metadata_cache is not None:
+            raw = self._metadata_cache.get(key)
+            if raw is not None:
+                return self.serializer.metadata_to_object(raw)
+            if default == "_":
+                return []
+            return default
+
         self.dbapi.execute(
             f"SELECT {self.serializer.metadata_field} FROM metadata WHERE setting = ?",
             [key],
@@ -451,6 +472,40 @@ class DBAPI(DbGeneric):
             )
         if use_txn:
             self._txn_commit()
+
+    def _prime_metadata_cache(self) -> None:
+        """
+        Fetch all metadata rows in a single query and store them in
+        ``self._metadata_cache`` so that the subsequent per-key
+        :meth:`_get_metadata` calls issued during :meth:`load` are served
+        from memory rather than from the database.
+
+        :rtype: None
+        """
+        self.dbapi.execute(
+            f"SELECT setting, {self.serializer.metadata_field} FROM metadata"
+        )
+        self._metadata_cache = dict(self.dbapi.fetchall())
+
+    def _clear_metadata_cache(self) -> None:
+        """
+        Discard the metadata cache populated by :meth:`_prime_metadata_cache`.
+
+        :rtype: None
+        """
+        self._metadata_cache = None
+
+    def _set_all_metadata(self) -> None:
+        """
+        Persist all in-memory metadata to the database in a single
+        transaction, reducing the number of round-trips from one per key
+        to one for the entire batch.
+
+        :rtype: None
+        """
+        self.dbapi.begin()
+        super()._set_all_metadata(use_txn=False)
+        self.dbapi.commit()
 
     def get_name_group_keys(self):
         """

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -436,12 +436,9 @@ class DBAPI(DbGeneric):
         :returns: The deserialized metadata value, or *default*.
         """
         if self._metadata_cache is not None:
-            raw = self._metadata_cache.get(key)
-            if raw is not None:
-                return self.serializer.metadata_to_object(raw)
-            if default == "_":
-                return []
-            return default
+            if key not in self._metadata_cache:
+                return [] if default == "_" else default
+            return self.serializer.metadata_to_object(self._metadata_cache[key])
 
         self.dbapi.execute(
             f"SELECT {self.serializer.metadata_field} FROM metadata WHERE setting = ?",

--- a/gramps/plugins/db/dbapi/test/db_test.py
+++ b/gramps/plugins/db/dbapi/test/db_test.py
@@ -901,5 +901,135 @@ class DbPersonTest(unittest.TestCase):
         self.assertEqual(saved["Mary"], (1, 3, 1))
 
 
+# -------------------------------------------------------------------------
+#
+# DbMetadataBatchTest class
+#
+# -------------------------------------------------------------------------
+class DbMetadataBatchTest(unittest.TestCase):
+    """
+    Tests for metadata batch-read and batch-write optimisations.
+
+    All assertions are expressed in terms of the number of SQL
+    ``execute()`` calls and ``begin()`` calls so they stay meaningful
+    even if the set of metadata keys grows.
+    """
+
+    def _make_db(self):
+        """Return a freshly opened in-memory database."""
+        db = make_database("sqlite")
+        db.load(":memory:")
+        return db
+
+    def _count_executes(self, db, fn):
+        """
+        Call *fn* and return the number of SQL statements executed
+        against the metadata table during that call.
+
+        :param db: An open DBAPI database instance.
+        :param fn: Zero-argument callable to instrument.
+        :returns: Number of ``execute()`` calls whose first argument
+            contains the word ``metadata``.
+        :rtype: int
+        """
+        real_execute = db.dbapi.execute
+        count = 0
+
+        def counting_execute(sql, *args, **kwargs):
+            nonlocal count
+            if "metadata" in sql.lower():
+                count += 1
+            return real_execute(sql, *args, **kwargs)
+
+        db.dbapi.execute = counting_execute
+        try:
+            fn()
+        finally:
+            db.dbapi.execute = real_execute
+        return count
+
+    def _count_begins(self, db, fn):
+        """
+        Call *fn* and return the number of ``BEGIN TRANSACTION``
+        statements issued during that call.
+
+        :param db: An open DBAPI database instance.
+        :param fn: Zero-argument callable to instrument.
+        :returns: Number of ``begin()`` calls.
+        :rtype: int
+        """
+        real_begin = db.dbapi.begin
+        count = 0
+
+        def counting_begin():
+            nonlocal count
+            count += 1
+            return real_begin()
+
+        db.dbapi.begin = counting_begin
+        try:
+            fn()
+        finally:
+            db.dbapi.begin = real_begin
+        return count
+
+    # ------------------------------------------------------------------
+    # Batch-read tests
+    # ------------------------------------------------------------------
+
+    def test_prime_cache_issues_single_query(self):
+        """
+        _prime_metadata_cache() must hit the database exactly once.
+        """
+        db = self._make_db()
+        queries = self._count_executes(db, db._prime_metadata_cache)
+        db.close(update=False)
+        self.assertEqual(queries, 1)
+
+    def test_cached_get_metadata_issues_no_queries(self):
+        """
+        _get_metadata() must not issue any SQL while the cache is active.
+        """
+        db = self._make_db()
+        db._prime_metadata_cache()
+        queries = self._count_executes(db, lambda: db._get_metadata("name_formats"))
+        db._clear_metadata_cache()
+        db.close(update=False)
+        self.assertEqual(queries, 0)
+
+    def test_cache_cleared_after_load(self):
+        """
+        After load() completes, _metadata_cache must be None so that
+        later _get_metadata() calls go to the database.
+        """
+        db = self._make_db()
+        self.assertIsNone(db._metadata_cache)
+        db.close(update=False)
+
+    def test_uncached_get_metadata_issues_one_query(self):
+        """
+        _get_metadata() with no active cache must issue exactly one query.
+        """
+        db = self._make_db()
+        self.assertIsNone(db._metadata_cache)
+        queries = self._count_executes(db, lambda: db._get_metadata("name_formats"))
+        db.close(update=False)
+        self.assertEqual(queries, 1)
+
+    # ------------------------------------------------------------------
+    # Batch-write tests
+    # ------------------------------------------------------------------
+
+    def test_set_all_metadata_single_transaction(self):
+        """
+        _set_all_metadata() must open exactly one database transaction
+        regardless of how many keys are written.
+        """
+        db = self._make_db()
+        begins = self._count_begins(db, db._set_all_metadata)
+        db.close(update=False)
+        self.assertEqual(begins, 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/gramps/plugins/db/dbapi/test/db_test.py
+++ b/gramps/plugins/db/dbapi/test/db_test.py
@@ -913,5 +913,135 @@ class DbPersonTest(unittest.TestCase):
         self.assertEqual(saved["Mary"], (1, 3, 1))
 
 
+# -------------------------------------------------------------------------
+#
+# DbMetadataBatchTest class
+#
+# -------------------------------------------------------------------------
+class DbMetadataBatchTest(unittest.TestCase):
+    """
+    Tests for metadata batch-read and batch-write optimisations.
+
+    All assertions are expressed in terms of the number of SQL
+    ``execute()`` calls and ``begin()`` calls so they stay meaningful
+    even if the set of metadata keys grows.
+    """
+
+    def _make_db(self):
+        """Return a freshly opened in-memory database."""
+        db = make_database("sqlite")
+        db.load(":memory:")
+        return db
+
+    def _count_executes(self, db, fn):
+        """
+        Call *fn* and return the number of SQL statements executed
+        against the metadata table during that call.
+
+        :param db: An open DBAPI database instance.
+        :param fn: Zero-argument callable to instrument.
+        :returns: Number of ``execute()`` calls whose first argument
+            contains the word ``metadata``.
+        :rtype: int
+        """
+        real_execute = db.dbapi.execute
+        count = 0
+
+        def counting_execute(sql, *args, **kwargs):
+            nonlocal count
+            if "metadata" in sql.lower():
+                count += 1
+            return real_execute(sql, *args, **kwargs)
+
+        db.dbapi.execute = counting_execute
+        try:
+            fn()
+        finally:
+            db.dbapi.execute = real_execute
+        return count
+
+    def _count_begins(self, db, fn):
+        """
+        Call *fn* and return the number of ``BEGIN TRANSACTION``
+        statements issued during that call.
+
+        :param db: An open DBAPI database instance.
+        :param fn: Zero-argument callable to instrument.
+        :returns: Number of ``begin()`` calls.
+        :rtype: int
+        """
+        real_begin = db.dbapi.begin
+        count = 0
+
+        def counting_begin():
+            nonlocal count
+            count += 1
+            return real_begin()
+
+        db.dbapi.begin = counting_begin
+        try:
+            fn()
+        finally:
+            db.dbapi.begin = real_begin
+        return count
+
+    # ------------------------------------------------------------------
+    # Batch-read tests
+    # ------------------------------------------------------------------
+
+    def test_prime_cache_issues_single_query(self):
+        """
+        _prime_metadata_cache() must hit the database exactly once.
+        """
+        db = self._make_db()
+        queries = self._count_executes(db, db._prime_metadata_cache)
+        db.close(update=False)
+        self.assertEqual(queries, 1)
+
+    def test_cached_get_metadata_issues_no_queries(self):
+        """
+        _get_metadata() must not issue any SQL while the cache is active.
+        """
+        db = self._make_db()
+        db._prime_metadata_cache()
+        queries = self._count_executes(db, lambda: db._get_metadata("name_formats"))
+        db._clear_metadata_cache()
+        db.close(update=False)
+        self.assertEqual(queries, 0)
+
+    def test_cache_cleared_after_load(self):
+        """
+        After load() completes, _metadata_cache must be None so that
+        later _get_metadata() calls go to the database.
+        """
+        db = self._make_db()
+        self.assertIsNone(db._metadata_cache)
+        db.close(update=False)
+
+    def test_uncached_get_metadata_issues_one_query(self):
+        """
+        _get_metadata() with no active cache must issue exactly one query.
+        """
+        db = self._make_db()
+        self.assertIsNone(db._metadata_cache)
+        queries = self._count_executes(db, lambda: db._get_metadata("name_formats"))
+        db.close(update=False)
+        self.assertEqual(queries, 1)
+
+    # ------------------------------------------------------------------
+    # Batch-write tests
+    # ------------------------------------------------------------------
+
+    def test_set_all_metadata_single_transaction(self):
+        """
+        _set_all_metadata() must open exactly one database transaction
+        regardless of how many keys are written.
+        """
+        db = self._make_db()
+        begins = self._count_begins(db, db._set_all_metadata)
+        db.close(update=False)
+        self.assertEqual(begins, 1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Opening a database issued one SELECT per metadata key (~28 queries); closing issued one BEGIN/INSERT-or-UPDATE/COMMIT per key (~38 transactions, ~114 round-trips). Both costs are paid on every request in web apps that reopen the database per request, and the transaction overhead is especially painful over network databases.
- On open: DBAPI now fetches all metadata rows in a single SELECT into a short-lived cache that serves the per-key `_get_metadata()` calls with no further queries. The cache is discarded before `load()` returns.
- On close: DBAPI overrides `_set_all_metadata()` to wrap `super()._set_all_metadata(use_txn=False)` in a single `BEGIN`/`COMMIT`, reducing ~38 transactions to one. A `use_txn` parameter is added to `_set_all_metadata()` so non-DBAPI backends retain their existing per-key transaction behaviour unchanged. Gender stats saving is extracted from `_set_all_metadata()` into its callers so it manages its own transaction independently.

## Context

This might be a small optimization for Gramps running on SQLite, but for Gramps Web it's an irreducible overhead that dominates the request duration for small/simple requests. It becomes particularly bad when using PostgreSQL, since a network lag is paid for each and every request.