### PR TITLE
Fix PlaceDetails Gramplet

### DIFF
--- a/gramps/plugins/gramplet/placedetails.py
+++ b/gramps/plugins/gramplet/placedetails.py
@@ -128,7 +128,7 @@ class PlaceDetails(Gramplet):
 
         self.clear_grid()
         self.add_row(_("Name"), place.get_name().get_value())
-        self.add_row(_("Type"), place.get_type())
+        self.add_row(_("Type"), str(place.get_type()))
         self.display_separator()
         self.display_alt_names(place)
         self.display_separator()


### PR DESCRIPTION
The PlaceDetails gramplet is not displaying anything and generates an error to the console

```
  File "C:\msys64\home\steve\gramps2\gramps\gen\utils\callback.py", line 424, in emit
    fn(*args)
    ~~^^^^^^^
  File "C:\msys64\home\steve\gramps2\gramps\gen\plug\_gramplet.py", line 316, in update
    self._generator = self.main()
                      ~~~~~~~~~^^
  File "C:\msys64\home\steve\gramps2\gramps\plugins\gramplet\placedetails.py", line 112, in main
    self.display_place(place)
    ~~~~~~~~~~~~~~~~~~^^^^^^^
  File "C:\msys64\home\steve\gramps2\gramps\plugins\gramplet\placedetails.py", line 132, in display_place
    self.add_row(_("Type"), place.get_type())
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\msys64\home\steve\gramps2\gramps\plugins\gramplet\placedetails.py", line 81, in add_row
    value = Gtk.Label(label=value, halign=Gtk.Align.START)
  File "C:\msys64\ucrt64\lib\python3.14\site-packages\gi\overrides\__init__.py", line 357, in new_init
    return super_init_func(self, **new_kwargs)
TypeError: Must be string, not PlaceType
```

The message correctly identifies the problem.

**To reproduce**
1. configure Gramps so that the PlaceDetails gramplet is shown.
2. open a database with one or more places defined
3. switch to the places view
4. select a place.
5. observe that nothing is show in the PlaceDetails gramplet

**Background**
By @hgohel. Taken from #2239 
The argument label to Gtk.Label must be of type string. In recent versions of Python and/or PyGObject, this check has become stricter and as a result is throwing an exception instead of silently converting to a string. So now we explicitly convert to string.

Fixes #[14183](https://gramps-project.org/bugs/view.php?id=14183) which was reported for Place details. 

