### PR TITLE
Follow symlinks when scanning plugin directories (#10436)

### DIFF
--- a/gramps/gen/plug/_manager.py
+++ b/gramps/gen/plug/_manager.py
@@ -140,7 +140,18 @@ class BasePluginManager:
         #             direct in self.__scanned_dirs, os.path.isdir(direct))
 
         if os.path.isdir(direct):
-            for dirpath, dirnames, filenames in os.walk(direct, topdown=True):
+            # Follow symlinks so users can organize plugins by symlinking
+            # directories into their plugin path.  Track resolved paths to
+            # avoid infinite recursion on symlink loops.
+            visited_realpaths: set[str] = set()
+            for dirpath, dirnames, filenames in os.walk(
+                direct, topdown=True, followlinks=True
+            ):
+                real = os.path.realpath(dirpath)
+                if real in visited_realpaths:
+                    dirnames[:] = []
+                    continue
+                visited_realpaths.add(real)
                 for dirname in dirnames[:]:
                     # Skip hidden and system directories:
                     if dirname.startswith(".") or dirname in [

--- a/gramps/gen/plug/test/_manager_symlinks_test.py
+++ b/gramps/gen/plug/test/_manager_symlinks_test.py
@@ -1,0 +1,95 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Eduard Ralph
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Tests that plugin scanning follows symlinks and survives symlink loops."""
+
+# ------------------------
+# Python modules
+# ------------------------
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+# ------------------------
+# Gramps modules
+# ------------------------
+from .._manager import BasePluginManager
+from gramps.gen.constfunc import win
+
+
+# ------------------------------------------------------------
+#
+# RegPluginsSymlinkTest
+#
+# ------------------------------------------------------------
+@unittest.skipIf(win(), "Symlinks not supported or tested by default on Windows")
+class RegPluginsSymlinkTest(unittest.TestCase):
+    """Exercise the os.walk(followlinks=True) behavior in reg_plugins."""
+
+    def setUp(self) -> None:
+        self.mgr = BasePluginManager.get_instance()
+        self.pgr = self.mgr._BasePluginManager__pgr  # type: ignore[attr-defined]
+
+    def test_symlinked_subdir_is_scanned(self) -> None:
+        """A directory reached only via a symlink must be scanned."""
+        with tempfile.TemporaryDirectory() as tmp:
+            target = os.path.join(tmp, "target_plugin")
+            os.makedirs(target)
+            # A marker filename so we can confirm scan_dir saw target's contents.
+            open(os.path.join(target, "marker.gpr.py"), "w").close()
+
+            plugin_root = os.path.join(tmp, "plugins")
+            os.makedirs(plugin_root)
+            link = os.path.join(plugin_root, "linked_plugin")
+            os.symlink(target, link, target_is_directory=True)
+
+            with patch.object(self.pgr, "scan_dir") as mock_scan:
+                self.mgr.reg_plugins(plugin_root)
+
+            visited = [call.args[0] for call in mock_scan.call_args_list]
+            self.assertIn(link, visited)
+            # scan_dir must have received the marker filename for the link.
+            link_call = next(
+                call for call in mock_scan.call_args_list if call.args[0] == link
+            )
+            self.assertIn("marker.gpr.py", link_call.args[1])
+
+    def test_self_referential_symlink_loop_terminates(self) -> None:
+        """A symlink pointing at an ancestor must not cause infinite recursion."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = os.path.join(tmp, "plugin_root")
+            os.makedirs(root)
+            # Absolute symlink pointing back at root creates an infinite tree
+            # under os.walk(..., followlinks=True) unless guarded.
+            os.symlink(root, os.path.join(root, "loop"), target_is_directory=True)
+
+            with patch.object(self.pgr, "scan_dir") as mock_scan:
+                self.mgr.reg_plugins(root)
+
+            # Either scan_dir is called a bounded number of times, or our
+            # realpath dedup prunes the recursion before reaching scan_dir
+            # a second time.  The absolute bound here is generous on purpose
+            # to leave room for platform quirks.
+            self.assertLess(mock_scan.call_count, 10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -261,6 +261,11 @@ gramps/gen/plug/report/_options.py
 gramps/gen/plug/report/_paper.py
 gramps/gen/plug/report/_reportbase.py
 #
+# gen.plug.test
+#
+gramps/gen/plug/test/__init__.py
+gramps/gen/plug/test/_manager_symlinks_test.py
+#
 # gen proxy API
 #
 gramps/gen/proxy/__init__.py


### PR DESCRIPTION
## Summary

Fixes Mantis [bug #10436](https://gramps-project.org/bugs/view.php?id=10436) (open since 2018-02-16, tagged PATCH).

`BasePluginManager.reg_plugins` walked plugin directories with `os.walk(..., topdown=True)`, leaving `followlinks` at the default of `False`. Any plugin directory reached via a symlink was silently skipped. Users who wanted to organize their plugin library by symlinking individual plugins into the Gramps plugin path had to work around this with a separate loader addon (the `pluginloader.py` community addon by kku does exactly this).

This PR flips `followlinks=True` on the walk and adds a small guard to prevent infinite recursion if a symlink points back at an ancestor.

## Change

`gramps/gen/plug/_manager.py`:

- Pass `followlinks=True` to `os.walk()`.
- Track the resolved path (`os.path.realpath`) of each visited directory within the walk and prune recursion if we re-enter a directory we've already seen. This terminates on pathological symlink loops without relying on the process being killed.

## Tests

New test file `gramps/gen/plug/test/_manager_symlinks_test.py` with two cases:

1. `test_symlinked_subdir_is_scanned` — creates a plugin directory that is only reachable via a symlink and asserts `scan_dir` is invoked against it.
2. `test_self_referential_symlink_loop_terminates` — creates a self-referential symlink loop and asserts `reg_plugins` terminates with a bounded number of `scan_dir` calls.

Full test suite: 32499 baseline + 2 new = 32501 tests, pass (the two pre-existing `test_WebCal` / `test_navwebpage` failures on `master` are unrelated to this change).

## Policy note — unconditional vs. dev-mode gated

In the 2018 discussion on #10436, admin Sam888 suggested that symlink-following might only be enabled in developer mode. The reporter (Pander) pushed back, observing that Gramps runs as the user and a symlink inside a plugin directory cannot expose anything the user does not already have access to — there is no security delta.

I agree with the reporter and have implemented this unconditionally:

- **No security delta.** Symlinks honor the user's own filesystem permissions.
- **Dev-mode gating would defeat the request.** The bug was filed by an end user who wants to organize their own plugins by symlinking. Hiding the feature behind developer mode leaves that exact user unable to use it.
- **The only real hazard — symlink loops — is handled in code** via the `realpath` dedup, not by a flag.

Happy to move this behind a config option if reviewers prefer; that would be a small conditional around the walk call.