### PR TITLE
Modernize type hints

### DIFF
--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -57,7 +57,7 @@ from .optimizer import Optimizer
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import cast, Dict, List, Literal, Set, Tuple
+from typing import cast, Literal
 from ..db import Database
 from ..types import PrimaryObjectHandle
 
@@ -169,7 +169,7 @@ class GenericFilter:
     def apply_logical_op_to_all(
         self,
         db,
-        possible_handles: Set[PrimaryObjectHandle],
+        possible_handles: set[PrimaryObjectHandle],
         apply_logical_op,
         user=None,
     ):
@@ -246,11 +246,11 @@ class GenericFilter:
     def apply(
         self,
         db,
-        id_list: List[PrimaryObjectHandle | Tuple] | None = None,
+        id_list: list[PrimaryObjectHandle | tuple] | None = None,
         tupleind: int | None = None,
         user=None,
         tree: bool = False,
-    ) -> List[PrimaryObjectHandle | Tuple]:
+    ) -> list[PrimaryObjectHandle | tuple]:
         """
         Apply the filter using db.
 
@@ -294,18 +294,18 @@ class GenericFilter:
         start_time = time.time()
 
         # build the starting set of possible_handles to be filtered
-        possible_handles: Set[PrimaryObjectHandle]
+        possible_handles: set[PrimaryObjectHandle]
         if id_list is not None:
             if tupleind is not None:
                 # construct a dict from handle to corresponding tuple
                 # this is used to efficiently transform final_list from a list of
                 # handles to a list of tuples
-                handle_tuple: Dict[PrimaryObjectHandle, Tuple] = {
-                    data[tupleind]: data for data in cast(List[Tuple], id_list)
+                handle_tuple: dict[PrimaryObjectHandle, tuple] = {
+                    data[tupleind]: data for data in cast(list[tuple], id_list)
                 }
                 possible_handles = set(handle_tuple.keys())
             else:
-                possible_handles = set(cast(List[PrimaryObjectHandle], id_list))
+                possible_handles = set(cast(list[PrimaryObjectHandle], id_list))
         elif tree:
             tree_handles = [handle for handle, obj in self.get_tree_cursor(db)]
             possible_handles = set(tree_handles)

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -30,7 +30,7 @@ import logging
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import List, Set, TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING
 from .rules import Rule
 
 if TYPE_CHECKING:
@@ -46,7 +46,7 @@ class Optimizer:
 
     def compute_potential_handles_for_filter(
         self, filter: GenericFilter
-    ) -> Tuple[Set[PrimaryObjectHandle] | None, Set[PrimaryObjectHandle] | None]:
+    ) -> tuple[set[PrimaryObjectHandle] | None, set[PrimaryObjectHandle] | None]:
         if len(filter.flist) == 0:
             return (None, None)
 
@@ -74,7 +74,7 @@ class Optimizer:
     def compute_potential_handles_for_rule(
         self,
         rule: Rule,
-    ) -> Tuple[Set[PrimaryObjectHandle] | None, Set[PrimaryObjectHandle] | None]:
+    ) -> tuple[set[PrimaryObjectHandle] | None, set[PrimaryObjectHandle] | None]:
         """
         Find the the handles for a particular rule.
         """

--- a/gramps/gen/filters/rules/_hasgrampsid.py
+++ b/gramps/gen/filters/rules/_hasgrampsid.py
@@ -39,7 +39,6 @@ from . import Rule
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Set
 from ...types import PrimaryObjectHandle, PrimaryObject
 from ...db import Database
 
@@ -56,7 +55,7 @@ class HasGrampsId(Rule):
     name = "Object with <Id>"
     description = "Matches objects with a specified Gramps ID"
     category = _("General filters")
-    selected_handles: Set[PrimaryObjectHandle] = set([])
+    selected_handles: set[PrimaryObjectHandle] = set()
 
     def apply_to_one(self, db: Database, obj: PrimaryObject) -> bool:
         """

--- a/gramps/gen/filters/rules/_matchesfilterbase.py
+++ b/gramps/gen/filters/rules/_matchesfilterbase.py
@@ -45,7 +45,7 @@ _ = glocale.translation.gettext
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Any, Union
+from typing import Any
 from ...db import Database
 
 
@@ -67,7 +67,7 @@ class MatchesFilterBase(Rule):
     name = "Objects matching the <filter>"
     description = "Matches objects matched by the specified filter name"
     category = _("General filters")
-    namespace: Union[str, None] = None
+    namespace: str | None = None
 
     def prepare(self, db: Database, user):
         if gramps.gen.filters.CustomFilters:

--- a/gramps/gen/filters/rules/_rule.py
+++ b/gramps/gen/filters/rules/_rule.py
@@ -50,7 +50,7 @@ LOG = logging.getLogger(".")
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Any, List
+from typing import Any
 from ...db import Database
 
 

--- a/gramps/gen/filters/rules/family/_isancestorof.py
+++ b/gramps/gen/filters/rules/family/_isancestorof.py
@@ -42,9 +42,9 @@ from ....const import GRAMPS_LOCALE as glocale
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Set
 from ....lib import Family
 from ....db import Database
+from ....types import FamilyHandle
 
 _ = glocale.translation.gettext
 
@@ -65,7 +65,7 @@ class IsAncestorOf(Rule):
     description = _("Matches ancestor families of the specified family")
 
     def prepare(self, db: Database, user):
-        self.selected_handles: Set[str] = set()
+        self.selected_handles: set[FamilyHandle] = set()
         first = False if int(self.list[1]) else True
         root_family = db.get_family_from_gramps_id(self.list[0])
         self.init_list(db, root_family, first)

--- a/gramps/gen/filters/rules/family/_isbookmarked.py
+++ b/gramps/gen/filters/rules/family/_isbookmarked.py
@@ -38,9 +38,9 @@ from .. import Rule
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Set
 from ....lib import Family
 from ....db import Database
+from ....types import FamilyHandle
 
 
 # -------------------------------------------------------------------------
@@ -56,7 +56,9 @@ class IsBookmarked(Rule):
     description = _("Matches the families on the bookmark list")
 
     def prepare(self, db: Database, user):
-        self.selected_handles: Set[str] = set(list(db.get_family_bookmarks().get()))
+        self.selected_handles: set[FamilyHandle] = set(
+            list(db.get_family_bookmarks().get())
+        )
 
     def apply_to_one(self, db: Database, family: Family) -> bool:
         return family.handle in self.selected_handles

--- a/gramps/gen/filters/rules/family/_isdescendantof.py
+++ b/gramps/gen/filters/rules/family/_isdescendantof.py
@@ -42,9 +42,9 @@ from ....const import GRAMPS_LOCALE as glocale
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Set
 from ....lib import Family
 from ....db import Database
+from ....types import FamilyHandle
 
 _ = glocale.translation.gettext
 
@@ -65,7 +65,7 @@ class IsDescendantOf(Rule):
     description = _("Matches descendant families of the specified family")
 
     def prepare(self, db: Database, user):
-        self.selected_handles: Set[str] = set()
+        self.selected_handles: set[FamilyHandle] = set()
         first = False if int(self.list[1]) else True
         root_family = db.get_family_from_gramps_id(self.list[0])
         self.init_list(db, root_family, first)

--- a/gramps/gen/filters/rules/person/_deeprelationshippathbetween.py
+++ b/gramps/gen/filters/rules/person/_deeprelationshippathbetween.py
@@ -41,7 +41,6 @@ from ....const import GRAMPS_LOCALE as glocale
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Union, List, Set, Dict
 from ....lib import Person
 from ....db import Database
 from ....types import FamilyHandle, PersonHandle
@@ -55,13 +54,13 @@ _ = glocale.translation.gettext
 
 
 def get_family_handle_people(
-    db: Database, exclude_handle: str, family_handle: FamilyHandle
+    db: Database, exclude_handle: PersonHandle, family_handle: FamilyHandle
 ):
-    people: Set[str] = set()
+    people: set[PersonHandle] = set()
 
     family = db.get_family_from_handle(family_handle)
 
-    def possibly_add_handle(h: str):
+    def possibly_add_handle(h: PersonHandle):
         if h is not None and h != exclude_handle:
             people.add(h)
 
@@ -77,10 +76,10 @@ def get_family_handle_people(
 
 def get_person_family_people(
     db: Database, person: Person, person_handle: PersonHandle
-) -> Set[str]:
-    people: Set[str] = set()
+) -> set[PersonHandle]:
+    people: set[PersonHandle] = set()
 
-    def add_family_handle_list(fam_list: List[FamilyHandle]):
+    def add_family_handle_list(fam_list: list[FamilyHandle]):
         for family_handle in fam_list:
             people.update(get_family_handle_people(db, person_handle, family_handle))
 
@@ -91,8 +90,8 @@ def get_person_family_people(
 
 
 def find_deep_relations(
-    db: Database, user, person: Person | None, target_people: List[str]
-) -> Set[str]:
+    db: Database, user, person: Person | None, target_people: list[PersonHandle]
+) -> set[PersonHandle]:
     """This explores all possible paths between a person and one or more
     targets.  The algorithm processes paths in a breadth first wave, one
     remove at a time.  The first path that reaches a target causes the target
@@ -101,12 +100,16 @@ def find_deep_relations(
     The function stores to do data and intermediate results in an ordered dict,
     rather than using a recursive algorithm because some trees have been found
     that exceed the standard python recursive depth."""
-    return_paths: Set[str] = set()  # all people in paths between targets and person
+    return_paths: set[PersonHandle] = (
+        set()
+    )  # all people in paths between targets and person
     if person is None:
         return return_paths
     todo = deque([person.handle])  # list of work to do, handles, add to right,
     #                                pop from left
-    done: Dict[str, Union[str, None]] = {}  # The key records handles already examined,
+    done: dict[PersonHandle, PersonHandle | None] = (
+        {}
+    )  # The key records handles already examined,
     # the value is a handle of the previous person in the path, or None at
     # head of path.  This forms a linked list of handles along the path.
     done[person.handle] = None
@@ -185,7 +188,7 @@ class DeepRelationshipPathBetween(Rule):
                 _("Evaluating people"),
                 db.get_number_of_people(),
             )
-        self.selected_handles: Set[str] = find_deep_relations(
+        self.selected_handles: set[PersonHandle] = find_deep_relations(
             db, user, root_person, target_people
         )
         if user:

--- a/gramps/gen/filters/rules/person/_hascommonancestorwith.py
+++ b/gramps/gen/filters/rules/person/_hascommonancestorwith.py
@@ -39,9 +39,9 @@ from .. import Rule
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Dict, Set
 from ....lib import Person
 from ....db import Database
+from ....types import PersonHandle
 
 
 # -------------------------------------------------------------------------
@@ -65,7 +65,7 @@ class HasCommonAncestorWith(Rule):
         # are, in a set(). So we only have to compute a person's
         # ancestor list once.
         # Start with filling the cache for root person (gramps_id in self.list[0])
-        self.ancestor_cache: Dict[str, Set[str]] = {}
+        self.ancestor_cache: dict[PersonHandle, set[PersonHandle]] = {}
         root_person = db.get_person_from_gramps_id(self.list[0])
         if root_person:
             self.add_ancs(db, root_person)

--- a/gramps/gen/filters/rules/person/_hastextmatchingsubstringof.py
+++ b/gramps/gen/filters/rules/person/_hastextmatchingsubstringof.py
@@ -43,12 +43,13 @@ from .. import Rule
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Set
 from ....lib import Person
 from ....db import Database
 from ....types import (
     PersonHandle,
     EventHandle,
+    SourceHandle,
+    RepositoryHandle,
     PlaceHandle,
     MediaHandle,
     FamilyHandle,
@@ -69,13 +70,13 @@ class HasTextMatchingSubstringOf(Rule):
 
     def prepare(self, db: Database, user):
         self.db = db
-        self.person_map: Set[str] = set()
-        self.event_map: Set[str] = set()
-        self.source_map: Set[str] = set()
-        self.repo_map: Set[str] = set()
-        self.family_map: Set[str] = set()
-        self.place_map: Set[str] = set()
-        self.media_map: Set[str] = set()
+        self.person_map: set[PersonHandle] = set()
+        self.event_map: set[EventHandle] = set()
+        self.source_map: set[SourceHandle] = set()
+        self.repo_map: set[RepositoryHandle] = set()
+        self.family_map: set[FamilyHandle] = set()
+        self.place_map: set[PlaceHandle] = set()
+        self.media_map: set[MediaHandle] = set()
         try:
             if int(self.list[1]):
                 self.case_sensitive = True

--- a/gramps/gen/filters/rules/person/_isancestorof.py
+++ b/gramps/gen/filters/rules/person/_isancestorof.py
@@ -39,9 +39,9 @@ from .. import Rule
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Set
 from ....lib import Person
 from ....db import Database
+from ....types import PersonHandle
 
 
 # -------------------------------------------------------------------------
@@ -60,7 +60,7 @@ class IsAncestorOf(Rule):
     def prepare(self, db: Database, user):
         """Assume that if 'Inclusive' not defined, assume inclusive"""
         self.db = db
-        self.selected_handles: Set[str] = set()
+        self.selected_handles: set[PersonHandle] = set()
         try:
             first = False if int(self.list[1]) else True
         except IndexError:

--- a/gramps/gen/filters/rules/person/_isancestoroffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_isancestoroffiltermatch.py
@@ -39,9 +39,9 @@ from ._matchesfilter import MatchesFilter
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Set
 from ....lib import Person
 from ....db import Database
+from ....types import PersonHandle
 
 
 # -------------------------------------------------------------------------
@@ -62,7 +62,7 @@ class IsAncestorOfFilterMatch(IsAncestorOf):
 
     def prepare(self, db: Database, user):
         self.db = db
-        self.selected_handles: Set[str] = set()
+        self.selected_handles: set[PersonHandle] = set()
         try:
             if int(self.list[1]):
                 first = False

--- a/gramps/gen/filters/rules/person/_isbookmarked.py
+++ b/gramps/gen/filters/rules/person/_isbookmarked.py
@@ -39,9 +39,9 @@ from .. import Rule
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Set
 from ....lib import Person
 from ....db import Database
+from ....types import PersonHandle
 
 
 # -------------------------------------------------------------------------
@@ -57,7 +57,7 @@ class IsBookmarked(Rule):
     description = _("Matches the people on the bookmark list")
 
     def prepare(self, db: Database, user):
-        self.selected_handles: Set[str] = set(list(db.get_bookmarks().get()))
+        self.selected_handles: set[PersonHandle] = set(list(db.get_bookmarks().get()))
 
     def apply_to_one(self, db: Database, person: Person) -> bool:
         return person.handle in self.selected_handles

--- a/gramps/gen/filters/rules/person/_ischildoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_ischildoffiltermatch.py
@@ -39,9 +39,9 @@ from ._matchesfilter import MatchesFilter
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Set
 from ....lib import Person
 from ....db import Database
+from ....types import PersonHandle
 
 
 # -------------------------------------------------------------------------
@@ -60,7 +60,7 @@ class IsChildOfFilterMatch(Rule):
 
     def prepare(self, db: Database, user):
         self.db = db
-        self.selected_handles: Set[str] = set()
+        self.selected_handles: set[PersonHandle] = set()
         self.filt = MatchesFilter(self.list)
         self.filt.requestprepare(db, user)
         if user:

--- a/gramps/gen/filters/rules/person/_isdefaultperson.py
+++ b/gramps/gen/filters/rules/person/_isdefaultperson.py
@@ -38,9 +38,9 @@ from .. import Rule
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Set
 from ....lib import Person
 from ....db import Database
+from ....types import PersonHandle
 
 
 # -------------------------------------------------------------------------
@@ -56,7 +56,7 @@ class IsDefaultPerson(Rule):
     description = _("Matches the Home Person")
 
     def prepare(self, db: Database, user):
-        self.selected_handles: Set[str] = set()
+        self.selected_handles: set[PersonHandle] = set()
         p: Person = db.get_default_person()
         if p:
             self.selected_handles.add(p.handle)

--- a/gramps/gen/filters/rules/person/_isdescendantfamilyof.py
+++ b/gramps/gen/filters/rules/person/_isdescendantfamilyof.py
@@ -26,10 +26,6 @@ from __future__ import annotations
 from ....const import GRAMPS_LOCALE as glocale
 
 _ = glocale.translation.gettext
-try:
-    set()
-except NameError:
-    from sets import Set as set
 
 # -------------------------------------------------------------------------
 #
@@ -43,7 +39,6 @@ from .. import Rule
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import List, Set
 from ....lib import Person
 from ....db import Database
 from ....types import PersonHandle
@@ -68,7 +63,7 @@ class IsDescendantFamilyOf(Rule):
 
     def prepare(self, db: Database, user):
         self.db = db
-        self.selected_handles: Set[PersonHandle] = set()
+        self.selected_handles: set[PersonHandle] = set()
         self.root_person = db.get_person_from_gramps_id(self.list[0])
         self.add_matches(self.root_person)
         try:
@@ -92,7 +87,7 @@ class IsDescendantFamilyOf(Rule):
             return
 
         # Add self
-        queue: List[Person] = [person]
+        queue: list[Person] = [person]
 
         while queue:
             person = queue.pop(0)

--- a/gramps/gen/filters/rules/person/_isdescendantfamilyoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_isdescendantfamilyoffiltermatch.py
@@ -22,8 +22,6 @@
 # Standard Python modules
 #
 # -------------------------------------------------------------------------
-from typing import Set
-
 from ....const import GRAMPS_LOCALE as glocale
 
 _ = glocale.translation.gettext

--- a/gramps/gen/filters/rules/person/_isdescendantfamilyoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_isdescendantfamilyoffiltermatch.py
@@ -58,7 +58,7 @@ class IsDescendantFamilyOfFilterMatch(IsDescendantFamilyOf):
 
     def prepare(self, db: Database, user):
         self.db = db
-        self.selected_handles: Set[PersonHandle] = set()
+        self.selected_handles: set[PersonHandle] = set()
 
         self.matchfilt = MatchesFilter(self.list[0:1])
         self.matchfilt.requestprepare(db, user)

--- a/gramps/gen/filters/rules/person/_isdescendantof.py
+++ b/gramps/gen/filters/rules/person/_isdescendantof.py
@@ -39,9 +39,9 @@ from .. import Rule
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Set
 from ....lib import Person
 from ....db import Database
+from ....types import PersonHandle
 
 
 # -------------------------------------------------------------------------
@@ -60,7 +60,7 @@ class IsDescendantOf(Rule):
 
     def prepare(self, db: Database, user):
         self.db = db
-        self.selected_handles: Set[str] = set()
+        self.selected_handles: set[PersonHandle] = set()
         try:
             first = False if int(self.list[1]) else True
         except IndexError:

--- a/gramps/gen/filters/rules/person/_isdescendantoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_isdescendantoffiltermatch.py
@@ -39,9 +39,9 @@ from ._matchesfilter import MatchesFilter
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Set
 from ....lib import Person
 from ....db import Database
+from ....types import PersonHandle
 
 
 # -------------------------------------------------------------------------
@@ -62,7 +62,7 @@ class IsDescendantOfFilterMatch(IsDescendantOf):
 
     def prepare(self, db: Database, user):
         self.db = db
-        self.selected_handles: Set[str] = set()
+        self.selected_handles: set[PersonHandle] = set()
         try:
             if int(self.list[1]):
                 first = False

--- a/gramps/gen/filters/rules/person/_isduplicatedancestorof.py
+++ b/gramps/gen/filters/rules/person/_isduplicatedancestorof.py
@@ -39,9 +39,9 @@ from .. import Rule
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Set
 from ....lib import Person
 from ....db import Database
+from ....types import PersonHandle
 
 
 # -------------------------------------------------------------------------
@@ -62,8 +62,8 @@ class IsDuplicatedAncestorOf(Rule):
 
     def prepare(self, db: Database, user):
         self.db = db
-        self.cache: Set[str] = set()
-        self.selected_handles: Set[str] = set()
+        self.cache: set[PersonHandle] = set()
+        self.selected_handles: set[PersonHandle] = set()
         root_person = db.get_person_from_gramps_id(self.list[0])
         if root_person:
             self.init_ancestor_list(db, root_person)

--- a/gramps/gen/filters/rules/person/_islessthannthgenerationancestorof.py
+++ b/gramps/gen/filters/rules/person/_islessthannthgenerationancestorof.py
@@ -38,7 +38,6 @@ from .. import Rule
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import List, Set, Tuple
 from ....lib import Person
 from ....db import Database
 from ....types import PersonHandle
@@ -63,7 +62,7 @@ class IsLessThanNthGenerationAncestorOf(Rule):
 
     def prepare(self, db: Database, user):
         self.db = db
-        self.selected_handles: Set[str] = set()
+        self.selected_handles: set[PersonHandle] = set()
         person = db.get_person_from_gramps_id(self.list[0])
         if person:
             root_handle = person.handle
@@ -71,7 +70,7 @@ class IsLessThanNthGenerationAncestorOf(Rule):
                 self.init_ancestor_list(root_handle)
 
     def init_ancestor_list(self, root_handle: PersonHandle):
-        queue: List[Tuple[PersonHandle, int]] = [
+        queue: list[tuple[PersonHandle, int]] = [
             (root_handle, 1)
         ]  # generation 1 is root
         while queue:

--- a/gramps/gen/filters/rules/person/_islessthannthgenerationancestorofbookmarked.py
+++ b/gramps/gen/filters/rules/person/_islessthannthgenerationancestorofbookmarked.py
@@ -43,7 +43,6 @@ from .. import Rule
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import List, Set
 from ....lib import Person
 from ....db import Database
 from ....types import PersonHandle
@@ -69,10 +68,10 @@ class IsLessThanNthGenerationAncestorOfBookmarked(Rule):
 
     def prepare(self, db: Database, user):
         self.db = db
-        bookmarks: List[str] = db.get_bookmarks().get()
-        self.selected_handles: Set[PersonHandle] = set()
+        bookmarks: list[PersonHandle] = db.get_bookmarks().get()
+        self.selected_handles: set[PersonHandle] = set()
         if len(bookmarks) != 0:
-            self.bookmarks: Set[PersonHandle] = set(bookmarks)
+            self.bookmarks: set[PersonHandle] = set(bookmarks)
             for self.bookmarkhandle in self.bookmarks:
                 self.init_ancestor_list(self.bookmarkhandle, 1)
 

--- a/gramps/gen/filters/rules/person/_islessthannthgenerationancestorofdefaultperson.py
+++ b/gramps/gen/filters/rules/person/_islessthannthgenerationancestorofdefaultperson.py
@@ -38,7 +38,6 @@ from .. import Rule
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Set
 from ....lib import Person
 from ....db import Database
 from ....types import PersonHandle
@@ -63,7 +62,7 @@ class IsLessThanNthGenerationAncestorOfDefaultPerson(Rule):
 
     def prepare(self, db: Database, user):
         self.db = db
-        self.selected_handles: Set[PersonHandle] = set()
+        self.selected_handles: set[PersonHandle] = set()
         p: Person = db.get_default_person()
         if p:
             self.init_ancestor_list(p.handle, 1)

--- a/gramps/gen/filters/rules/person/_islessthannthgenerationdescendantof.py
+++ b/gramps/gen/filters/rules/person/_islessthannthgenerationdescendantof.py
@@ -39,9 +39,9 @@ from .. import Rule
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Set
 from ....lib import Person
 from ....db import Database
+from ....types import PersonHandle
 
 
 # -------------------------------------------------------------------------
@@ -63,7 +63,7 @@ class IsLessThanNthGenerationDescendantOf(Rule):
 
     def prepare(self, db: Database, user):
         self.db = db
-        self.selected_handles: Set[str] = set()
+        self.selected_handles: set[PersonHandle] = set()
         try:
             root_person = db.get_person_from_gramps_id(self.list[0])
             self.init_list(root_person, 0)

--- a/gramps/gen/filters/rules/person/_ismorethannthgenerationancestorof.py
+++ b/gramps/gen/filters/rules/person/_ismorethannthgenerationancestorof.py
@@ -38,7 +38,6 @@ from .. import Rule
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Set
 from ....lib import Person
 from ....db import Database
 from ....types import PersonHandle
@@ -63,7 +62,7 @@ class IsMoreThanNthGenerationAncestorOf(Rule):
 
     def prepare(self, db: Database, user):
         self.db = db
-        self.selected_handles: Set[PersonHandle] = set()
+        self.selected_handles: set[PersonHandle] = set()
         person = db.get_person_from_gramps_id(self.list[0])
         if person:
             root_handle = person.handle

--- a/gramps/gen/filters/rules/person/_ismorethannthgenerationdescendantof.py
+++ b/gramps/gen/filters/rules/person/_ismorethannthgenerationdescendantof.py
@@ -38,9 +38,9 @@ from .. import Rule
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Set
 from ....lib import Person
 from ....db import Database
+from ....types import PersonHandle
 
 
 # -------------------------------------------------------------------------
@@ -62,7 +62,7 @@ class IsMoreThanNthGenerationDescendantOf(Rule):
 
     def prepare(self, db: Database, user):
         self.db = db
-        self.selected_handles: Set[str] = set()
+        self.selected_handles: set[PersonHandle] = set()
         try:
             root_person = db._get_raw_person_from_id_data(self.list[0])
             self.init_list(root_person, 0)

--- a/gramps/gen/filters/rules/person/_isparentoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_isparentoffiltermatch.py
@@ -39,9 +39,9 @@ from ._matchesfilter import MatchesFilter
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Set
 from ....lib import Person
 from ....db import Database
+from ....types import PersonHandle
 
 
 # -------------------------------------------------------------------------
@@ -60,7 +60,7 @@ class IsParentOfFilterMatch(Rule):
 
     def prepare(self, db: Database, user):
         self.db = db
-        self.selected_handles: Set[str] = set()
+        self.selected_handles: set[PersonHandle] = set()
         self.filt = MatchesFilter(self.list)
         self.filt.requestprepare(db, user)
         if user:

--- a/gramps/gen/filters/rules/person/_isrelatedwith.py
+++ b/gramps/gen/filters/rules/person/_isrelatedwith.py
@@ -39,9 +39,9 @@ from .. import Rule
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import List, Set
 from ....lib import Person
 from ....db import Database
+from ....types import PersonHandle
 
 
 # -------------------------------------------------------------------------
@@ -64,7 +64,7 @@ class IsRelatedWith(Rule):
         """
         self.db = db
 
-        self.selected_handles: Set[str] = set()
+        self.selected_handles: set[PersonHandle] = set()
         self.add_relative(db.get_person_from_gramps_id(self.list[0]))
 
     def reset(self):
@@ -78,7 +78,7 @@ class IsRelatedWith(Rule):
         if not start:
             return
 
-        queue: List[Person] = [start]
+        queue: list[Person] = [start]
 
         while queue:
             person = queue.pop()

--- a/gramps/gen/filters/rules/person/_issiblingoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_issiblingoffiltermatch.py
@@ -39,9 +39,9 @@ from ._matchesfilter import MatchesFilter
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Set
 from ....lib import Person
 from ....db import Database
+from ....types import PersonHandle
 
 
 # -------------------------------------------------------------------------
@@ -59,7 +59,7 @@ class IsSiblingOfFilterMatch(Rule):
 
     def prepare(self, db: Database, user):
         self.db = db
-        self.selected_handles: Set[str] = set()
+        self.selected_handles: set[PersonHandle] = set()
         self.matchfilt = MatchesFilter(self.list)
         self.matchfilt.requestprepare(db, user)
         if user:

--- a/gramps/gen/filters/rules/person/_relationshippathbetween.py
+++ b/gramps/gen/filters/rules/person/_relationshippathbetween.py
@@ -38,7 +38,6 @@ from .. import Rule
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import List, Set, Dict
 from ....lib import Person
 from ....db import Database
 from ....types import PersonHandle
@@ -64,7 +63,7 @@ class RelationshipPathBetween(Rule):
 
     def prepare(self, db: Database, user):
         self.db = db
-        self.selected_handles: Set[PersonHandle] = set()
+        self.selected_handles: set[PersonHandle] = set()
         root1 = db.get_person_from_gramps_id(self.list[0])
         root2 = db.get_person_from_gramps_id(self.list[1])
         if root1 and root2:
@@ -89,8 +88,8 @@ class RelationshipPathBetween(Rule):
         self,
         rank: int,
         handle: PersonHandle,
-        plist: Set[PersonHandle],
-        pmap: Dict[PersonHandle, int],
+        plist: set[PersonHandle],
+        pmap: dict[PersonHandle, int],
     ):
         if not handle:
             return
@@ -114,11 +113,11 @@ class RelationshipPathBetween(Rule):
         return person.handle in self.selected_handles
 
     def init_list(self, p1_handle: PersonHandle, p2_handle: PersonHandle):
-        firstMap: Dict[PersonHandle, int] = {}
-        firstSet: Set[PersonHandle] = set()
-        secondMap: Dict[PersonHandle, int] = {}
-        secondSet: Set[PersonHandle] = set()
-        common: List[PersonHandle] = []
+        firstMap: dict[PersonHandle, int] = {}
+        firstSet: set[PersonHandle] = set()
+        secondMap: dict[PersonHandle, int] = {}
+        secondSet: set[PersonHandle] = set()
+        common: list[PersonHandle] = []
         rank = 9999999
 
         self.apply_filter(0, p1_handle, firstSet, firstMap)
@@ -136,7 +135,7 @@ class RelationshipPathBetween(Rule):
         path2 = set([p2_handle])
 
         for person_handle in common:
-            new_map: Set[PersonHandle] = set()
+            new_map: set[PersonHandle] = set()
             self.desc_list(person_handle, new_map, True)
             path1.update(new_map.intersection(firstMap))
             path2.update(new_map.intersection(secondMap))

--- a/gramps/gen/filters/rules/person/_relationshippathbetweenbookmarks.py
+++ b/gramps/gen/filters/rules/person/_relationshippathbetweenbookmarks.py
@@ -25,10 +25,7 @@
 from ....const import GRAMPS_LOCALE as glocale
 
 _ = glocale.translation.gettext
-try:
-    set()
-except NameError:
-    from sets import Set as set
+
 # -------------------------------------------------------------------------
 #
 # Gramps modules
@@ -41,10 +38,9 @@ from .. import Rule
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import List, Set, Dict
 from ....lib import Person
 from ....db import Database
-from ....types import PersonHandle, FamilyHandle
+from ....types import PersonHandle
 
 
 # -------------------------------------------------------------------------
@@ -69,9 +65,9 @@ class RelationshipPathBetweenBookmarks(Rule):
 
     def prepare(self, db: Database, user):
         self.db = db
-        self.selected_handles: Set[PersonHandle] = set()
+        self.selected_handles: set[PersonHandle] = set()
         bookmarks = db.get_bookmarks().get()
-        self.bookmarks: Set[PersonHandle] = set(bookmarks)
+        self.bookmarks: set[PersonHandle] = set(bookmarks)
         try:
             self.init_list()
         except:
@@ -99,10 +95,10 @@ class RelationshipPathBetweenBookmarks(Rule):
     # Given a group of individuals, returns all of their parents.
     # The value keyed by the individual handles is the path from
     # the original person up, like generation[gfather]= [son,father,gfather]
-    def parents(self, generation: Dict[PersonHandle, List[PersonHandle]]):
+    def parents(self, generation: dict[PersonHandle, list[PersonHandle]]):
         if len(generation) < 1:
             return None
-        prev_generation: Dict[PersonHandle, List[PersonHandle]] = {}
+        prev_generation: dict[PersonHandle, list[PersonHandle]] = {}
         for handle in generation:
             try:
                 person = self.db.get_person_from_handle(handle)
@@ -136,7 +132,7 @@ class RelationshipPathBetweenBookmarks(Rule):
         gmap2 = {handle2: [handle2]}
         map1 = {}
         map2 = {}
-        overlap = set({})
+        overlap = set()
         for rank in range(1, 50):  # Limit depth of search
             try:
                 gmap1 = self.parents(gmap1)  # Get previous generation into map
@@ -163,7 +159,7 @@ class RelationshipPathBetweenBookmarks(Rule):
         self.selected_handles.update(self.bookmarks)
         if len(self.bookmarks) < 2:
             return
-        bmarks: List[PersonHandle] = list(self.bookmarks)
+        bmarks: list[PersonHandle] = list(self.bookmarks)
 
         # Go through all bookmarked individuals, and mark all
         # of the people in each of the paths betweent them.

--- a/gramps/gen/filters/rules/place/_inlatlonneighborhood.py
+++ b/gramps/gen/filters/rules/place/_inlatlonneighborhood.py
@@ -41,7 +41,6 @@ from ....utils.place import conv_lat_lon
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Union
 from ....lib import Place
 from ....db import Database
 
@@ -70,8 +69,8 @@ class InLatLonNeighborhood(Rule):
     category = _("Position filters")
 
     def prepare(self, db: Database, user):
-        self.halfheight: Union[float, None] = None
-        self.halfwidth: Union[float, None] = None
+        self.halfheight: float | None = None
+        self.halfwidth: float | None = None
         if self.list[0]:
             try:
                 self.halfheight = float(self.list[2]) / 2.0

--- a/gramps/gen/filters/rules/place/_withinarea.py
+++ b/gramps/gen/filters/rules/place/_withinarea.py
@@ -47,7 +47,6 @@ from ....utils.place import conv_lat_lon
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Union
 from ....lib import Place
 from ....db import Database
 
@@ -70,8 +69,8 @@ class WithinArea(Rule):
     category = _("Position filters")
     handle = None
     radius: float = 0.0
-    latitude: Union[float, None] = None
-    longitude: Union[float, None] = None
+    latitude: float | None = None
+    longitude: float | None = None
 
     def prepare(self, db: Database, user):
         ref_place = db.get_place_from_gramps_id(self.list[0])
@@ -114,8 +113,8 @@ class WithinArea(Rule):
             self.radius = self.radius / 2
 
     def apply_to_one(self, db: Database, place: Place) -> bool:
-        latit: Union[float, None] = None
-        longit: Union[float, None] = None
+        latit: float | None = None
+        longit: float | None = None
 
         if not (place and self.handle and self.latitude and self.longitude):
             return False

--- a/gramps/gen/types.py
+++ b/gramps/gen/types.py
@@ -21,7 +21,7 @@
 
 from __future__ import annotations
 
-from typing import NewType, Type, TypeVar, Union
+from typing import NewType, Type, TypeVar
 
 from .lib import (
     Citation,
@@ -48,18 +48,18 @@ CitationHandle = NewType("CitationHandle", str)
 MediaHandle = NewType("MediaHandle", str)
 NoteHandle = NewType("NoteHandle", str)
 TagHandle = NewType("TagHandle", str)
-PrimaryObjectHandle = Union[
-    PersonHandle,
-    FamilyHandle,
-    EventHandle,
-    PlaceHandle,
-    SourceHandle,
-    RepositoryHandle,
-    CitationHandle,
-    MediaHandle,
-    NoteHandle,
-]
-AnyHandle = Union[PrimaryObjectHandle, TagHandle]
+PrimaryObjectHandle = (
+    PersonHandle
+    | FamilyHandle
+    | EventHandle
+    | PlaceHandle
+    | SourceHandle
+    | RepositoryHandle
+    | CitationHandle
+    | MediaHandle
+    | NoteHandle
+)
+AnyHandle = PrimaryObjectHandle | TagHandle
 TableObjectType = TypeVar("TableObjectType", bound=TableObject)
 
 PersonGrampsID = NewType("PersonGrampsID", str)
@@ -72,15 +72,15 @@ CitationGrampsID = NewType("CitationGrampsID", str)
 MediaGrampsID = NewType("MediaGrampsID", str)
 NoteGrampsID = NewType("NoteGrampsID", str)
 # No Tag IDs
-PrimaryObjectGrampsID = Union[
-    PersonGrampsID,
-    FamilyGrampsID,
-    EventGrampsID,
-    PlaceGrampsID,
-    SourceGrampsID,
-    RepositoryGrampsID,
-    CitationGrampsID,
-    MediaGrampsID,
-    NoteGrampsID,
-]
+PrimaryObjectGrampsID = (
+    PersonGrampsID
+    | FamilyGrampsID
+    | EventGrampsID
+    | PlaceGrampsID
+    | SourceGrampsID
+    | RepositoryGrampsID
+    | CitationGrampsID
+    | MediaGrampsID
+    | NoteGrampsID
+)
 AnyGrampsID = PrimaryObjectGrampsID  # No Tag IDs


### PR DESCRIPTION
Convert type hints to the form preferred by gramps
- Use the correct handle type rather than `str`
- Use `set`, `list`, `dict`, `tuple` instead of `Set`, `List`, `Dict`, `Tuple`
- Use | instead of Union[]