### PR TITLE
Warn on plugins that target the previous minor Gramps version

### DIFF
--- a/gramps/gen/plug/_pluginreg.py
+++ b/gramps/gen/plug/_pluginreg.py
@@ -212,23 +212,84 @@ def version(string_version):
     return tuple(myint(x or "0") for x in (f"{string_version}..").split("."))
 
 
-def valid_plugin_version(plugin_version_string):
+# ------------------------------------------------------------
+#
+# PluginVersionStatus
+#
+# ------------------------------------------------------------
+class PluginVersionStatus:
     """
-    Checks to see if string is a valid version string for this version
-    of Gramps.
+    Classification of a plugin's ``gramps_target_version`` relative to the
+    currently running Gramps version.
     """
+
+    #: Plugin targets the current major.minor (and, if three-part, a patch
+    #: level no later than the running Gramps).
+    CURRENT = "current"
+    #: Plugin targets the immediately previous minor within the same major.
+    #: It is still loaded but its author should refresh the target version.
+    DEPRECATED = "deprecated"
+    #: Anything else: malformed, cross-major, future version, or a minor
+    #: more than one release behind.
+    INVALID = "invalid"
+
+
+def plugin_version_status(
+    plugin_version_string: object,
+    current_version: tuple[int, int, int] | None = None,
+) -> str:
+    """
+    Classify *plugin_version_string* against *current_version*.
+
+    :param plugin_version_string: The value a plugin sets for
+                                  ``gramps_target_version``.
+    :type plugin_version_string: object
+    :param current_version: A ``(major, minor, patch)`` tuple describing the
+                            running Gramps version. Defaults to
+                            :data:`VERSION_TUPLE`.
+    :type current_version: tuple[int, int, int] | None
+    :returns: One of the :class:`PluginVersionStatus` string constants.
+    :rtype: str
+    """
+    if current_version is None:
+        current_version = VERSION_TUPLE
     if not isinstance(plugin_version_string, str):
-        return False
+        return PluginVersionStatus.INVALID
     dots = plugin_version_string.count(".")
-    if dots == 1:
-        plugin_version = tuple(map(int, plugin_version_string.split(".", 1)))
-        return plugin_version == VERSION_TUPLE[:2]
-    if dots == 2:
-        plugin_version = tuple(map(int, plugin_version_string.split(".", 2)))
-        return (
-            plugin_version[:2] == VERSION_TUPLE[:2] and plugin_version <= VERSION_TUPLE
-        )
-    return False
+    if dots not in (1, 2):
+        return PluginVersionStatus.INVALID
+    try:
+        parsed = tuple(int(part) for part in plugin_version_string.split("."))
+    except ValueError:
+        return PluginVersionStatus.INVALID
+    current_major_minor = current_version[:2]
+    if parsed[:2] == current_major_minor:
+        if dots == 1 or parsed <= current_version:
+            return PluginVersionStatus.CURRENT
+        return PluginVersionStatus.INVALID
+    if (
+        parsed[0] == current_version[0]
+        and current_version[1] >= 1
+        and parsed[1] == current_version[1] - 1
+    ):
+        return PluginVersionStatus.DEPRECATED
+    return PluginVersionStatus.INVALID
+
+
+def valid_plugin_version(plugin_version_string: object) -> bool:
+    """
+    Check whether *plugin_version_string* is a valid target for the running
+    Gramps. Deprecated (one-minor-behind) targets are treated as valid so
+    the plugin is still loaded; callers that want to surface the
+    deprecation should use :func:`plugin_version_status` instead.
+
+    :param plugin_version_string: The value a plugin sets for
+                                  ``gramps_target_version``.
+    :type plugin_version_string: object
+    :returns: ``True`` if the plugin should be loaded, ``False`` otherwise.
+    :rtype: bool
+    """
+    return plugin_version_status(plugin_version_string) != PluginVersionStatus.INVALID
 
 
 class PluginData:
@@ -1460,7 +1521,8 @@ class PluginRegister:
                 # LOG.warning("\nPlugin scanned %s at registration", plugin.id)
                 ind += 1
                 plugin.directory = directory
-                if not valid_plugin_version(plugin.gramps_target_version):
+                version_status = plugin_version_status(plugin.gramps_target_version)
+                if version_status == PluginVersionStatus.INVALID:
                     print(
                         _(
                             "ERROR: Plugin file %(filename)s has a version of "
@@ -1475,6 +1537,16 @@ class PluginRegister:
                     )
                     rmlist.append(ind)
                     continue
+                if version_status == PluginVersionStatus.DEPRECATED:
+                    LOG.warning(
+                        "Plugin file %s targets Gramps %s, which is deprecated "
+                        "(one minor version behind the current %s); the plugin "
+                        "was loaded but its gramps_target_version should be "
+                        "updated.",
+                        os.path.join(directory, plugin.fname),
+                        plugin.gramps_target_version,
+                        GRAMPSVERSION,
+                    )
                 if not self.__req.check_plugin(plugin):
                     rmlist.append(ind)
                     continue

--- a/gramps/gen/plug/test/_pluginreg_version_status_test.py
+++ b/gramps/gen/plug/test/_pluginreg_version_status_test.py
@@ -1,0 +1,243 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Eduard Ralph
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Tests for ``plugin_version_status`` classification and the deprecation
+warning emitted by ``PluginRegister.scan_dir`` for one-minor-behind
+plugins.
+"""
+
+# ------------------------
+# Python modules
+# ------------------------
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+# ------------------------
+# Gramps modules
+# ------------------------
+from .. import _pluginreg
+from .._pluginreg import (
+    PluginRegister,
+    PluginVersionStatus,
+    plugin_version_status,
+    valid_plugin_version,
+)
+
+
+# ------------------------------------------------------------
+#
+# PluginVersionStatusTest
+#
+# ------------------------------------------------------------
+class PluginVersionStatusTest(unittest.TestCase):
+    """Unit tests for :func:`plugin_version_status`."""
+
+    def test_exact_major_minor_is_current(self) -> None:
+        self.assertEqual(
+            plugin_version_status("6.1", current_version=(6, 1, 0)),
+            PluginVersionStatus.CURRENT,
+        )
+
+    def test_exact_major_minor_patch_is_current(self) -> None:
+        self.assertEqual(
+            plugin_version_status("6.1.0", current_version=(6, 1, 0)),
+            PluginVersionStatus.CURRENT,
+        )
+
+    def test_older_patch_of_current_minor_is_current(self) -> None:
+        self.assertEqual(
+            plugin_version_status("6.1.0", current_version=(6, 1, 5)),
+            PluginVersionStatus.CURRENT,
+        )
+
+    def test_future_patch_of_current_minor_is_invalid(self) -> None:
+        self.assertEqual(
+            plugin_version_status("6.1.5", current_version=(6, 1, 0)),
+            PluginVersionStatus.INVALID,
+        )
+
+    def test_previous_minor_is_deprecated(self) -> None:
+        self.assertEqual(
+            plugin_version_status("6.0", current_version=(6, 1, 0)),
+            PluginVersionStatus.DEPRECATED,
+        )
+
+    def test_previous_minor_with_any_patch_is_deprecated(self) -> None:
+        self.assertEqual(
+            plugin_version_status("6.0.99", current_version=(6, 1, 0)),
+            PluginVersionStatus.DEPRECATED,
+        )
+
+    def test_two_minors_behind_is_invalid(self) -> None:
+        self.assertEqual(
+            plugin_version_status("6.0", current_version=(6, 2, 0)),
+            PluginVersionStatus.INVALID,
+        )
+
+    def test_different_major_is_invalid(self) -> None:
+        self.assertEqual(
+            plugin_version_status("5.9", current_version=(6, 1, 0)),
+            PluginVersionStatus.INVALID,
+        )
+
+    def test_future_major_is_invalid(self) -> None:
+        self.assertEqual(
+            plugin_version_status("7.0", current_version=(6, 1, 0)),
+            PluginVersionStatus.INVALID,
+        )
+
+    def test_future_minor_is_invalid(self) -> None:
+        self.assertEqual(
+            plugin_version_status("6.2", current_version=(6, 1, 0)),
+            PluginVersionStatus.INVALID,
+        )
+
+    def test_zero_minor_has_no_deprecation_window(self) -> None:
+        """On Gramps X.0.0 there is no previous minor to be deprecated."""
+        self.assertEqual(
+            plugin_version_status("6.0", current_version=(6, 0, 0)),
+            PluginVersionStatus.CURRENT,
+        )
+        self.assertEqual(
+            plugin_version_status("5.9", current_version=(6, 0, 0)),
+            PluginVersionStatus.INVALID,
+        )
+
+    def test_non_string_is_invalid(self) -> None:
+        self.assertEqual(
+            plugin_version_status(None, current_version=(6, 1, 0)),
+            PluginVersionStatus.INVALID,
+        )
+        self.assertEqual(
+            plugin_version_status(61, current_version=(6, 1, 0)),
+            PluginVersionStatus.INVALID,
+        )
+
+    def test_malformed_string_is_invalid(self) -> None:
+        for bad in ("", "not-a-version", "6", "6.1.2.3", "6.x", "..", "6.1."):
+            with self.subTest(value=bad):
+                self.assertEqual(
+                    plugin_version_status(bad, current_version=(6, 1, 0)),
+                    PluginVersionStatus.INVALID,
+                )
+
+
+# ------------------------------------------------------------
+#
+# ValidPluginVersionCompatTest
+#
+# ------------------------------------------------------------
+class ValidPluginVersionCompatTest(unittest.TestCase):
+    """``valid_plugin_version`` is kept as a bool compat wrapper; verify it
+    now also accepts one-minor-behind (deprecated) targets."""
+
+    def test_current_is_valid(self) -> None:
+        with mock.patch.object(_pluginreg, "VERSION_TUPLE", new=(6, 1, 0)):
+            self.assertTrue(valid_plugin_version("6.1"))
+
+    def test_deprecated_is_valid(self) -> None:
+        with mock.patch.object(_pluginreg, "VERSION_TUPLE", new=(6, 1, 0)):
+            self.assertTrue(valid_plugin_version("6.0"))
+
+    def test_invalid_is_rejected(self) -> None:
+        with mock.patch.object(_pluginreg, "VERSION_TUPLE", new=(6, 1, 0)):
+            self.assertFalse(valid_plugin_version("5.9"))
+            self.assertFalse(valid_plugin_version("6.2"))
+            self.assertFalse(valid_plugin_version("garbage"))
+
+
+# ------------------------------------------------------------
+#
+# ScanDirDeprecationWarningTest
+#
+# ------------------------------------------------------------
+class ScanDirDeprecationWarningTest(unittest.TestCase):
+    """A ``.gpr.py`` targeting the previous minor must be registered but
+    must also trigger a deprecation warning through the module logger."""
+
+    def setUp(self) -> None:
+        """
+        Create a temporary plugin directory and snapshot the shared
+        ``PluginRegister`` state so it can be restored in ``tearDown``.
+        """
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.directory = self._tmp.name
+        self.registry = PluginRegister.get_instance()
+        self._before_pdata = list(self.registry._PluginRegister__plugindata)
+        self._before_ids = dict(self.registry._PluginRegister__id_to_pdata)
+
+    def tearDown(self) -> None:
+        """
+        Restore the ``PluginRegister`` state captured in ``setUp`` so the
+        scan performed by a test does not leak into other tests.
+        """
+        self.registry._PluginRegister__plugindata = self._before_pdata
+        self.registry._PluginRegister__id_to_pdata = self._before_ids
+
+    def _write_gpr(self, name: str, body: str) -> None:
+        """
+        Write *body* to a file named *name* in the temporary directory.
+
+        :param name: The file name to create within the temporary
+                     plugin directory.
+        :type name: str
+        :param body: The text content to write into the file.
+        :type body: str
+        :returns: Nothing.
+        :rtype: None
+        """
+        path = os.path.join(self.directory, name)
+        with open(path, "w", encoding="utf-8") as file_descriptor:
+            file_descriptor.write(body)
+
+    def test_deprecated_plugin_is_registered_with_warning(self) -> None:
+        gpr_body = (
+            "register(TOOL,\n"
+            "    id='version_skew_test', name='Skewed Plugin',\n"
+            "    description='targets previous minor version',\n"
+            "    version='1.0', status=STABLE,\n"
+            "    fname='version_skew_plugin.py',\n"
+            "    authors=['Test'], authors_email=['t@example.com'],\n"
+            "    category=TOOL_UTILS,\n"
+            "    gramps_target_version='6.0')\n"
+        )
+        self._write_gpr("version_skew_test.gpr.py", gpr_body)
+        with open(
+            os.path.join(self.directory, "version_skew_plugin.py"),
+            "w",
+            encoding="utf-8",
+        ) as file_descriptor:
+            file_descriptor.write("")
+        with mock.patch.object(_pluginreg, "VERSION_TUPLE", new=(6, 1, 0)):
+            with mock.patch.object(_pluginreg, "GRAMPSVERSION", new="6.1.0"):
+                with self.assertLogs("._manager", level="WARNING") as captured:
+                    self.registry.scan_dir(self.directory, ["version_skew_test.gpr.py"])
+        self.assertIn("version_skew_test", self.registry._PluginRegister__id_to_pdata)
+        joined = "\n".join(captured.output)
+        self.assertIn("6.0", joined)
+        self.assertIn("deprecated", joined.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -212,6 +212,11 @@ gramps/gen/plug/_export.py
 gramps/gen/plug/_import.py
 gramps/gen/plug/_plugin.py
 #
+# gen.plug.test
+#
+gramps/gen/plug/test/__init__.py
+gramps/gen/plug/test/_pluginreg_version_status_test.py
+#
 # gen.plug.docbackend
 #
 gramps/gen/plug/docbackend/__init__.py


### PR DESCRIPTION
## Summary
**User impact:** When an add-on is written for the previous Gramps version, Gramps silently refuses to load it and buries the reason among the other start-up messages. Add-on authors usually only find out from user bug reports — with no early warning before their add-on stops working.

This loads such one-version-behind add-ons for a one-release grace period while emitting a clear deprecation warning, giving authors a window to update the target before the add-on is dropped entirely.

Origin: feature enhancement to the plugin loader — no Mantis tracker ticket (opened as a draft because it is a feature, not a bug fix).

## What to look at
Plugins whose `gramps_target_version` is exactly one minor behind the running Gramps are now loaded, but with a `LOG.warning` telling the author to bump the target; two-minors-behind, wrong-major, or future versions are still rejected and skipped exactly as before. To try it: drop a `.gpr.py` targeting the previous minor version into a plugin directory and confirm it registers *and* emits a deprecation warning naming that version.

## Root cause
In `gramps/gen/plug/_pluginreg.py`, a `gpr.py` that still targets the previous minor version is silently rejected with an error message mixed in with the rest of the plugin-registration output. There is no deprecation window and no structured signal, so authors typically learn about it only from user bug reports.

## Fix
- Introduce a three-way `PluginVersionStatus` (`CURRENT` / `DEPRECATED` / `INVALID`) and a `plugin_version_status()` classifier in `gramps/gen/plug/_pluginreg.py`.
- `PluginRegister.scan_dir` now loads plugins one minor behind the running Gramps but emits a `LOG.warning` through the `._manager` logger; `INVALID` (two minors behind, wrong major, or future) still routes through the existing print-and-skip path — no behaviour change for those.
- `valid_plugin_version()` is kept as a thin bool compat wrapper that delegates to `plugin_version_status()` and treats `DEPRECATED` as valid, so external callers do not regress.
- Adds `gramps/gen/plug/test/__init__.py` (new, empty) test-package marker.

## Verification
- **Claim:** a plugin one minor behind the running Gramps loads and emits a deprecation warning; two-minors-behind / wrong-major / future remain rejected; the `valid_plugin_version()` bool contract is preserved.
- **Checked:** `gramps/gen/plug/_pluginreg.py` on master (the branch this PR targets) — `scan_dir` routes `DEPRECATED` through `LOG.warning` while still registering the plugin.
- **Test:** `gramps/gen/plug/test/_pluginreg_version_status_test.py` (new) — 17 tests: 13 classifier units (CURRENT / DEPRECATED / INVALID including patch handling, zero-minor edge case, non-string inputs, malformed strings), 3 compat-wrapper tests, and an integration test that writes a real `.gpr.py` targeting the previous minor, invokes `scan_dir`, and asserts the plugin is registered *and* a warning containing "deprecated" and the deprecated version number is emitted. `mypy` and `black --check` clean; full suite 32,516 tests, only the two pre-existing unrelated `test_WebCal` / `test_navwebpage` failures. As a new feature there is no pre-existing bug to reproduce; the integration test guards the new deprecation-window behaviour.

No Mantis tracker ticket — feature enhancement, opened as a draft.
