### PR TITLE
Small one-line fixes mainly to comments and log messages

### DIFF
--- a/gramps/gen/db/base.py
+++ b/gramps/gen/db/base.py
@@ -91,7 +91,7 @@ class DbReadBase:
 
     def db_has_bm_changes(self):
         """
-        Return whethere there were bookmark changes during the session.
+        Return whether there were bookmark changes during the session.
         """
         raise NotImplementedError
 
@@ -838,7 +838,7 @@ class DbReadBase:
 
     def get_url_types(self):
         """
-        Return a list of all custom names types associated with Url instances
+        Return a list of all custom url types associated with Url instances
         in the database.
         """
         raise NotImplementedError
@@ -947,7 +947,7 @@ class DbReadBase:
 
     def get_raw_media_data(self, handle):
         """
-        Return raw (serialized and pickled) Family object from handle
+        Return raw (serialized and pickled) Media object from handle
         """
         raise NotImplementedError
 

--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -117,7 +117,6 @@ from . import (
 from .bookmarks import DbBookmarks
 from .exceptions import DbUpgradeRequiredError, DbVersionError
 from .utils import clear_lock_file, write_lock_file
-from typing import Union
 
 _ = glocale.translation.gettext
 
@@ -2511,7 +2510,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
 
     def get_url_types(self):
         """
-        Return a list of all custom names types assocated with Url instances
+        Return a list of all custom url types assocated with Url instances
         in the database.
         """
         return list(self.url_types)
@@ -2677,7 +2676,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
 
     def db_has_bm_changes(self):
         """
-        Return whethere there were bookmark changes during the session.
+        Return whether there were bookmark changes during the session.
         """
         return self._bm_changes > 0
 

--- a/gramps/gen/lib/genderstats.py
+++ b/gramps/gen/lib/genderstats.py
@@ -39,7 +39,7 @@ class GenderStats:
     """
     Class for keeping track of statistics related to Given Name vs. Gender.
 
-    This allows the tracking of the liklihood of a person's given name
+    This allows the tracking of the likelihood of a person's given name
     indicating the gender of the person.
     """
 

--- a/gramps/gen/lib/serialize.py
+++ b/gramps/gen/lib/serialize.py
@@ -143,7 +143,7 @@ class JSONSerializer:
 
     @staticmethod
     def object_to_data(obj):
-        LOG.debug("json, object_to_string: %r", obj)
+        LOG.debug("json, object_to_data: %r", obj)
         return object_to_data(obj)
 
     @staticmethod

--- a/gramps/gen/lib/tableobj.py
+++ b/gramps/gen/lib/tableobj.py
@@ -49,7 +49,7 @@ CODESET = glocale.encoding
 class TableObject(BaseObject):
     """
     The TableObject is the base class for all objects that are stored in a
-    seperate database table.  Each object has a database handle and a last
+    separate database table.  Each object has a database handle and a last
     changed time.  The database handle is used as the unique key for a record
     in the database.  This is not the same as the Gramps ID, which is a user
     visible identifier for a record.
@@ -61,7 +61,7 @@ class TableObject(BaseObject):
         """
         Initialize a TableObject.
 
-        If source is None, the handle is assigned as an empty string.
+        If source is None, the handle is initialized to None.
         If source is not None, then the handle is initialized from the value in
         the source object.
 

--- a/gramps/gen/merge/test/merge_ref_test.py
+++ b/gramps/gen/merge/test/merge_ref_test.py
@@ -2252,7 +2252,7 @@ class FamilyMergeCheck(BaseMergeCheck):
         )
 
     def test_regular_merge(self):
-        """Merge two families succesfully"""
+        """Merge two families successfully"""
         expect = ET.fromstring(self.basedoc, parser=self.parser)
         persons = expect.xpath("//g:person", namespaces={"g": NS_G})
         altname = ET.SubElement(persons[0], NSP + "name", alt="1", type="Birth Name")

--- a/gramps/gen/utils/test/callback_test.py
+++ b/gramps/gen/utils/test/callback_test.py
@@ -37,7 +37,7 @@ class TestCallback(unittest.TestCase):
         t.emit("test-signal", (1,))
 
         self.assertEqual(len(rl), 1, "No signal emitted")
-        self.assertEqual(rl[0], 1, "Wrong argument recieved")
+        self.assertEqual(rl[0], 1, "Wrong argument received")
 
     def test_exception_catch(self):
         class TestSignals(Callback):
@@ -78,7 +78,7 @@ class TestCallback(unittest.TestCase):
         t.emit("test-signal", (1,))
 
         self.assertEqual(len(rl), 1, "No signal emitted")
-        self.assertEqual(rl[0], 1, "Wrong argument recieved")
+        self.assertEqual(rl[0], 1, "Wrong argument received")
 
         t.disconnect(key)
 
@@ -101,7 +101,7 @@ class TestCallback(unittest.TestCase):
         t.emit("test-noargs")
 
         self.assertEqual(len(rl), 1, "No signal emitted")
-        self.assertEqual(rl[0], 1, "Wrong argument recieved")
+        self.assertEqual(rl[0], 1, "Wrong argument received")
 
     def test_no_callback(self):
         class TestSignals(Callback):
@@ -129,13 +129,13 @@ class TestCallback(unittest.TestCase):
         t.emit("test-signal", (1,))
 
         self.assertEqual(len(rl), 1, "No signal emitted")
-        self.assertEqual(rl[0], 1, "Wrong argument recieved")
+        self.assertEqual(rl[0], 1, "Wrong argument received")
 
         t.connect("test-sub-signal", fn)
         t.emit("test-sub-signal", (1,))
 
         self.assertEqual(len(rl), 2, "No subclass signal emitted")
-        self.assertEqual(rl[1], 1, "Wrong argument recieved in subclass")
+        self.assertEqual(rl[1], 1, "Wrong argument received in subclass")
 
     def test_signal_block(self):
         class TestSignals(Callback):
@@ -151,7 +151,7 @@ class TestCallback(unittest.TestCase):
         t.emit("test-signal", (1,))
 
         self.assertEqual(len(rl), 1, "No signal emitted")
-        self.assertEqual(rl[0], 1, "Wrong argument recieved")
+        self.assertEqual(rl[0], 1, "Wrong argument received")
 
         Callback.disable_all_signals()
         t.emit("test-signal", (1,))

--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -1800,7 +1800,7 @@ class GrampsPreferences(ConfigureDialog):
 
     def color_scheme_changed(self, obj):
         """
-        Called on swiching color scheme.
+        Called on switching color scheme.
         """
         scheme = obj.get_active()
         config.set("colors.scheme", scheme)

--- a/gramps/gui/editors/displaytabs/surnametab.py
+++ b/gramps/gui/editors/displaytabs/surnametab.py
@@ -315,7 +315,7 @@ class SurnameTab(EmbeddedList):
 
     def on_origcmb_change(self, cmb, path, colnr):
         """
-        A selection occured in the cmb of the origin type column. colnr must
+        A selection occurred in the cmb of the origin type column. colnr must
         be the column in the model.
         """
         act = cmb.get_active()

--- a/gramps/gui/views/treemodels/flatbasemodel.py
+++ b/gramps/gui/views/treemodels/flatbasemodel.py
@@ -186,7 +186,7 @@ class FlatNodeMap:
         This method keeps the index2hndl map, but sets it up the index in
         reverse order. If the hndl2index map does not exist yet, it is created
         in the acending order as given in index2hndl
-        The result is always a hndl2index map wich is correct, so or ascending
+        The result is always a hndl2index map which is correct, so or ascending
         order, or reverse order.
         """
         if self._hndl2index:

--- a/gramps/gui/widgets/fanchart.py
+++ b/gramps/gui/widgets/fanchart.py
@@ -1955,7 +1955,7 @@ class FanChartWidget(FanChartBaseWidget):
         return None
 
     def do_mouse_click(self):
-        # no drag occured, expand or collapse the section
+        # no drag occurred, expand or collapse the section
         self.toggle_cell_state(self._mouse_click_cell_address)
         self._mouse_click = False
         self.draw()

--- a/gramps/gui/widgets/fanchart2way.py
+++ b/gramps/gui/widgets/fanchart2way.py
@@ -732,7 +732,7 @@ class FanChart2WayWidget(FanChartWidget, FanChartDescWidget):
         return None
 
     def do_mouse_click(self):
-        # no drag occured, expand or collapse the section
+        # no drag occurred, expand or collapse the section
         self.toggle_cell_state(self._mouse_click_cell_address)
         self._mouse_click = False
         self.draw()

--- a/gramps/gui/widgets/fanchartdesc.py
+++ b/gramps/gui/widgets/fanchartdesc.py
@@ -743,7 +743,7 @@ class FanChartDescWidget(FanChartBaseWidget):
 
     def do_mouse_click(self):
         """
-        no drag occured, expand or collapse the section
+        no drag occurred, expand or collapse the section
         """
         self.toggle_cell_state(self._mouse_click_cell_address)
         self._compute_angles(*self.rootangle_rad)

--- a/gramps/gui/widgets/grampletpane.py
+++ b/gramps/gui/widgets/grampletpane.py
@@ -343,7 +343,7 @@ class GrampletWindow(ManagedWindow):
             expand = gramplet.gstate == "maximized" and gramplet.expand
             column.set_child_packing(gramplet.mainframe, expand, fill, padding, pack)
         # set_image on buttons as get_image is None in first run
-        # or point to invalid adress in every other run
+        # or point to invalid address in every other run
         self.gramplet.gvstate.set_image(self.gramplet.xml.get_object("gvstateimage"))
         self.gramplet.gvclose.set_image(self.gramplet.xml.get_object("gvcloseimage"))
         self.gramplet.gvproperties.set_image(

--- a/gramps/gui/widgets/validatedmaskedentry.py
+++ b/gramps/gui/widgets/validatedmaskedentry.py
@@ -135,7 +135,7 @@ class MaskedEntry(UndoableEntry):
         self._mask_validators = []
         self._mask = None
         # Fields defined by mask
-        # each item is a tuble, containing the begining and the end of the
+        # each item is a tuble, containing the beginning and the end of the
         # field in the text
         self._mask_fields = []
         self._current_field = -1
@@ -201,7 +201,6 @@ class MaskedEntry(UndoableEntry):
 
         mask = str(mask)
         input_length = len(mask)
-        lenght = 0
         pos = 0
         field_begin = 0
         field_end = 0

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -28,7 +28,6 @@ Database API interface
 #
 # -------------------------------------------------------------------------
 import logging
-import json
 import time
 
 from gramps.gen.const import GRAMPS_LOCALE as glocale

--- a/gramps/plugins/importer/importgeneweb.py
+++ b/gramps/plugins/importer/importgeneweb.py
@@ -579,7 +579,7 @@ class GeneWebParser:
                 idx += 1
             elif field == "#sep" and idx < len(fields):
                 sep_date = self.parse_date(self.decode(fields[idx]))
-                LOG.debug(" Seperated since: %s" % fields[idx])
+                LOG.debug(" Separated since: %s" % fields[idx])
                 idx += 1
             elif field == "#nm":
                 LOG.debug(" Are not married.")

--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -5214,7 +5214,7 @@ class GedcomParser(UpdateCallback):
         state.msg += sub_state.msg
 
         # if the handle is not already in the person's parent family list, we
-        # need to add it to thie list.
+        # need to add it to the list.
 
         flist = state.person.get_parent_family_handle_list()
         if handle not in flist:

--- a/gramps/plugins/tool/eventcmp.py
+++ b/gramps/plugins/tool/eventcmp.py
@@ -388,7 +388,7 @@ class EventComparisonResults(ManagedWindow):
         sort_list = [item[1] for item in unsort_list]
         ## Presently there's no Birth and Death. Instead there's Birth Date and
         ## Birth Place, as well as Death Date and Death Place.
-        ##         # Move birth and death to the begining of the list
+        ##         # Move birth and death to the beginning of the list
         ##         if _("Death") in the_map:
         ##             sort_list.remove(_("Death"))
         ##             sort_list = [_("Death")] + sort_list

--- a/gramps/plugins/tool/reorderids.py
+++ b/gramps/plugins/tool/reorderids.py
@@ -580,7 +580,7 @@ class ReorderIds(tool.BatchTool, ManagedWindow, UpdateCallback):
             )
 
     def _execute(self):
-        """execute all primary objects and reorder if neccessary"""
+        """execute all primary objects and reorder if necessary"""
 
         # Update progress calculation
         if self.uistate:

--- a/gramps/plugins/tool/testcasegenerator.py
+++ b/gramps/plugins/tool/testcasegenerator.py
@@ -204,7 +204,7 @@ LDS_SPOUSE_SEALING = [(LdsOrd.SEAL_TO_SPOUSE, LDS_SPOUSE_SEALING_DATE_STATUS)]
 
 class TestcaseGenerator(tool.BatchTool):
     """
-    This tool generates various test cases for problems that have occured.
+    This tool generates various test cases for problems that have occurred.
     The issues it generates can be corrected via the 'Check and Repair' tool.
     """
 

--- a/gramps/plugins/webreport/buchheim.py
+++ b/gramps/plugins/webreport/buchheim.py
@@ -257,7 +257,7 @@ def apportion(tree, default_ancestor, v_separation):
 
 def move_subtree(walk_l, walk_r, shift):
     """
-    Determine possible shifts required to accomodate new node, but don't
+    Determine possible shifts required to accommodate new node, but don't
     perform the shifts yet.
     """
     subtrees = walk_r.number - walk_l.number


### PR DESCRIPTION
A set of short [one line mostly] fixes for

- typos and obvious mistakes in comments
- mistake in log message
- remove unused imports
- make method signature consistent
- fix mistake in type hint

These have been separated out from #2232 