### PR TITLE
Make plugin scan and import transactional against failures

### DIFF
--- a/gramps/gen/plug/_manager.py
+++ b/gramps/gen/plug/_manager.py
@@ -187,9 +187,13 @@ class BasePluginManager:
                             plugins_to_load.remove(plugin)
                 count += 1
                 if count > max_count:
-                    print("Cannot resolve the following plugin dependencies:")
+                    LOG.error("Cannot resolve the following plugin dependencies:")
                     for plugin in plugins_to_load:
-                        print(f"   Plugin '{plugin.id}' requires: {plugin.depends_on}")
+                        LOG.error(
+                            "   Plugin '%s' requires: %s",
+                            plugin.id,
+                            plugin.depends_on,
+                        )
                     break
             # now load them:
             for plugin in plugins_sorted:
@@ -201,16 +205,15 @@ class BasePluginManager:
                     # LOG.warning("\nRun %s at registration", plugin.id)
                     try:
                         results = mod.load_on_reg(dbstate, uistate, plugin)
-                    except:
-                        import traceback
-
-                        traceback.print_exc()
-                        print(f"Plugin '{plugin.name}' did not run; continuing...")
+                    except Exception:
+                        LOG.exception(
+                            "Plugin '%s' did not run; continuing...", plugin.name
+                        )
                         continue
                     try:
                         iter(results)
                         plugin.data += results
-                    except:
+                    except TypeError:
                         plugin.data = results
         # Get the addon rules and import them and make them findable
         for plugin in self.__pgr.rule_plugins():
@@ -279,10 +282,8 @@ class BasePluginManager:
                 self.__loaded_plugins[pdata.id] = _module
                 self.__mod2text[_module.__name__] = pdata.description
             return _module
-        except:
-            import traceback
-
-            traceback.print_exc()
+        except Exception:
+            LOG.exception("Failed to load plugin '%s' from %s", pdata.id, filename)
             self.__failmsg_list.append((filename, sys.exc_info(), pdata))
 
         return None
@@ -328,7 +329,7 @@ class BasePluginManager:
                     LOG.warning("Plugin error (from '%s'): %s", pdata.mod_name, err)
                 sys.path.pop(0)
             else:
-                print("WARNING: module cannot be loaded")
+                LOG.warning("Module cannot be loaded for plugin '%s'", pdata.id)
         else:
             module = __import__(pdata.mod_name)
         return module
@@ -367,7 +368,10 @@ class BasePluginManager:
                 self.reload(plugin[1], pdata)
                 self.__modules[filename] = plugin[1]
                 self.__loaded_plugins[pdata.id] = plugin[1]
-            except:
+            except Exception:
+                LOG.exception(
+                    "Failed to reload plugin '%s' from %s", pdata.id, filename
+                )
                 dellist.append(index)
                 self.__failmsg_list.append((filename, sys.exc_info(), pdata))
 
@@ -391,7 +395,7 @@ class BasePluginManager:
             spec = importlib.util.find_spec(pdata.mod_name, [pdata.fpath])
             module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)
-        except:
+        except Exception:
             if pdata.mod_name in sys.modules:
                 del sys.modules[pdata.mod_name]
             module = self.import_plugin(pdata)
@@ -508,7 +512,7 @@ class BasePluginManager:
             try:
                 iter(data)
                 retval.extend(data)
-            except:
+            except TypeError:
                 retval.append(data)
         return retval
 
@@ -534,7 +538,7 @@ class BasePluginManager:
                 try:
                     iter(data)
                     retval.extend(data)
-                except:
+                except TypeError:
                     retval.append(data)
         # LOG.warning("Process plugin data=%s, %s, items=%s",
         #             process is not None, category, len(retval))

--- a/gramps/gen/plug/_manager.py
+++ b/gramps/gen/plug/_manager.py
@@ -38,6 +38,8 @@ import importlib
 import logging
 import os
 import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 # -------------------------------------------------------------------------
 #
@@ -61,6 +63,28 @@ _ = glocale.translation.gettext
 #
 # -------------------------------------------------------------------------
 _UNAVAILABLE = _("No description was provided")
+
+
+@contextmanager
+def _prepended_sys_path(path: str) -> Iterator[None]:
+    """Temporarily prepend *path* to ``sys.path``.
+
+    The entry is removed on exit regardless of how the ``with`` block
+    terminates, so plugin import failures cannot leak ``sys.path``
+    entries into the rest of the process.
+    """
+    inserted = False
+    if path and path not in sys.path:
+        sys.path.insert(0, path)
+        inserted = True
+    try:
+        yield
+    finally:
+        if inserted:
+            try:
+                sys.path.remove(path)
+            except ValueError:
+                pass
 
 
 # -------------------------------------------------------------------------
@@ -292,47 +316,46 @@ class BasePluginManager:
         """
         Rather than just __import__(id), this will add the pdata.fpath
         to sys.path first (if needed), import, and then reset path.
+
+        ``sys.path`` is restored to its prior state even when the import
+        raises an unexpected exception.
         """
-        module = None
         if isinstance(pdata, str):
             pdata = self.get_plugin(pdata)
         if not pdata:
             return None
-        if pdata.fpath not in sys.path:
-            if pdata.mod_name:
-                sys.path.insert(0, pdata.fpath)
-                try:
-                    module = __import__(pdata.mod_name)
-                except ValueError as err:
-                    # Python3 on Windows  work with unicode in sys.path
-                    # but they are mbcs encode for checking validity
-                    if win():
-                        # we don't want to load Gramps core plugin like this
-                        # only 3rd party plugins
-                        if "gramps" in pdata.fpath:
+        if pdata.fpath in sys.path:
+            return __import__(pdata.mod_name) if pdata.mod_name else None
+        if not pdata.mod_name:
+            LOG.warning("Module cannot be loaded for plugin '%s'", pdata.id)
+            return None
+        with _prepended_sys_path(pdata.fpath):
+            try:
+                return __import__(pdata.mod_name)
+            except ValueError as err:
+                # Python 3 on Windows works with unicode in sys.path but
+                # mbcs-encodes for checking validity. Retry third-party
+                # plugins after cd'ing into the plugin directory.
+                if win() and "gramps" in pdata.fpath:
+                    oldwd = os.getcwd()
+                    try:
+                        os.chdir(pdata.fpath)
+                        with _prepended_sys_path("."):
                             try:
-                                sys.path.insert(0, ".")
-                                oldwd = os.getcwd()
-                                os.chdir(pdata.fpath)
-                                module = __import__(pdata.mod_name)
-                                os.chdir(oldwd)
-                                sys.path.pop(0)
+                                return __import__(pdata.mod_name)
                             except ValueError as error:
                                 LOG.warning(
                                     "Plugin error (from '%s'): %s",
                                     pdata.mod_name,
                                     error,
                                 )
-                    else:
-                        LOG.warning("Plugin error (from '%s'): %s", pdata.mod_name, err)
-                except ImportError as err:
+                    finally:
+                        os.chdir(oldwd)
+                else:
                     LOG.warning("Plugin error (from '%s'): %s", pdata.mod_name, err)
-                sys.path.pop(0)
-            else:
-                LOG.warning("Module cannot be loaded for plugin '%s'", pdata.id)
-        else:
-            module = __import__(pdata.mod_name)
-        return module
+            except ImportError as err:
+                LOG.warning("Plugin error (from '%s'): %s", pdata.mod_name, err)
+        return None
 
     def empty_managed_plugins(self):
         """For some plugins, managed Plugin are used. These are only

--- a/gramps/gen/plug/_pluginreg.py
+++ b/gramps/gen/plug/_pluginreg.py
@@ -33,6 +33,7 @@ import logging
 import os
 import re
 import sys
+from typing import Any
 
 # -------------------------------------------------------------------------
 #
@@ -1382,6 +1383,11 @@ class PluginRegister:
         The dir name will be scanned for plugin registration code, which will
         be loaded in :class:`PluginData` objects if they satisfy some checks.
 
+        Per-file processing is transactional: if a ``.gpr.py`` fails at any
+        point (read, exec, registration, or validation), the internal plugin
+        registry is rolled back to the state it had before the file was
+        processed. Other files in the same scan continue to be processed.
+
         :returns: A list with :class:`PluginData` objects
         """
         # if the directory does not exist, do nothing
@@ -1390,106 +1396,129 @@ class PluginRegister:
 
         ext = r".gpr.py"
         extlen = -len(ext)
-        pymod = re.compile(r"^(.*)\.py$")
 
         for filename in filenames:
             if not filename[extlen:] == ext:
                 continue
-            lenpd = len(self.__plugindata)
-            full_filename = os.path.join(directory, filename)
+            plugindata_snapshot = list(self.__plugindata)
+            id_to_pdata_snapshot = dict(self.__id_to_pdata)
             try:
-                with open(full_filename, "r", encoding="utf-8") as file_descriptor:
-                    stream = file_descriptor.read()
+                self.__scan_file(directory, filename, uistate)
             except (OSError, UnicodeDecodeError):
                 LOG.exception("Failed reading plugin registration %s", filename)
-                continue
-            if os.path.exists(os.path.join(os.path.dirname(full_filename), "locale")):
-                try:
-                    local_gettext = glocale.get_addon_translator(full_filename).gettext
-                except ValueError:
-                    LOG.warning(
-                        "Plugin %s has no translation for any of your"
-                        " configured languages, using US English instead",
-                        filename.split(".")[0],
-                    )
-                    local_gettext = glocale.translation.gettext
-            else:
-                local_gettext = glocale.translation.gettext
-            try:
-                exec(
-                    compile(stream, filename, "exec"),
-                    make_environment(_=local_gettext),
-                    {"uistate": uistate},
-                )
-                for pdata in self.__plugindata[lenpd:]:
-                    if pdata.id in self.__id_to_pdata:
-                        # reloading
-                        old = self.__id_to_pdata[pdata.id]
-                        self.__plugindata.remove(old)
-                        lenpd -= 1
-                    self.__id_to_pdata[pdata.id] = pdata
+                self.__plugindata = plugindata_snapshot
+                self.__id_to_pdata = id_to_pdata_snapshot
             except ValueError as msg:
                 LOG.error("Failed reading plugin registration %s: %s", filename, msg)
-                self.__plugindata = self.__plugindata[:lenpd]
+                self.__plugindata = plugindata_snapshot
+                self.__id_to_pdata = id_to_pdata_snapshot
             except Exception:
                 LOG.exception("Failed reading plugin registration %s", filename)
-                self.__plugindata = self.__plugindata[:lenpd]
-            # check if:
-            #  1. plugin exists, if not remove, otherwise set module name
-            #  2. plugin not stable, if stable_only=True, remove
-            #  3. TOOL_DEBUG only if DEBUG True
-            rmlist = []
-            ind = lenpd - 1
-            for plugin in self.__plugindata[lenpd:]:
-                # LOG.warning("\nPlugin scanned %s at registration", plugin.id)
-                ind += 1
-                plugin.directory = directory
-                if not valid_plugin_version(plugin.gramps_target_version):
-                    LOG.error(
-                        'Plugin file %s has a version of "%s" which is'
-                        ' invalid for Gramps "%s".',
-                        os.path.join(directory, plugin.fname),
-                        plugin.gramps_target_version,
-                        GRAMPSVERSION,
-                    )
-                    rmlist.append(ind)
-                    continue
-                if not self.__req.check_plugin(plugin):
-                    rmlist.append(ind)
-                    continue
-                if plugin.status == UNSTABLE and self.stable_only:
-                    rmlist.append(ind)
-                    continue
-                if plugin.ptype == TOOL and plugin.category == TOOL_DEBUG and not DEBUG:
-                    rmlist.append(ind)
-                    continue
-                if plugin.fname is None:
-                    continue
-                match = pymod.match(plugin.fname)
-                if not match:
-                    rmlist.append(ind)
-                    LOG.error(
-                        "Wrong python file %s in register file %s",
-                        os.path.join(directory, plugin.fname),
-                        os.path.join(directory, filename),
-                    )
-                    continue
-                if not os.path.isfile(os.path.join(directory, plugin.fname)):
-                    rmlist.append(ind)
-                    LOG.error(
-                        "Python file %s in register file %s does not exist",
-                        os.path.join(directory, plugin.fname),
-                        os.path.join(directory, filename),
-                    )
-                    continue
-                module = match.groups()[0]
-                plugin.mod_name = module
-                plugin.fpath = directory
-                # LOG.warning("\nPlugin added %s at registration", plugin.id)
-            rmlist.reverse()
-            for ind in rmlist:
-                del self.__id_to_pdata[self.__plugindata[ind].id]
-                del self.__plugindata[ind]
+                self.__plugindata = plugindata_snapshot
+                self.__id_to_pdata = id_to_pdata_snapshot
+
+    def __scan_file(self, directory: str, filename: str, uistate: Any) -> None:
+        """
+        Read and execute one ``.gpr.py`` file, registering and validating
+        its plugins.
+
+        On any failure this method raises; the caller is responsible for
+        rolling back ``__plugindata`` and ``__id_to_pdata``.
+
+        :param directory: The directory containing the registration file.
+        :type directory: str
+        :param filename: The name of the ``.gpr.py`` file in *directory*.
+        :type filename: str
+        :param uistate: The Gramps UI state, or ``None`` when scanning
+                        without a running UI; passed through to the
+                        registration file's execution environment.
+        :type uistate: Any
+        :returns: Nothing.
+        :rtype: None
+        """
+        pymod = re.compile(r"^(.*)\.py$")
+        lenpd = len(self.__plugindata)
+        full_filename = os.path.join(directory, filename)
+        with open(full_filename, "r", encoding="utf-8") as file_descriptor:
+            stream = file_descriptor.read()
+        if os.path.exists(os.path.join(os.path.dirname(full_filename), "locale")):
+            try:
+                local_gettext = glocale.get_addon_translator(full_filename).gettext
+            except ValueError:
+                LOG.warning(
+                    "Plugin %s has no translation for any of your"
+                    " configured languages, using US English instead",
+                    filename.split(".")[0],
+                )
+                local_gettext = glocale.translation.gettext
+        else:
+            local_gettext = glocale.translation.gettext
+        exec(
+            compile(stream, filename, "exec"),
+            make_environment(_=local_gettext),
+            {"uistate": uistate},
+        )
+        for pdata in self.__plugindata[lenpd:]:
+            if pdata.id in self.__id_to_pdata:
+                # reloading
+                old = self.__id_to_pdata[pdata.id]
+                self.__plugindata.remove(old)
+                lenpd -= 1
+            self.__id_to_pdata[pdata.id] = pdata
+        # check if:
+        #  1. plugin exists, if not remove, otherwise set module name
+        #  2. plugin not stable, if stable_only=True, remove
+        #  3. TOOL_DEBUG only if DEBUG True
+        rmlist = []
+        ind = lenpd - 1
+        for plugin in self.__plugindata[lenpd:]:
+            ind += 1
+            plugin.directory = directory
+            if not valid_plugin_version(plugin.gramps_target_version):
+                LOG.error(
+                    'Plugin file %s has a version of "%s" which is'
+                    ' invalid for Gramps "%s".',
+                    os.path.join(directory, plugin.fname),
+                    plugin.gramps_target_version,
+                    GRAMPSVERSION,
+                )
+                rmlist.append(ind)
+                continue
+            if not self.__req.check_plugin(plugin):
+                rmlist.append(ind)
+                continue
+            if plugin.status == UNSTABLE and self.stable_only:
+                rmlist.append(ind)
+                continue
+            if plugin.ptype == TOOL and plugin.category == TOOL_DEBUG and not DEBUG:
+                rmlist.append(ind)
+                continue
+            if plugin.fname is None:
+                continue
+            match = pymod.match(plugin.fname)
+            if not match:
+                rmlist.append(ind)
+                LOG.error(
+                    "Wrong python file %s in register file %s",
+                    os.path.join(directory, plugin.fname),
+                    os.path.join(directory, filename),
+                )
+                continue
+            if not os.path.isfile(os.path.join(directory, plugin.fname)):
+                rmlist.append(ind)
+                LOG.error(
+                    "Python file %s in register file %s does not exist",
+                    os.path.join(directory, plugin.fname),
+                    os.path.join(directory, filename),
+                )
+                continue
+            module = match.groups()[0]
+            plugin.mod_name = module
+            plugin.fpath = directory
+        rmlist.reverse()
+        for ind in rmlist:
+            del self.__id_to_pdata[self.__plugindata[ind].id]
+            del self.__plugindata[ind]
 
     def get_plugin(self, plugin_id):
         """

--- a/gramps/gen/plug/_pluginreg.py
+++ b/gramps/gen/plug/_pluginreg.py
@@ -33,7 +33,6 @@ import logging
 import os
 import re
 import sys
-import traceback
 
 # -------------------------------------------------------------------------
 #
@@ -1401,24 +1400,17 @@ class PluginRegister:
             try:
                 with open(full_filename, "r", encoding="utf-8") as file_descriptor:
                     stream = file_descriptor.read()
-            except Exception as msg:
-                print(
-                    _("ERROR: Failed reading plugin registration %(filename)s")
-                    % {"filename": filename}
-                )
-                print(msg)
+            except (OSError, UnicodeDecodeError):
+                LOG.exception("Failed reading plugin registration %s", filename)
                 continue
             if os.path.exists(os.path.join(os.path.dirname(full_filename), "locale")):
                 try:
                     local_gettext = glocale.get_addon_translator(full_filename).gettext
                 except ValueError:
-                    print(
-                        _(
-                            "WARNING: Plugin %(plugin_name)s has no translation"
-                            " for any of your configured languages, using US"
-                            " English instead"
-                        )
-                        % {"plugin_name": filename.split(".")[0]}
+                    LOG.warning(
+                        "Plugin %s has no translation for any of your"
+                        " configured languages, using US English instead",
+                        filename.split(".")[0],
                     )
                     local_gettext = glocale.translation.gettext
             else:
@@ -1437,18 +1429,10 @@ class PluginRegister:
                         lenpd -= 1
                     self.__id_to_pdata[pdata.id] = pdata
             except ValueError as msg:
-                print(
-                    _("ERROR: Failed reading plugin registration %(filename)s")
-                    % {"filename": filename}
-                )
-                print(msg)
+                LOG.error("Failed reading plugin registration %s: %s", filename, msg)
                 self.__plugindata = self.__plugindata[:lenpd]
-            except:
-                print(
-                    _("ERROR: Failed reading plugin registration %(filename)s")
-                    % {"filename": filename}
-                )
-                print("".join(traceback.format_exception(*sys.exc_info())))
+            except Exception:
+                LOG.exception("Failed reading plugin registration %s", filename)
                 self.__plugindata = self.__plugindata[:lenpd]
             # check if:
             #  1. plugin exists, if not remove, otherwise set module name
@@ -1461,17 +1445,12 @@ class PluginRegister:
                 ind += 1
                 plugin.directory = directory
                 if not valid_plugin_version(plugin.gramps_target_version):
-                    print(
-                        _(
-                            "ERROR: Plugin file %(filename)s has a version of "
-                            '"%(gramps_target_version)s" which is invalid for Gramps '
-                            '"%(gramps_version)s".'
-                            % {
-                                "filename": os.path.join(directory, plugin.fname),
-                                "gramps_version": GRAMPSVERSION,
-                                "gramps_target_version": plugin.gramps_target_version,
-                            }
-                        )
+                    LOG.error(
+                        'Plugin file %s has a version of "%s" which is'
+                        ' invalid for Gramps "%s".',
+                        os.path.join(directory, plugin.fname),
+                        plugin.gramps_target_version,
+                        GRAMPSVERSION,
                     )
                     rmlist.append(ind)
                     continue
@@ -1489,28 +1468,18 @@ class PluginRegister:
                 match = pymod.match(plugin.fname)
                 if not match:
                     rmlist.append(ind)
-                    print(
-                        _(
-                            "ERROR: Wrong python file %(filename)s in register file "
-                            "%(regfile)s"
-                        )
-                        % {
-                            "filename": os.path.join(directory, plugin.fname),
-                            "regfile": os.path.join(directory, filename),
-                        }
+                    LOG.error(
+                        "Wrong python file %s in register file %s",
+                        os.path.join(directory, plugin.fname),
+                        os.path.join(directory, filename),
                     )
                     continue
                 if not os.path.isfile(os.path.join(directory, plugin.fname)):
                     rmlist.append(ind)
-                    print(
-                        _(
-                            "ERROR: Python file %(filename)s in register file "
-                            "%(regfile)s does not exist"
-                        )
-                        % {
-                            "filename": os.path.join(directory, plugin.fname),
-                            "regfile": os.path.join(directory, filename),
-                        }
+                    LOG.error(
+                        "Python file %s in register file %s does not exist",
+                        os.path.join(directory, plugin.fname),
+                        os.path.join(directory, filename),
                     )
                     continue
                 module = match.groups()[0]

--- a/gramps/gen/plug/test/_manager_import_test.py
+++ b/gramps/gen/plug/test/_manager_import_test.py
@@ -1,0 +1,143 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Eduard Ralph
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Tests that ``BasePluginManager.import_plugin`` does not leak ``sys.path``
+entries, even when the imported plugin module raises an unexpected
+exception.
+"""
+
+# ------------------------
+# Python modules
+# ------------------------
+import os
+import sys
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+# ------------------------
+# Gramps modules
+# ------------------------
+from .._manager import BasePluginManager, _prepended_sys_path
+
+
+# ------------------------------------------------------------
+#
+# PluginImportSysPathTest
+#
+# ------------------------------------------------------------
+class PluginImportSysPathTest(unittest.TestCase):
+    """Exercise the ``sys.path`` invariants of ``import_plugin``."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.directory = self._tmp.name
+        self.manager = BasePluginManager.get_instance()
+        self._sys_path_before = list(sys.path)
+        self._sys_modules_before = set(sys.modules)
+
+    def tearDown(self) -> None:
+        sys.path[:] = self._sys_path_before
+        for modname in list(sys.modules):
+            if modname not in self._sys_modules_before:
+                del sys.modules[modname]
+
+    def _pdata(self, mod_name: str, plugin_id: str = "tpl") -> SimpleNamespace:
+        return SimpleNamespace(fpath=self.directory, mod_name=mod_name, id=plugin_id)
+
+    def _write_module(self, name: str, body: str) -> None:
+        path = os.path.join(self.directory, name + ".py")
+        with open(path, "w", encoding="utf-8") as file_descriptor:
+            file_descriptor.write(body)
+
+    def test_successful_import_does_not_leak_sys_path(self) -> None:
+        """sys.path must be pristine after a successful import."""
+        self._write_module("gramps_test_ok_mod", "VALUE = 42\n")
+        pdata = self._pdata("gramps_test_ok_mod")
+        module = self.manager.import_plugin(pdata)
+        self.assertIsNotNone(module)
+        self.assertEqual(sys.path, self._sys_path_before)
+        self.assertNotIn(self.directory, sys.path)
+
+    def test_import_error_does_not_leak_sys_path(self) -> None:
+        """ImportError is caught and sys.path is still restored."""
+        self._write_module(
+            "gramps_test_bad_mod",
+            "import this_module_does_not_exist_xyzzy\n",
+        )
+        pdata = self._pdata("gramps_test_bad_mod")
+        result = self.manager.import_plugin(pdata)
+        self.assertIsNone(result)
+        self.assertEqual(sys.path, self._sys_path_before)
+
+    def test_unexpected_exception_does_not_leak_sys_path(self) -> None:
+        """An uncaught exception from the plugin module must still restore
+        sys.path via the context manager's finally clause."""
+        self._write_module(
+            "gramps_test_raises_mod",
+            "raise RuntimeError('oops at import time')\n",
+        )
+        pdata = self._pdata("gramps_test_raises_mod")
+        with self.assertRaises(RuntimeError):
+            self.manager.import_plugin(pdata)
+        self.assertEqual(sys.path, self._sys_path_before)
+
+
+# ------------------------------------------------------------
+#
+# PrependedSysPathTest
+#
+# ------------------------------------------------------------
+class PrependedSysPathTest(unittest.TestCase):
+    """Direct unit tests for the ``_prepended_sys_path`` context manager."""
+
+    def test_inserts_and_removes_new_entry(self) -> None:
+        marker = "/definitely/not/a/real/path/gramps_test_marker"
+        self.assertNotIn(marker, sys.path)
+        with _prepended_sys_path(marker):
+            self.assertEqual(sys.path[0], marker)
+        self.assertNotIn(marker, sys.path)
+
+    def test_preserves_existing_entry(self) -> None:
+        """If the path is already present we must not remove it on exit."""
+        existing = sys.path[0] if sys.path else os.getcwd()
+        with _prepended_sys_path(existing):
+            pass
+        self.assertIn(existing, sys.path)
+
+    def test_removes_entry_even_on_exception(self) -> None:
+        marker = "/definitely/not/a/real/path/gramps_test_marker_exc"
+        self.assertNotIn(marker, sys.path)
+        with self.assertRaises(RuntimeError):
+            with _prepended_sys_path(marker):
+                raise RuntimeError("boom")
+        self.assertNotIn(marker, sys.path)
+
+    def test_empty_path_is_noop(self) -> None:
+        before = list(sys.path)
+        with _prepended_sys_path(""):
+            self.assertEqual(sys.path, before)
+        self.assertEqual(sys.path, before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gen/plug/test/_pluginreg_errors_test.py
+++ b/gramps/gen/plug/test/_pluginreg_errors_test.py
@@ -1,0 +1,96 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Eduard Ralph
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Tests that the plugin registration scanner logs errors rather than crashing
+and leaves no partial registrations behind when a gpr.py fails.
+"""
+
+# ------------------------
+# Python modules
+# ------------------------
+import os
+import tempfile
+import unittest
+
+# ------------------------
+# Gramps modules
+# ------------------------
+from .._pluginreg import PluginRegister
+
+
+# ------------------------------------------------------------
+#
+# PluginRegScanErrorsTest
+#
+# ------------------------------------------------------------
+class PluginRegScanErrorsTest(unittest.TestCase):
+    """Exercise the error paths in ``PluginRegister.scan_dir``."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.directory = self._tmp.name
+        self.registry = PluginRegister.get_instance()
+        # name-mangled access; the registry is a singleton and other tests
+        # may have populated it, so we measure deltas against a snapshot.
+        self._before_pdata = list(self.registry._PluginRegister__plugindata)
+        self._before_ids = dict(self.registry._PluginRegister__id_to_pdata)
+
+    def tearDown(self) -> None:
+        self.registry._PluginRegister__plugindata = self._before_pdata
+        self.registry._PluginRegister__id_to_pdata = self._before_ids
+
+    def _write_gpr(self, name: str, body: str, *, encoding: str = "utf-8") -> str:
+        path = os.path.join(self.directory, name)
+        with open(path, "w", encoding=encoding) as file_descriptor:
+            file_descriptor.write(body)
+        return name
+
+    def test_runtime_error_in_gpr_is_caught_and_logged(self) -> None:
+        """A non-ValueError raised by a gpr.py must be logged, not propagated."""
+        self._write_gpr("broken.gpr.py", "raise RuntimeError('kaboom')\n")
+        with self.assertLogs("._manager", level="ERROR") as captured:
+            self.registry.scan_dir(self.directory, ["broken.gpr.py"])
+        joined = "\n".join(captured.output)
+        self.assertIn("Failed reading plugin registration", joined)
+        self.assertIn("broken.gpr.py", joined)
+        added = self.registry._PluginRegister__plugindata[len(self._before_pdata) :]
+        self.assertEqual(added, [], "No plugin data should be registered on failure")
+
+    def test_value_error_in_gpr_is_caught_and_logged(self) -> None:
+        """ValueError has its own except arm; ensure it still logs."""
+        self._write_gpr("bad_value.gpr.py", "raise ValueError('bad value')\n")
+        with self.assertLogs("._manager", level="ERROR") as captured:
+            self.registry.scan_dir(self.directory, ["bad_value.gpr.py"])
+        self.assertIn("bad_value.gpr.py", "\n".join(captured.output))
+
+    def test_non_utf8_gpr_is_caught_and_logged(self) -> None:
+        """A gpr.py with non-UTF-8 bytes must not crash the scan."""
+        path = os.path.join(self.directory, "bad_bytes.gpr.py")
+        with open(path, "wb") as file_descriptor:
+            file_descriptor.write(b"\xff\xfe not utf-8 bytes")
+        with self.assertLogs("._manager", level="ERROR") as captured:
+            self.registry.scan_dir(self.directory, ["bad_bytes.gpr.py"])
+        self.assertIn("bad_bytes.gpr.py", "\n".join(captured.output))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gen/plug/test/_pluginreg_transaction_test.py
+++ b/gramps/gen/plug/test/_pluginreg_transaction_test.py
@@ -1,0 +1,138 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Eduard Ralph
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Tests that ``PluginRegister.scan_dir`` is transactional per .gpr.py file:
+a failure anywhere in the read/exec/register/validate pipeline must leave
+the plugin registry exactly as it was before the file was processed.
+"""
+
+# ------------------------
+# Python modules
+# ------------------------
+import os
+import tempfile
+import unittest
+
+# ------------------------
+# Gramps modules
+# ------------------------
+from .._pluginreg import PluginRegister
+
+
+# ------------------------------------------------------------
+#
+# PluginRegTransactionTest
+#
+# ------------------------------------------------------------
+class PluginRegTransactionTest(unittest.TestCase):
+    """Exercise rollback semantics in ``PluginRegister.scan_dir``."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.directory = self._tmp.name
+        self.registry = PluginRegister.get_instance()
+        self._before_pdata = list(self.registry._PluginRegister__plugindata)
+        self._before_ids = dict(self.registry._PluginRegister__id_to_pdata)
+
+    def tearDown(self) -> None:
+        self.registry._PluginRegister__plugindata = self._before_pdata
+        self.registry._PluginRegister__id_to_pdata = self._before_ids
+
+    def _write_gpr(self, name: str, body: str) -> None:
+        path = os.path.join(self.directory, name)
+        with open(path, "w", encoding="utf-8") as file_descriptor:
+            file_descriptor.write(body)
+
+    def test_rollback_on_exception_after_register_call(self) -> None:
+        """If a gpr.py registers a plugin and then raises, the plugin must
+        not remain in ``__plugindata`` or ``__id_to_pdata``."""
+        body = (
+            "register(TOOL,\n"
+            "    id='tx_rollback_1', name='Rollback Test',\n"
+            "    description='tx rollback test plugin',\n"
+            "    version='1.0', status=STABLE, fname='tx_rollback.py',\n"
+            "    authors=['Test'], authors_email=['t@example.com'],\n"
+            "    category=TOOL_UTILS,\n"
+            "    gramps_target_version=GRAMPSVERSION)\n"
+            "raise RuntimeError('boom after register')\n"
+        )
+        self._write_gpr("tx_rollback.gpr.py", body)
+        with self.assertLogs("._manager", level="ERROR"):
+            self.registry.scan_dir(self.directory, ["tx_rollback.gpr.py"])
+        plugindata = self.registry._PluginRegister__plugindata
+        id_map = self.registry._PluginRegister__id_to_pdata
+        self.assertEqual(
+            plugindata,
+            self._before_pdata,
+            "scan_dir must roll back __plugindata on exception",
+        )
+        self.assertEqual(
+            id_map,
+            self._before_ids,
+            "scan_dir must roll back __id_to_pdata on exception",
+        )
+        self.assertNotIn("tx_rollback_1", id_map)
+
+    def test_rollback_on_value_error_in_gpr(self) -> None:
+        """ValueError raised mid-file must also trigger a full rollback."""
+        body = (
+            "register(TOOL,\n"
+            "    id='tx_rollback_2', name='Value Rollback',\n"
+            "    description='tx rollback test plugin',\n"
+            "    version='1.0', status=STABLE, fname='tx_rollback2.py',\n"
+            "    authors=['Test'], authors_email=['t@example.com'],\n"
+            "    category=TOOL_UTILS,\n"
+            "    gramps_target_version=GRAMPSVERSION)\n"
+            "raise ValueError('bad value')\n"
+        )
+        self._write_gpr("tx_rollback2.gpr.py", body)
+        with self.assertLogs("._manager", level="ERROR"):
+            self.registry.scan_dir(self.directory, ["tx_rollback2.gpr.py"])
+        id_map = self.registry._PluginRegister__id_to_pdata
+        self.assertEqual(self.registry._PluginRegister__plugindata, self._before_pdata)
+        self.assertEqual(id_map, self._before_ids)
+        self.assertNotIn("tx_rollback_2", id_map)
+
+    def test_successful_scan_leaves_new_registrations(self) -> None:
+        """Sanity check: a clean gpr.py must register normally and not be
+        rolled back by the new transactional wrapper."""
+        body = (
+            "register(TOOL,\n"
+            "    id='tx_success_1', name='Happy Plugin',\n"
+            "    description='a plugin that registers cleanly',\n"
+            "    version='1.0', status=STABLE, fname='tx_happy.py',\n"
+            "    authors=['Test'], authors_email=['t@example.com'],\n"
+            "    category=TOOL_UTILS,\n"
+            "    gramps_target_version=GRAMPSVERSION)\n"
+        )
+        self._write_gpr("tx_happy.gpr.py", body)
+        # the referenced fname must exist for the plugin to survive validation
+        with open(
+            os.path.join(self.directory, "tx_happy.py"), "w", encoding="utf-8"
+        ) as file_descriptor:
+            file_descriptor.write("")
+        self.registry.scan_dir(self.directory, ["tx_happy.gpr.py"])
+        self.assertIn("tx_success_1", self.registry._PluginRegister__id_to_pdata)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -212,6 +212,11 @@ gramps/gen/plug/_export.py
 gramps/gen/plug/_import.py
 gramps/gen/plug/_plugin.py
 #
+# gen.plug.test
+#
+gramps/gen/plug/test/__init__.py
+gramps/gen/plug/test/_pluginreg_errors_test.py
+#
 # gen.plug.docbackend
 #
 gramps/gen/plug/docbackend/__init__.py

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -215,7 +215,9 @@ gramps/gen/plug/_plugin.py
 # gen.plug.test
 #
 gramps/gen/plug/test/__init__.py
+gramps/gen/plug/test/_manager_import_test.py
 gramps/gen/plug/test/_pluginreg_errors_test.py
+gramps/gen/plug/test/_pluginreg_transaction_test.py
 #
 # gen.plug.docbackend
 #


### PR DESCRIPTION
> **Note:** This PR is stacked on top of #2243. Merging #2243 first and then rebasing this PR onto `master` is recommended. Only the commit titled *"Make plugin scan and import transactional against failures"* is new here.

## Summary
**User impact:** A single broken add-on can leave Gramps' internal list of installed add-ons half-updated, or permanently pollute the set of places Gramps looks for code. Both cause confusing, hard-to-diagnose problems in setups with third-party add-ons — sometimes long after the broken add-on itself is gone.

This makes scanning and importing each add-on all-or-nothing, so one broken add-on can no longer leave partial state or a lingering side effect behind.

Origin: robustness / code-quality change to the plugin loader — no Mantis tracker ticket (stacked on #2243).

## What to look at
`PluginRegister.scan_dir` now snapshots the registry per `.gpr.py` and rolls it back on any failure; `import_plugin` routes its search-path insertion through a context manager so the entry is always removed. To try it: point Gramps at a `.gpr.py` that raises mid-registration and confirm the registry and the module search path are exactly as they were before the attempt.

## Root cause
A failing `.gpr.py` today can leave the registry inconsistent: `__plugindata` is trimmed on exception but `__id_to_pdata` is not, and the validation loop is not wrapped in a try/except, so a raise there leaves partial data in both. Separately, an uncaught exception from an imported plugin module (e.g. a `RuntimeError` at import time) skips the manual `sys.path.pop(0)` at the end of `import_plugin`, permanently leaking `pdata.fpath` into `sys.path` — a source of hard-to-diagnose side effects in third-party plugin setups.

## Fix
- `PluginRegister.scan_dir` is now transactional per `.gpr.py`: before processing each file it snapshots `__plugindata` and `__id_to_pdata`; any failure in read / exec / id-mapping / validation restores both snapshots. The per-file body is extracted into a private `__scan_file` helper.
- `BasePluginManager.import_plugin` routes `sys.path` manipulation through a new `_prepended_sys_path` context manager so the inserted entry is removed on exit regardless of how the `with` block terminates. The Windows retry branch is hardened with the same pattern, removing a nested double-pop risk.
- The external contract of `get_fail_list()` and `scan_dir()` return values is preserved; no user-visible behaviour changes for correctly registered plugins.

## Verification
- **Claim:** a failing `.gpr.py` or plugin import leaves the registry (`__plugindata` and `__id_to_pdata`) and `sys.path` exactly as they were before the attempt.
- **Checked:** `gramps/gen/plug/_pluginreg.py`, `gramps/gen/plug/_manager.py` on maintenance/gramps60 (the branch this PR targets).
- **Test:** `gramps/gen/plug/test/_pluginreg_transaction_test.py` (rollback on mid-file `RuntimeError` / `ValueError`, plus a successful-scan sanity check) and `gramps/gen/plug/test/_manager_import_test.py` (`sys.path` invariants after successful / `ImportError` / uncaught-exception imports, plus direct unit tests for the `_prepended_sys_path` context manager). Full suite: 32,512 tests, only the two pre-existing unrelated `test_WebCal` / `test_navwebpage` CSS failures; `mypy` and `black --check` clean on the touched files.

No Mantis tracker ticket — internal robustness change stacked on #2243.
