### PR TITLE
Log plugin registration and load failures instead of printing

### DIFF
--- a/gramps/gen/plug/_manager.py
+++ b/gramps/gen/plug/_manager.py
@@ -187,9 +187,13 @@ class BasePluginManager:
                             plugins_to_load.remove(plugin)
                 count += 1
                 if count > max_count:
-                    print("Cannot resolve the following plugin dependencies:")
+                    LOG.error("Cannot resolve the following plugin dependencies:")
                     for plugin in plugins_to_load:
-                        print(f"   Plugin '{plugin.id}' requires: {plugin.depends_on}")
+                        LOG.error(
+                            "   Plugin '%s' requires: %s",
+                            plugin.id,
+                            plugin.depends_on,
+                        )
                     break
             # now load them:
             for plugin in plugins_sorted:
@@ -201,16 +205,15 @@ class BasePluginManager:
                     # LOG.warning("\nRun %s at registration", plugin.id)
                     try:
                         results = mod.load_on_reg(dbstate, uistate, plugin)
-                    except:
-                        import traceback
-
-                        traceback.print_exc()
-                        print(f"Plugin '{plugin.name}' did not run; continuing...")
+                    except Exception:
+                        LOG.exception(
+                            "Plugin '%s' did not run; continuing...", plugin.name
+                        )
                         continue
                     try:
                         iter(results)
                         plugin.data += results
-                    except:
+                    except TypeError:
                         plugin.data = results
         # Get the addon rules and import them and make them findable
         for plugin in self.__pgr.rule_plugins():
@@ -279,10 +282,8 @@ class BasePluginManager:
                 self.__loaded_plugins[pdata.id] = _module
                 self.__mod2text[_module.__name__] = pdata.description
             return _module
-        except:
-            import traceback
-
-            traceback.print_exc()
+        except Exception:
+            LOG.exception("Failed to load plugin '%s' from %s", pdata.id, filename)
             self.__failmsg_list.append((filename, sys.exc_info(), pdata))
 
         return None
@@ -328,7 +329,7 @@ class BasePluginManager:
                     LOG.warning("Plugin error (from '%s'): %s", pdata.mod_name, err)
                 sys.path.pop(0)
             else:
-                print("WARNING: module cannot be loaded")
+                LOG.warning("Module cannot be loaded for plugin '%s'", pdata.id)
         else:
             module = __import__(pdata.mod_name)
         return module
@@ -367,7 +368,10 @@ class BasePluginManager:
                 self.reload(plugin[1], pdata)
                 self.__modules[filename] = plugin[1]
                 self.__loaded_plugins[pdata.id] = plugin[1]
-            except:
+            except Exception:
+                LOG.exception(
+                    "Failed to reload plugin '%s' from %s", pdata.id, filename
+                )
                 dellist.append(index)
                 self.__failmsg_list.append((filename, sys.exc_info(), pdata))
 
@@ -391,7 +395,7 @@ class BasePluginManager:
             spec = importlib.util.find_spec(pdata.mod_name, [pdata.fpath])
             module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)
-        except:
+        except Exception:
             if pdata.mod_name in sys.modules:
                 del sys.modules[pdata.mod_name]
             module = self.import_plugin(pdata)
@@ -508,7 +512,7 @@ class BasePluginManager:
             try:
                 iter(data)
                 retval.extend(data)
-            except:
+            except TypeError:
                 retval.append(data)
         return retval
 
@@ -534,7 +538,7 @@ class BasePluginManager:
                 try:
                     iter(data)
                     retval.extend(data)
-                except:
+                except TypeError:
                     retval.append(data)
         # LOG.warning("Process plugin data=%s, %s, items=%s",
         #             process is not None, category, len(retval))

--- a/gramps/gen/plug/_pluginreg.py
+++ b/gramps/gen/plug/_pluginreg.py
@@ -33,7 +33,6 @@ import logging
 import os
 import re
 import sys
-import traceback
 
 # -------------------------------------------------------------------------
 #
@@ -1401,24 +1400,17 @@ class PluginRegister:
             try:
                 with open(full_filename, "r", encoding="utf-8") as file_descriptor:
                     stream = file_descriptor.read()
-            except Exception as msg:
-                print(
-                    _("ERROR: Failed reading plugin registration %(filename)s")
-                    % {"filename": filename}
-                )
-                print(msg)
+            except (OSError, UnicodeDecodeError):
+                LOG.exception("Failed reading plugin registration %s", filename)
                 continue
             if os.path.exists(os.path.join(os.path.dirname(full_filename), "locale")):
                 try:
                     local_gettext = glocale.get_addon_translator(full_filename).gettext
                 except ValueError:
-                    print(
-                        _(
-                            "WARNING: Plugin %(plugin_name)s has no translation"
-                            " for any of your configured languages, using US"
-                            " English instead"
-                        )
-                        % {"plugin_name": filename.split(".")[0]}
+                    LOG.warning(
+                        "Plugin %s has no translation for any of your"
+                        " configured languages, using US English instead",
+                        filename.split(".")[0],
                     )
                     local_gettext = glocale.translation.gettext
             else:
@@ -1437,18 +1429,10 @@ class PluginRegister:
                         lenpd -= 1
                     self.__id_to_pdata[pdata.id] = pdata
             except ValueError as msg:
-                print(
-                    _("ERROR: Failed reading plugin registration %(filename)s")
-                    % {"filename": filename}
-                )
-                print(msg)
+                LOG.error("Failed reading plugin registration %s: %s", filename, msg)
                 self.__plugindata = self.__plugindata[:lenpd]
-            except:
-                print(
-                    _("ERROR: Failed reading plugin registration %(filename)s")
-                    % {"filename": filename}
-                )
-                print("".join(traceback.format_exception(*sys.exc_info())))
+            except Exception:
+                LOG.exception("Failed reading plugin registration %s", filename)
                 self.__plugindata = self.__plugindata[:lenpd]
             # check if:
             #  1. plugin exists, if not remove, otherwise set module name
@@ -1461,17 +1445,12 @@ class PluginRegister:
                 ind += 1
                 plugin.directory = directory
                 if not valid_plugin_version(plugin.gramps_target_version):
-                    print(
-                        _(
-                            "ERROR: Plugin file %(filename)s has a version of "
-                            '"%(gramps_target_version)s" which is invalid for Gramps '
-                            '"%(gramps_version)s".'
-                            % {
-                                "filename": os.path.join(directory, plugin.fname),
-                                "gramps_version": GRAMPSVERSION,
-                                "gramps_target_version": plugin.gramps_target_version,
-                            }
-                        )
+                    LOG.error(
+                        'Plugin file %s has a version of "%s" which is'
+                        ' invalid for Gramps "%s".',
+                        os.path.join(directory, plugin.fname),
+                        plugin.gramps_target_version,
+                        GRAMPSVERSION,
                     )
                     rmlist.append(ind)
                     continue
@@ -1489,28 +1468,18 @@ class PluginRegister:
                 match = pymod.match(plugin.fname)
                 if not match:
                     rmlist.append(ind)
-                    print(
-                        _(
-                            "ERROR: Wrong python file %(filename)s in register file "
-                            "%(regfile)s"
-                        )
-                        % {
-                            "filename": os.path.join(directory, plugin.fname),
-                            "regfile": os.path.join(directory, filename),
-                        }
+                    LOG.error(
+                        "Wrong python file %s in register file %s",
+                        os.path.join(directory, plugin.fname),
+                        os.path.join(directory, filename),
                     )
                     continue
                 if not os.path.isfile(os.path.join(directory, plugin.fname)):
                     rmlist.append(ind)
-                    print(
-                        _(
-                            "ERROR: Python file %(filename)s in register file "
-                            "%(regfile)s does not exist"
-                        )
-                        % {
-                            "filename": os.path.join(directory, plugin.fname),
-                            "regfile": os.path.join(directory, filename),
-                        }
+                    LOG.error(
+                        "Python file %s in register file %s does not exist",
+                        os.path.join(directory, plugin.fname),
+                        os.path.join(directory, filename),
                     )
                     continue
                 module = match.groups()[0]

--- a/gramps/gen/plug/test/_pluginreg_errors_test.py
+++ b/gramps/gen/plug/test/_pluginreg_errors_test.py
@@ -1,0 +1,96 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Eduard Ralph
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Tests that the plugin registration scanner logs errors rather than crashing
+and leaves no partial registrations behind when a gpr.py fails.
+"""
+
+# ------------------------
+# Python modules
+# ------------------------
+import os
+import tempfile
+import unittest
+
+# ------------------------
+# Gramps modules
+# ------------------------
+from .._pluginreg import PluginRegister
+
+
+# ------------------------------------------------------------
+#
+# PluginRegScanErrorsTest
+#
+# ------------------------------------------------------------
+class PluginRegScanErrorsTest(unittest.TestCase):
+    """Exercise the error paths in ``PluginRegister.scan_dir``."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.directory = self._tmp.name
+        self.registry = PluginRegister.get_instance()
+        # name-mangled access; the registry is a singleton and other tests
+        # may have populated it, so we measure deltas against a snapshot.
+        self._before_pdata = list(self.registry._PluginRegister__plugindata)
+        self._before_ids = dict(self.registry._PluginRegister__id_to_pdata)
+
+    def tearDown(self) -> None:
+        self.registry._PluginRegister__plugindata = self._before_pdata
+        self.registry._PluginRegister__id_to_pdata = self._before_ids
+
+    def _write_gpr(self, name: str, body: str, *, encoding: str = "utf-8") -> str:
+        path = os.path.join(self.directory, name)
+        with open(path, "w", encoding=encoding) as file_descriptor:
+            file_descriptor.write(body)
+        return name
+
+    def test_runtime_error_in_gpr_is_caught_and_logged(self) -> None:
+        """A non-ValueError raised by a gpr.py must be logged, not propagated."""
+        self._write_gpr("broken.gpr.py", "raise RuntimeError('kaboom')\n")
+        with self.assertLogs("._manager", level="ERROR") as captured:
+            self.registry.scan_dir(self.directory, ["broken.gpr.py"])
+        joined = "\n".join(captured.output)
+        self.assertIn("Failed reading plugin registration", joined)
+        self.assertIn("broken.gpr.py", joined)
+        added = self.registry._PluginRegister__plugindata[len(self._before_pdata) :]
+        self.assertEqual(added, [], "No plugin data should be registered on failure")
+
+    def test_value_error_in_gpr_is_caught_and_logged(self) -> None:
+        """ValueError has its own except arm; ensure it still logs."""
+        self._write_gpr("bad_value.gpr.py", "raise ValueError('bad value')\n")
+        with self.assertLogs("._manager", level="ERROR") as captured:
+            self.registry.scan_dir(self.directory, ["bad_value.gpr.py"])
+        self.assertIn("bad_value.gpr.py", "\n".join(captured.output))
+
+    def test_non_utf8_gpr_is_caught_and_logged(self) -> None:
+        """A gpr.py with non-UTF-8 bytes must not crash the scan."""
+        path = os.path.join(self.directory, "bad_bytes.gpr.py")
+        with open(path, "wb") as file_descriptor:
+            file_descriptor.write(b"\xff\xfe not utf-8 bytes")
+        with self.assertLogs("._manager", level="ERROR") as captured:
+            self.registry.scan_dir(self.directory, ["bad_bytes.gpr.py"])
+        self.assertIn("bad_bytes.gpr.py", "\n".join(captured.output))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -212,6 +212,11 @@ gramps/gen/plug/_export.py
 gramps/gen/plug/_import.py
 gramps/gen/plug/_plugin.py
 #
+# gen.plug.test
+#
+gramps/gen/plug/test/__init__.py
+gramps/gen/plug/test/_pluginreg_errors_test.py
+#
 # gen.plug.docbackend
 #
 gramps/gen/plug/docbackend/__init__.py


### PR DESCRIPTION
## Summary
**User impact:** When an add-on fails to load or register, the error is printed to the terminal — where it is easy to miss and hard to capture in a bug report — instead of going through Gramps' normal message channel. In the worst case a stray failure in one add-on could swallow an unrelated interruption (like Ctrl-C).

This routes every plugin scan/load failure through Gramps' logging so the diagnostics land in one place users and packagers can control and attach to reports.

Origin: robustness / code-quality change to the plugin loader — no Mantis tracker ticket.

## What to look at
The change swaps bare `except:` clauses for typed handlers and replaces `print()` / `traceback.print_exc()` with logger calls, while keeping the tuple shape `get_fail_list()` returns so the existing GUI error dialog is untouched. To try it: install a deliberately broken third-party add-on and watch the failure surface through the logger instead of stdout, with `KeyboardInterrupt` / `SystemExit` still propagating.

## Root cause
Bare `except:` clauses in `gramps/gen/plug/_manager.py` and `gramps/gen/plug/_pluginreg.py` catch everything — including `KeyboardInterrupt` / `SystemExit` — and plugin scan/load diagnostics are emitted to `stdout` via `print()` / `traceback.print_exc()`, so a single broken add-on can silently swallow diagnostics or risk propagating an unrelated exception through the scanner.

## Fix
- Replace the bare `except:` clauses in `gramps/gen/plug/_manager.py` and `gramps/gen/plug/_pluginreg.py` with typed exception handlers (`Exception`, `TypeError`, `(OSError, UnicodeDecodeError)`), so genuine programming errors and `KeyboardInterrupt` propagate naturally.
- Route all plugin scan and load diagnostics through module loggers (`LOG.error`, `LOG.exception`, `LOG.warning`) instead of `print()` / `traceback.print_exc()`.
- Preserve the `(filename, sys.exc_info(), pdata)` shape returned by `BasePluginManager.get_fail_list()` so the existing GUI error dialog (`gramps/gui/viewmanager.py`, `gramps/gui/plug/_windows.py`) keeps working unchanged.
- Translatable strings: several scan diagnostics in `_pluginreg.py` / `_manager.py` that were previously wrapped in `_()` and `print()`ed are now unwrapped `LOG.*` messages (diagnostic log output is not localized). `_pluginreg.py` keeps other translatable strings, so no `po/POTFILES.in` change is required for it; only the new test module is added to `po/POTFILES.skip`. The touched function bodies (`reg_plugins`, `load_plugin`, `import_plugin`, `reload`, `reload_plugins`, `get_plugin_data`, `process_plugin_data`, `scan_dir`) already carry no type hints; retrofitting hints is intentionally left out to keep this to one concern.

## Verification
- **Claim:** plugin scan/load failures are reported through module loggers and no longer suppress `KeyboardInterrupt` / `SystemExit`, while the `get_fail_list()` tuple contract is unchanged.
- **Checked:** `gramps/gen/plug/_manager.py`, `gramps/gen/plug/_pluginreg.py` on maintenance/gramps60 (the branch this PR targets) — typed excepts plus `LOG.*` calls; `(filename, sys.exc_info(), pdata)` preserved for the GUI dialog.
- **Test:** `gramps/gen/plug/test/_pluginreg_errors_test.py` (new) exercises the error paths in `PluginRegister.scan_dir` for `RuntimeError`, `ValueError`, and non-UTF-8 bytes in a `gpr.py`, asserting `LOG.exception` fires via `assertLogs("._manager", level="ERROR")` for each arm. Full suite: 32,502 tests, only the two pre-existing unrelated `test_WebCal` / `test_navwebpage` CSS failures; `mypy` and `black --check` clean on the touched files.

No Mantis tracker ticket — this is an internal robustness / logging change.
