### PR TITLE
Explicitly convert label parameter to string in Gtk.Label

### DIFF
--- a/gramps/plugins/gramplet/persondetails.py
+++ b/gramps/plugins/gramplet/persondetails.py
@@ -82,7 +82,7 @@ class PersonDetails(Gramplet):
         )
         label.set_selectable(True)
         label.show()
-        value = Gtk.Label(label=value, halign=Gtk.Align.START)
+        value = Gtk.Label(label=str(value), halign=Gtk.Align.START)
         value.set_selectable(True)
         value.show()
         self.grid.add(label)

--- a/gramps/plugins/gramplet/placedetails.py
+++ b/gramps/plugins/gramplet/placedetails.py
@@ -77,7 +77,7 @@ class PlaceDetails(Gramplet):
         )
         label.set_selectable(True)
         label.show()
-        value = Gtk.Label(label=value, halign=Gtk.Align.START)
+        value = Gtk.Label(label=str(value), halign=Gtk.Align.START)
         value.set_selectable(True)
         value.show()
         self.grid.add(label)

--- a/gramps/plugins/gramplet/repositorydetails.py
+++ b/gramps/plugins/gramplet/repositorydetails.py
@@ -72,7 +72,7 @@ class RepositoryDetails(Gramplet):
         )
         label.set_selectable(True)
         label.show()
-        value = Gtk.Label(label=value, halign=Gtk.Align.START)
+        value = Gtk.Label(label=str(value), halign=Gtk.Align.START)
         value.set_selectable(True)
         value.show()
         self.grid.add(label)


### PR DESCRIPTION
The argument `label` to Gtk.Label must be of type string. In recent versions of Python and/or PyGObject, this check has become stricter and as a result is throwing an exception instead of silently converting to a string. So now we explicitly convert to string.

Note: I have not been able to reproduce the crash as it is data and view configuration dependent, so it is important to validate the changes.

Fixes #[14183](https://gramps-project.org/bugs/view.php?id=14183) which was reported for Place details. However, similar code exists in both Person details and Repository details so I've made a defensive change in both those locations as well.