### PR TITLE
Validate addon listing JSON gracefully in get_addons (Bug #12974)

### DIFF
--- a/gramps/gen/plug/test/_utils_addons_test.py
+++ b/gramps/gen/plug/test/_utils_addons_test.py
@@ -1,0 +1,147 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Eduard Ralph
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Tests that ``gramps.gen.plug.utils.get_addons`` validates addon listing
+JSON and fails gracefully rather than crashing the plugin manager UI.
+
+See Gramps bugtracker issue #12974.
+"""
+
+# ------------------------
+# Python modules
+# ------------------------
+import json
+import os
+import pathlib
+import tempfile
+import unittest
+from unittest import mock
+
+# ------------------------
+# Gramps modules
+# ------------------------
+from ...const import GRAMPS_LOCALE as glocale
+from ..utils import get_addons
+
+
+def _valid_entry(plugin_id: str, version: str = "1.0") -> dict:
+    """Build a minimal addon listing record that passes validation."""
+    return {
+        "i": plugin_id,
+        "n": f"Plugin {plugin_id}",
+        "v": version,
+        "d": "description",
+        "t": 2,
+        "z": f"{plugin_id}.zip",
+    }
+
+
+# ------------------------------------------------------------
+#
+# AddonListingValidationTest
+#
+# ------------------------------------------------------------
+class AddonListingValidationTest(unittest.TestCase):
+    """Exercise the validation paths of ``get_addons``."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.directory = self._tmp.name
+        self.listings = os.path.join(self.directory, "listings")
+        os.makedirs(self.listings)
+        self.url = pathlib.Path(self.directory).as_uri()
+        # Short-circuit the locale fallback so only the "en" listing is tried.
+        langs_patch = mock.patch.object(glocale, "get_language_list", return_value=[])
+        langs_patch.start()
+        self.addCleanup(langs_patch.stop)
+
+    def _write_listing(self, body: str, lang: str = "en") -> None:
+        path = os.path.join(self.listings, f"addons-{lang}.json")
+        with open(path, "w", encoding="utf-8") as file_descriptor:
+            file_descriptor.write(body)
+
+    def test_valid_listing_returns_all_entries(self) -> None:
+        """A well-formed listing passes through and gains the project/url
+        metadata keys plus the default optional fields."""
+        self._write_listing(
+            json.dumps([_valid_entry("plug1"), _valid_entry("plug2", "1.1")])
+        )
+        result = get_addons("proj", self.url)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["i"], "plug1")
+        self.assertEqual(result[0]["_p"], "proj")
+        self.assertEqual(result[0]["_u"], self.url)
+        self.assertEqual(result[0]["a"], 0)
+        self.assertEqual(result[0]["s"], 0)
+        self.assertEqual(result[0]["h"], "")
+
+    def test_malformed_json_returns_empty(self) -> None:
+        """A non-JSON body must be logged as an error, not propagated."""
+        self._write_listing("{not valid json at all")
+        with self.assertLogs(".gen.plug", level="ERROR") as captured:
+            result = get_addons("proj", self.url)
+        self.assertEqual(result, [])
+        self.assertIn("not valid JSON", "\n".join(captured.output))
+
+    def test_non_array_top_level_returns_empty(self) -> None:
+        """A JSON object at the top level is not a valid listing."""
+        self._write_listing(json.dumps({"not": "an array"}))
+        with self.assertLogs(".gen.plug", level="ERROR") as captured:
+            result = get_addons("proj", self.url)
+        self.assertEqual(result, [])
+        self.assertIn("not a JSON array", "\n".join(captured.output))
+
+    def test_non_dict_entry_is_skipped(self) -> None:
+        """A non-object element must be skipped; valid siblings survive."""
+        self._write_listing(json.dumps(["not a dict", _valid_entry("plug1")]))
+        with self.assertLogs(".gen.plug", level="WARNING") as captured:
+            result = get_addons("proj", self.url)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["i"], "plug1")
+        self.assertIn("expected object", "\n".join(captured.output))
+
+    def test_entry_missing_required_field_is_skipped(self) -> None:
+        """Entries missing any of i/n/v/d/t/z are skipped with a warning."""
+        incomplete = _valid_entry("incomplete")
+        del incomplete["z"]
+        self._write_listing(json.dumps([incomplete, _valid_entry("plug1")]))
+        with self.assertLogs(".gen.plug", level="WARNING") as captured:
+            result = get_addons("proj", self.url)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["i"], "plug1")
+        joined = "\n".join(captured.output)
+        self.assertIn("incomplete", joined)
+        self.assertIn("z", joined)
+
+    def test_unsupported_url_scheme_returns_empty(self) -> None:
+        """Anything other than http(s)/file is short-circuited."""
+        self.assertEqual(get_addons("proj", "ftp://example.invalid/"), [])
+
+    def test_missing_listing_file_returns_empty(self) -> None:
+        """No listing file present ⇒ empty list, not an exception."""
+        with self.assertLogs(".gen.plug", level="WARNING"):
+            result = get_addons("proj", self.url)
+        self.assertEqual(result, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gen/plug/utils.py
+++ b/gramps/gen/plug/utils.py
@@ -214,9 +214,28 @@ def urlopen_maybe_no_check_cert(url):
     return fptr
 
 
-def get_addons(project, url):
+#: Fields that every entry in an addon listing JSON file must provide.
+_ADDON_LISTING_REQUIRED_FIELDS = ("i", "n", "v", "d", "t", "z")
+
+
+def get_addons(project: str, url: str) -> list[dict]:
     """
-    Get addons
+    Fetch and parse the addon listing JSON for a single addon *project*.
+
+    The listing is expected to be a JSON array of objects, each describing
+    one addon with at least the keys in
+    :data:`_ADDON_LISTING_REQUIRED_FIELDS`. A malformed listing, an invalid
+    top-level structure, or individual records missing required fields are
+    logged and skipped so the plugin manager UI never crashes on a bad
+    server response.
+
+    :param project: The identifier of the addon project being queried.
+    :type project: str
+    :param url: The base URL of the addon project's listing repository.
+    :type url: str
+    :returns: A list of addon-description dictionaries; empty if the
+              listing could not be fetched or was not a valid JSON array.
+    :rtype: list[dict]
     """
     LOG.debug("Checking for updated addons...")
     if not url.startswith(("http://", "https://", "file://")):
@@ -225,43 +244,79 @@ def get_addons(project, url):
     langs.append("en")
     # now we have a list of languages to try:
     fptr = None
+    addon_url = None
     for lang in langs:
         addon_url = f"{url}/listings/addons-{lang}.json"
         LOG.debug("   trying: %s", addon_url)
         try:
             fptr = urlopen_maybe_no_check_cert(addon_url)
-        except:
+        except Exception:
             try:
                 addon_url = f"{url}/listings/addons-{lang[:2]}.json"
                 fptr = urlopen_maybe_no_check_cert(addon_url)
-            except Exception as err:  # some error
+            except Exception as err:
                 LOG.warning(
-                    "Failed to open addon metadata for %s %s: %s", lang, addon_url, err
+                    "Failed to open addon metadata for %s %s: %s",
+                    lang,
+                    addon_url,
+                    err,
                 )
                 fptr = None
         if fptr and (fptr.getcode() == 200 or fptr.file):
             break
 
-    addon_list = []
-    if fptr and (fptr.getcode() == 200 or fptr.file):
-        addon_list = json.load(fptr)
-        for plugin_dict in addon_list:
-            if "a" not in plugin_dict:
-                plugin_dict["a"] = 0
-            if "s" not in plugin_dict:
-                plugin_dict["s"] = 0
-            if "h" not in plugin_dict:
-                plugin_dict["h"] = ""
-            plugin_dict["_p"] = project
-            plugin_dict["_u"] = url
-            pmgr = BasePluginManager.get_instance()
-            plugin = pmgr.get_plugin(plugin_dict["i"])
-            if plugin:
-                plugin_dict["_v"] = plugin.version
-    else:
+    if not fptr or (fptr.getcode() != 200 and not fptr.file):
         LOG.debug("Checking Addons Failed")
-    LOG.debug("Done checking!")
+        LOG.debug("Done checking!")
+        return []
 
+    try:
+        raw_listing = json.load(fptr)
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError) as err:
+        LOG.error("Addon listing from %s is not valid JSON: %s", addon_url, err)
+        return []
+
+    if not isinstance(raw_listing, list):
+        LOG.error(
+            "Addon listing from %s is not a JSON array (got %s)",
+            addon_url,
+            type(raw_listing).__name__,
+        )
+        return []
+
+    pmgr = BasePluginManager.get_instance()
+    addon_list = []
+    for index, plugin_dict in enumerate(raw_listing):
+        if not isinstance(plugin_dict, dict):
+            LOG.warning(
+                "Skipping addon at index %d from %s: expected object, got %s",
+                index,
+                addon_url,
+                type(plugin_dict).__name__,
+            )
+            continue
+        missing = [
+            key for key in _ADDON_LISTING_REQUIRED_FIELDS if key not in plugin_dict
+        ]
+        if missing:
+            LOG.warning(
+                "Skipping addon %r from %s: missing required field(s): %s",
+                plugin_dict.get("i", f"<index {index}>"),
+                addon_url,
+                ", ".join(missing),
+            )
+            continue
+        plugin_dict.setdefault("a", 0)
+        plugin_dict.setdefault("s", 0)
+        plugin_dict.setdefault("h", "")
+        plugin_dict["_p"] = project
+        plugin_dict["_u"] = url
+        plugin = pmgr.get_plugin(plugin_dict["i"])
+        if plugin:
+            plugin_dict["_v"] = plugin.version
+        addon_list.append(plugin_dict)
+
+    LOG.debug("Done checking!")
     return addon_list
 
 

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -212,6 +212,11 @@ gramps/gen/plug/_export.py
 gramps/gen/plug/_import.py
 gramps/gen/plug/_plugin.py
 #
+# gen.plug.test
+#
+gramps/gen/plug/test/__init__.py
+gramps/gen/plug/test/_utils_addons_test.py
+#
 # gen.plug.docbackend
 #
 gramps/gen/plug/docbackend/__init__.py


### PR DESCRIPTION
## Summary
**User impact:** If the add-on server sends back a broken or incomplete list of available add-ons, the Add-on/Plugin Manager window crashes instead of simply skipping the bad entries and carrying on.

This makes the add-on list load defensively — skipping and logging malformed entries — so the manager never crashes on a bad server response.

Reported in Mantis [#12974](https://gramps-project.org/bugs/view.php?id=12974).

## What to look at
`get_addons()` now validates the downloaded listing before trusting it, and the bad-listing paths are logged and skipped rather than raised. To try it: point the manager at a `file://` listing that is malformed (bad JSON, not an array, or entries missing fields) and confirm the window stays up. Seven new tests drive exactly these cases through a `file://` fixture, so no network is involved.

## Root cause
`gramps/gen/plug/utils.py::get_addons` parses the downloaded addon listing without validation, so a malformed or partial listing on the remote side raises and crashes the plugin-manager window. A bare `except:` on the per-language fetch also swallowed `KeyboardInterrupt` / `SystemExit`.

## Fix
- `get_addons` now parses defensively: `json.load` is wrapped with explicit handling for `JSONDecodeError`, `OSError`, and `UnicodeDecodeError`; the top level must be a JSON array; individual entries must be objects containing the required keys `i`, `n`, `v`, `d`, `t`, `z`. Anything else is logged at an appropriate level and skipped.
- Narrowed the bare `except:` used when fetching per-language listings to `except Exception:`, keeping `KeyboardInterrupt` / `SystemExit` propagating.
- Strictly additive: well-formed listings behave exactly as before, and the returned dicts still carry the same keys the plugin-manager GUI consumes (including the defaulted `a` / `s` / `h` and the injected `_p` / `_u` / `_v`).

## Verification
- **Claim:** a malformed or partial addon listing is logged and skipped and never crashes the plugin manager, while well-formed listings behave unchanged.
- **Checked:** `gramps/gen/plug/utils.py` on maintenance/gramps60 (the branch this PR targets) — validation guard on the top-level array and per-entry required keys.
- **Test:** `gramps/gen/plug/test/_utils_addons_test.py` (new) — seven tests covering the happy path, malformed JSON body, non-array top level, non-dict entries, entries missing required fields, unsupported URL schemes, and a missing listing file, all via a `file://` fixture. Full suite: 32,506 tests, only the two pre-existing unrelated `test_WebCal` / `test_navwebpage` CSS failures; `mypy` and `black --check` clean on the touched files.

Fixes [#12974](https://gramps-project.org/bugs/view.php?id=12974)
