### PR TITLE
Classify Addon Manager project-path fetches for a validity indicator

### DIFF
--- a/gramps/gen/plug/test/_utils_project_status_test.py
+++ b/gramps/gen/plug/test/_utils_project_status_test.py
@@ -1,0 +1,283 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Eduard Ralph
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Tests for ``normalize_project_url`` and ``classify_project_fetch``
+(bug #13069 — Addon Manager "project" path validity indicator).
+"""
+
+# ------------------------
+# Python modules
+# ------------------------
+import io
+import json
+import unittest
+from email.message import Message
+from unittest import mock
+from urllib.error import HTTPError, URLError
+
+# ------------------------
+# Gramps modules
+# ------------------------
+from .. import utils as plug_utils
+from ..utils import (
+    ProjectFetchResult,
+    ProjectFetchStatus,
+    classify_project_fetch,
+    normalize_project_url,
+)
+
+
+# ------------------------------------------------------------
+#
+# _FakeResponse
+#
+# ------------------------------------------------------------
+class _FakeResponse:
+    """Minimal stand-in for the object returned by :func:`urlopen`."""
+
+    def __init__(self, payload: bytes, code: int = 200, is_file: bool = False) -> None:
+        self._buffer = io.BytesIO(payload)
+        self._code = code
+        self.file = self if is_file else None
+
+    def read(self, size: int = -1) -> bytes:
+        return self._buffer.read(size)
+
+    def getcode(self) -> int:
+        return self._code
+
+    def close(self) -> None:
+        self._buffer.close()
+
+
+def _json_response(records: object, code: int = 200) -> _FakeResponse:
+    return _FakeResponse(json.dumps(records).encode("utf-8"), code=code)
+
+
+# ------------------------------------------------------------
+#
+# NormalizeProjectUrlTest
+#
+# ------------------------------------------------------------
+class NormalizeProjectUrlTest(unittest.TestCase):
+    """Unit tests for :func:`normalize_project_url`."""
+
+    def test_strips_surrounding_whitespace(self) -> None:
+        self.assertEqual(
+            normalize_project_url("  https://example.com/path  "),
+            "https://example.com/path",
+        )
+
+    def test_strips_trailing_slashes(self) -> None:
+        self.assertEqual(
+            normalize_project_url("https://example.com/path///"),
+            "https://example.com/path",
+        )
+
+    def test_keeps_scheme_double_slash(self) -> None:
+        self.assertEqual(normalize_project_url("file://"), "file://")
+
+    def test_http_scheme_accepted(self) -> None:
+        self.assertEqual(
+            normalize_project_url("http://example.com"), "http://example.com"
+        )
+
+    def test_file_scheme_accepted(self) -> None:
+        self.assertEqual(
+            normalize_project_url("file:///tmp/addons/"), "file:///tmp/addons"
+        )
+
+    def test_empty_string_rejected(self) -> None:
+        self.assertIsNone(normalize_project_url(""))
+        self.assertIsNone(normalize_project_url("   "))
+
+    def test_unsupported_scheme_rejected(self) -> None:
+        self.assertIsNone(normalize_project_url("ftp://example.com"))
+        self.assertIsNone(normalize_project_url("gopher://example.com"))
+        self.assertIsNone(normalize_project_url("example.com"))
+
+    def test_non_string_rejected(self) -> None:
+        self.assertIsNone(normalize_project_url(None))
+        self.assertIsNone(normalize_project_url(42))
+        self.assertIsNone(normalize_project_url(b"https://example.com"))
+
+
+# ------------------------------------------------------------
+#
+# ClassifyProjectFetchTest
+#
+# ------------------------------------------------------------
+class ClassifyProjectFetchTest(unittest.TestCase):
+    """Unit tests for :func:`classify_project_fetch`."""
+
+    def _patch_urlopen(self, side_effect: object) -> mock._patch:
+        return mock.patch.object(
+            plug_utils, "urlopen_maybe_no_check_cert", side_effect=side_effect
+        )
+
+    def test_invalid_url_for_none(self) -> None:
+        result = classify_project_fetch(None)
+        self.assertIsInstance(result, ProjectFetchResult)
+        self.assertEqual(result.status, ProjectFetchStatus.INVALID_URL)
+        self.assertIsNone(result.normalized_url)
+
+    def test_invalid_url_for_wrong_scheme(self) -> None:
+        result = classify_project_fetch("ftp://example.com/addons")
+        self.assertEqual(result.status, ProjectFetchStatus.INVALID_URL)
+
+    def test_invalid_url_for_empty_string(self) -> None:
+        self.assertEqual(
+            classify_project_fetch("   ").status, ProjectFetchStatus.INVALID_URL
+        )
+
+    def test_ok_when_compatible_entry_present(self) -> None:
+        records = [
+            {"i": "one", "n": "One", "v": "1.0", "d": "d", "t": "6.1", "z": "z"},
+            {"i": "two", "n": "Two", "v": "0.9", "d": "d", "t": "5.2", "z": "z"},
+        ]
+        with self._patch_urlopen(lambda u, *a, **k: _json_response(records)):
+            result = classify_project_fetch(
+                "https://example.com/addons",
+                current_version=(6, 1, 0),
+                languages=["en"],
+            )
+        self.assertEqual(result.status, ProjectFetchStatus.OK)
+        self.assertEqual(result.addon_count, 2)
+        self.assertEqual(result.compatible_count, 1)
+        self.assertEqual(result.fetched_language, "en")
+
+    def test_empty_listing(self) -> None:
+        with self._patch_urlopen(lambda u, *a, **k: _json_response([])):
+            result = classify_project_fetch(
+                "https://example.com/addons",
+                current_version=(6, 1, 0),
+                languages=["en"],
+            )
+        self.assertEqual(result.status, ProjectFetchStatus.EMPTY_LISTING)
+        self.assertEqual(result.addon_count, 0)
+
+    def test_no_compatible_addons(self) -> None:
+        records = [
+            {"i": "x", "n": "X", "v": "1.0", "d": "d", "t": "5.2", "z": "z"},
+            {"i": "y", "n": "Y", "v": "1.0", "d": "d", "t": "5.1", "z": "z"},
+        ]
+        with self._patch_urlopen(lambda u, *a, **k: _json_response(records)):
+            result = classify_project_fetch(
+                "https://example.com/addons",
+                current_version=(6, 1, 0),
+                languages=["en"],
+            )
+        self.assertEqual(result.status, ProjectFetchStatus.NO_COMPATIBLE_ADDONS)
+        self.assertEqual(result.addon_count, 2)
+        self.assertEqual(result.compatible_count, 0)
+
+    def test_lang_fallback_to_en(self) -> None:
+        calls: list[str] = []
+        records = [
+            {"i": "a", "n": "A", "v": "1.0", "d": "d", "t": "6.1", "z": "z"},
+        ]
+
+        def fake_urlopen(addon_url: str, *a: object, **k: object) -> _FakeResponse:
+            calls.append(addon_url)
+            if "addons-en.json" in addon_url:
+                return _json_response(records)
+            raise HTTPError(addon_url, 404, "Not Found", hdrs=Message(), fp=None)
+
+        with self._patch_urlopen(fake_urlopen):
+            result = classify_project_fetch(
+                "https://example.com/addons",
+                current_version=(6, 1, 0),
+                languages=["de", "en"],
+            )
+        self.assertEqual(result.status, ProjectFetchStatus.LANG_FALLBACK_EN)
+        self.assertEqual(result.fetched_language, "en")
+        self.assertIn("de", result.tried_languages)
+        self.assertIn("en", result.tried_languages)
+        self.assertTrue(any("addons-en.json" in u for u in calls))
+
+    def test_json_error_on_invalid_body(self) -> None:
+        with self._patch_urlopen(
+            lambda u, *a, **k: _FakeResponse(b"not json at all", code=200)
+        ):
+            result = classify_project_fetch(
+                "https://example.com/addons",
+                current_version=(6, 1, 0),
+                languages=["en"],
+            )
+        self.assertEqual(result.status, ProjectFetchStatus.JSON_ERROR)
+
+    def test_json_error_on_non_array_payload(self) -> None:
+        with self._patch_urlopen(
+            lambda u, *a, **k: _FakeResponse(b'{"an": "object"}', code=200)
+        ):
+            result = classify_project_fetch(
+                "https://example.com/addons",
+                current_version=(6, 1, 0),
+                languages=["en"],
+            )
+        self.assertEqual(result.status, ProjectFetchStatus.JSON_ERROR)
+
+    def test_http_error(self) -> None:
+        def raise_404(addon_url: str, *a: object, **k: object) -> _FakeResponse:
+            raise HTTPError(addon_url, 404, "Not Found", hdrs=Message(), fp=None)
+
+        with self._patch_urlopen(raise_404):
+            result = classify_project_fetch(
+                "https://example.com/addons",
+                current_version=(6, 1, 0),
+                languages=["en"],
+            )
+        self.assertEqual(result.status, ProjectFetchStatus.HTTP_ERROR)
+        self.assertEqual(result.http_code, 404)
+
+    def test_network_error(self) -> None:
+        def raise_url_error(addon_url: str, *a: object, **k: object) -> _FakeResponse:
+            raise URLError("getaddrinfo failed")
+
+        with self._patch_urlopen(raise_url_error):
+            result = classify_project_fetch(
+                "https://example.com/addons",
+                current_version=(6, 1, 0),
+                languages=["en"],
+            )
+        self.assertEqual(result.status, ProjectFetchStatus.NETWORK_ERROR)
+        self.assertIn("getaddrinfo failed", result.detail or "")
+
+    def test_trailing_slashes_normalized_before_fetch(self) -> None:
+        seen: list[str] = []
+
+        def fake_urlopen(addon_url: str, *a: object, **k: object) -> _FakeResponse:
+            seen.append(addon_url)
+            return _json_response(
+                [{"i": "a", "n": "A", "v": "1.0", "d": "d", "t": "6.1", "z": "z"}]
+            )
+
+        with self._patch_urlopen(fake_urlopen):
+            classify_project_fetch(
+                "https://example.com/addons///",
+                current_version=(6, 1, 0),
+                languages=["en"],
+            )
+        self.assertEqual(seen[0], "https://example.com/addons/listings/addons-en.json")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gen/plug/utils.py
+++ b/gramps/gen/plug/utils.py
@@ -31,7 +31,10 @@ import json
 import logging
 import os
 import sys
+from dataclasses import dataclass, field
 from io import BytesIO
+from typing import Any
+from urllib.error import HTTPError, URLError
 
 # -------------------------------------------------------------------------
 #
@@ -212,6 +215,297 @@ def urlopen_maybe_no_check_cert(url):
     except TypeError:
         fptr = urlopen(url, timeout=timeout)
     return fptr
+
+
+_PROJECT_URL_SCHEMES = ("http://", "https://", "file://")
+
+
+def normalize_project_url(url: object) -> str | None:
+    """
+    Normalize an Addon Manager "project" URL.
+
+    Strips surrounding whitespace and trailing slashes so that callers
+    can build ``{url}/listings/addons-<lang>.json`` deterministically.
+    Returns ``None`` for values that are not a string, are empty, or do
+    not begin with a supported scheme (``http://``, ``https://``,
+    ``file://``); these are the same schemes accepted by
+    :func:`get_addons` today.
+    """
+    if not isinstance(url, str):
+        return None
+    stripped = url.strip()
+    if not stripped:
+        return None
+    if not stripped.startswith(_PROJECT_URL_SCHEMES):
+        return None
+    while stripped.endswith("/") and not stripped.endswith("://"):
+        stripped = stripped[:-1]
+    return stripped
+
+
+# ------------------------------------------------------------
+#
+# ProjectFetchStatus
+#
+# ------------------------------------------------------------
+class ProjectFetchStatus:
+    """
+    String constants describing the outcome of a single Addon Manager
+    project fetch. These are used both as machine-readable statuses
+    and as stable identifiers for UI indicators, so values are kept
+    short and untranslated.
+    """
+
+    OK = "ok"
+    INVALID_URL = "invalid_url"
+    NETWORK_ERROR = "network_error"
+    HTTP_ERROR = "http_error"
+    JSON_ERROR = "json_error"
+    EMPTY_LISTING = "empty_listing"
+    NO_COMPATIBLE_ADDONS = "no_compatible_addons"
+    LANG_FALLBACK_EN = "lang_fallback_en"
+
+
+# ------------------------------------------------------------
+#
+# ProjectFetchResult
+#
+# ------------------------------------------------------------
+@dataclass
+class ProjectFetchResult:
+    """
+    Structured result of :func:`classify_project_fetch`.
+
+    ``status`` is one of the :class:`ProjectFetchStatus` constants.
+    ``normalized_url`` is the cleaned URL that was actually tried, or
+    ``None`` when the input could not be normalized. ``fetched_url``
+    is the full listing URL that succeeded, if any; ``fetched_language``
+    is the language code whose ``addons-<lang>.json`` was returned.
+    ``http_code`` is populated for :data:`ProjectFetchStatus.HTTP_ERROR`.
+    ``detail`` is a short English string suitable for logging or a
+    tooltip. ``addon_count`` is the number of records in the listing;
+    ``compatible_count`` is how many of them target the running major.
+    minor Gramps version.
+    """
+
+    status: str
+    requested_url: str
+    normalized_url: str | None = None
+    fetched_url: str | None = None
+    fetched_language: str | None = None
+    http_code: int | None = None
+    detail: str | None = None
+    addon_count: int = 0
+    compatible_count: int = 0
+    tried_languages: list[str] = field(default_factory=list)
+
+
+def _candidate_languages(languages: list[str] | None) -> list[str]:
+    """Build the ordered list of language codes to try, matching
+    :func:`get_addons` behaviour: the user's locale chain followed by
+    ``en`` as a final fallback, with duplicates removed."""
+    if languages is None:
+        langs = list(glocale.get_language_list())
+        langs.append("en")
+    else:
+        langs = list(languages)
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for lang in langs:
+        if lang and lang not in seen:
+            ordered.append(lang)
+            seen.add(lang)
+    return ordered
+
+
+def _try_fetch_listing(url: str, lang: str) -> tuple[Any, str | None, int]:
+    """Try ``addons-<lang>.json`` then ``addons-<lang[:2]>.json``.
+
+    Returns ``(fptr, fetched_url, http_code)`` on a 200-or-file success,
+    or ``(None, None, code)`` otherwise. ``code`` is ``0`` when no HTTP
+    status was obtained (network error, file:// not found, ...).
+    Raises :class:`URLError` for pure network failures so that the
+    caller can distinguish them from HTTP errors.
+    """
+    candidates = [f"{url}/listings/addons-{lang}.json"]
+    short = lang[:2]
+    if short and short != lang:
+        candidates.append(f"{url}/listings/addons-{short}.json")
+    last_http_code = 0
+    last_network_error: URLError | None = None
+    for addon_url in candidates:
+        try:
+            fptr = urlopen_maybe_no_check_cert(addon_url)
+        except HTTPError as err:
+            last_http_code = err.code
+            continue
+        except URLError as err:
+            last_network_error = err
+            continue
+        code = 0
+        try:
+            code = fptr.getcode() or 0
+        except AttributeError:
+            code = 0
+        is_file = getattr(fptr, "file", None) is not None
+        if code == 200 or is_file:
+            return fptr, addon_url, code or 200
+        last_http_code = code
+        try:
+            fptr.close()
+        except Exception:
+            pass
+    if last_http_code:
+        return None, None, last_http_code
+    if last_network_error is not None:
+        raise last_network_error
+    return None, None, 0
+
+
+def classify_project_fetch(
+    url: object,
+    current_version: tuple[int, int, int] | None = None,
+    languages: list[str] | None = None,
+) -> ProjectFetchResult:
+    """
+    Fetch the ``addons-<lang>.json`` listing for ``url`` and classify
+    the outcome.
+
+    The classifier never raises: any problem is reported via
+    :class:`ProjectFetchResult`. The call does not mutate any global
+    state and does not update the plugin manager; it exists so that
+    the Addon Manager UI can render a per-project status indicator
+    (bug #13069) without re-implementing the lookup logic.
+
+    ``current_version`` defaults to the running Gramps
+    :data:`VERSION_TUPLE`; pass an explicit tuple in tests to pin the
+    compatibility check. ``languages`` overrides the locale list in
+    the same way.
+    """
+    requested_url = url if isinstance(url, str) else ""
+    normalized = normalize_project_url(url)
+    if normalized is None:
+        return ProjectFetchResult(
+            status=ProjectFetchStatus.INVALID_URL,
+            requested_url=requested_url,
+            detail=_(
+                "URL is empty or does not start with http://, https:// or file://"
+            ),
+        )
+    candidate_langs = _candidate_languages(languages)
+    tried: list[str] = []
+    fptr: Any = None
+    fetched_url: str | None = None
+    fetched_language: str | None = None
+    last_http_code = 0
+    network_error: URLError | None = None
+    for lang in candidate_langs:
+        tried.append(lang)
+        try:
+            fptr, fetched_url, code = _try_fetch_listing(normalized, lang)
+        except URLError as err:
+            network_error = err
+            continue
+        if fptr is not None:
+            fetched_language = lang
+            break
+        if code:
+            last_http_code = code
+    if fptr is None:
+        if network_error is not None:
+            return ProjectFetchResult(
+                status=ProjectFetchStatus.NETWORK_ERROR,
+                requested_url=requested_url,
+                normalized_url=normalized,
+                detail=_("Network error: %s") % network_error.reason,
+                tried_languages=tried,
+            )
+        if last_http_code:
+            return ProjectFetchResult(
+                status=ProjectFetchStatus.HTTP_ERROR,
+                requested_url=requested_url,
+                normalized_url=normalized,
+                http_code=last_http_code,
+                detail=_("HTTP %s while fetching listing") % last_http_code,
+                tried_languages=tried,
+            )
+        return ProjectFetchResult(
+            status=ProjectFetchStatus.NETWORK_ERROR,
+            requested_url=requested_url,
+            normalized_url=normalized,
+            detail=_("No listing could be fetched"),
+            tried_languages=tried,
+        )
+    try:
+        try:
+            payload = json.load(fptr)
+        except (ValueError, UnicodeDecodeError) as err:
+            return ProjectFetchResult(
+                status=ProjectFetchStatus.JSON_ERROR,
+                requested_url=requested_url,
+                normalized_url=normalized,
+                fetched_url=fetched_url,
+                fetched_language=fetched_language,
+                detail=_("Listing is not valid JSON: %s") % err,
+                tried_languages=tried,
+            )
+    finally:
+        try:
+            fptr.close()
+        except Exception:
+            pass
+    if not isinstance(payload, list):
+        return ProjectFetchResult(
+            status=ProjectFetchStatus.JSON_ERROR,
+            requested_url=requested_url,
+            normalized_url=normalized,
+            fetched_url=fetched_url,
+            fetched_language=fetched_language,
+            detail=_("Listing is not a JSON array"),
+            tried_languages=tried,
+        )
+    addon_count = len(payload)
+    target_major_minor = (
+        current_version[:2] if current_version is not None else VERSION_TUPLE[:2]
+    )
+    compatible = 0
+    for entry in payload:
+        if not isinstance(entry, dict):
+            continue
+        entry_version = entry.get("t")
+        if not isinstance(entry_version, str):
+            continue
+        if version_str_to_tup(entry_version, 2) == target_major_minor:
+            compatible += 1
+    if addon_count == 0:
+        status = ProjectFetchStatus.EMPTY_LISTING
+        detail = _("Listing fetched but contained no entries")
+    elif compatible == 0:
+        status = ProjectFetchStatus.NO_COMPATIBLE_ADDONS
+        detail = _("Listing fetched but no entries target the running Gramps %s.%s") % (
+            target_major_minor[0],
+            target_major_minor[1],
+        )
+    elif fetched_language == "en" and candidate_langs and candidate_langs[0] != "en":
+        status = ProjectFetchStatus.LANG_FALLBACK_EN
+        detail = (
+            _("No listing for the requested language; fell back to %s")
+            % fetched_language
+        )
+    else:
+        status = ProjectFetchStatus.OK
+        detail = None
+    return ProjectFetchResult(
+        status=status,
+        requested_url=requested_url,
+        normalized_url=normalized,
+        fetched_url=fetched_url,
+        fetched_language=fetched_language,
+        detail=detail,
+        addon_count=addon_count,
+        compatible_count=compatible,
+        tried_languages=tried,
+    )
 
 
 def get_addons(project, url):

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -212,6 +212,11 @@ gramps/gen/plug/_export.py
 gramps/gen/plug/_import.py
 gramps/gen/plug/_plugin.py
 #
+# gen.plug.test
+#
+gramps/gen/plug/test/__init__.py
+gramps/gen/plug/test/_utils_project_status_test.py
+#
 # gen.plug.docbackend
 #
 gramps/gen/plug/docbackend/__init__.py


### PR DESCRIPTION
## Summary
**User impact:** In the Add-on Manager, when a configured project's address cannot be reached — a wrong or missing local path, no internet, a server error, or a list left over from an older Gramps — it looks exactly the same as "no new add-ons available." Users get no hint that anything is actually wrong.

This adds the backend that classifies each project fetch into a specific outcome, so a follow-up can attach a per-project validity indicator (icon + tooltip) to each row of the Projects tab.

Reported in Mantis [#13069](https://gramps-project.org/bugs/view.php?id=13069).

## What to look at
A new `classify_project_fetch()` performs the same language-chain lookup as `get_addons()` and maps the result to one distinct status (OK / INVALID_URL / NETWORK_ERROR / HTTP_ERROR / JSON_ERROR / EMPTY_LISTING / NO_COMPATIBLE_ADDONS / LANG_FALLBACK_EN), alongside a `normalize_project_url()` helper. The change is backend-only — the existing fetch functions are untouched and the GTK wiring is a separate follow-up. To try it: call `classify_project_fetch()` against a bad URL and inspect the returned status (and `http_code` on HTTP errors).

## Root cause
Bug #13069 (*[6.1 Addon Manager] Add 'valid' indicator for 'project' paths*) lists several failure modes — invalid local paths, missing JSON for the current language, lost internet, HTTP 4xx/5xx, and add-on lists incompatible with the running version (the 2025-04-06 comment about 5.2 projects left over after upgrade to 6.0) — that all appear identical to the user today, because `gramps/gen/plug/utils.py` exposes no way to distinguish them.

## Fix
- Add to `gramps/gen/plug/utils.py`: `normalize_project_url()` (strips surrounding whitespace and trailing slashes, rejects non-`http(s)://` / `file://` values), `ProjectFetchStatus` constants, a `ProjectFetchResult` dataclass, `classify_project_fetch(url, current_version=None, languages=None)`, and two private helpers (`_candidate_languages`, `_try_fetch_listing`).
- `classify_project_fetch` runs the same language-chain lookup as `get_addons()`, then classifies the outcome as OK, INVALID_URL, NETWORK_ERROR (`urlopen` raised `URLError`), HTTP_ERROR (`HTTPError`, with `http_code` populated), JSON_ERROR (body not valid JSON / not an array), EMPTY_LISTING, NO_COMPATIBLE_ADDONS (no entry targets the running major.minor), or LANG_FALLBACK_EN (requested language unavailable, English fallback used).
- `get_addons()`, `get_all_addons()`, `available_updates()`, `load_addon_file()` are unchanged — the classifier is purely additive. Adds `gramps/gen/plug/test/__init__.py` (new, empty) marker. The GTK-side wiring (status icon / tooltip per Projects-tab row in `gramps/gui/plug/_windows.py`) is deliberately deferred to a follow-up PR.

## Verification
- **Claim:** each project-fetch outcome is classified into a distinct `ProjectFetchStatus` (populating `http_code` on HTTP errors), with URL normalization (whitespace / trailing slash / scheme) applied first.
- **Checked:** `gramps/gen/plug/utils.py` on master (the branch this PR targets) — additive classifier; existing fetch functions unchanged.
- **Test:** `gramps/gen/plug/test/_utils_project_status_test.py` (new) — 20 tests: 8 `NormalizeProjectUrlTest` (whitespace / trailing-slash stripping, scheme validation, non-string / empty rejection) and 12 `ClassifyProjectFetchTest` covering every `ProjectFetchStatus` value plus the "trailing slash is normalized before the listing URL is built" invariant, with all network access mocked via `urlopen_maybe_no_check_cert`. `mypy` and `black --check` clean; full suite 32,519 tests, only the two pre-existing unrelated `test_WebCal` / `test_navwebpage` failures. This PR is backend-only groundwork for the indicator; the user-facing UI is a follow-up, so it does not close the bug.

Bug [#13069](https://gramps-project.org/bugs/view.php?id=13069)
