### PR TITLE
Allow requires_mod entries to specify pip package name and version

### DIFF
--- a/gramps/gen/plug/_pluginreg.py
+++ b/gramps/gen/plug/_pluginreg.py
@@ -299,7 +299,10 @@ class PluginData:
        The URL where documentation for the plugin can be found
     .. attribute:: requires_mod
        A list of required modules that should be importable using the python
-       `import` statement.
+       `import` statement.  Each entry may be either a plain string (the
+       import name) or a ``(import_name, pip_spec)`` tuple where *pip_spec*
+       is the pip package name with an optional version constraint, e.g.
+       ``("gramps_gedcom7", "gramps-gedcom7>=1.0")``.
     .. attribute:: requires_gi
        A list of (module, version) tuples that specify required modules that
        are reuired to be loaded via the GObject introspection system.

--- a/gramps/gen/utils/requirements.py
+++ b/gramps/gen/utils/requirements.py
@@ -41,20 +41,47 @@ _ = glocale.translation.sgettext
 # Requirements
 #
 # -------------------------------------------------------------------------
+def _mod_entry(entry: str | tuple[str, str]) -> tuple[str, str]:
+    """
+    Normalise a requires_mod / rm list entry.
+
+    Accepted forms::
+
+      "import_name"                         ->  ("import_name", "import_name")
+      ("import_name", "pip-package>=1.0")   ->  ("import_name", "pip-package>=1.0")
+
+    :param entry: Either a plain import name string or a
+        ``(import_name, pip_spec)`` tuple.
+    :type entry: str | tuple[str, str]
+    :returns: A ``(import_name, pip_spec)`` tuple.
+    :rtype: tuple[str, str]
+    """
+    if isinstance(entry, str):
+        return (entry, entry)
+    return (entry[0], entry[1])
+
+
 class Requirements:
     def __init__(self):
         self.mod_list = []
         self.gi_list = []
         self.exe_list = []
 
-    def check_mod(self, module):
+    def check_mod(self, entry: str | tuple[str, str]) -> bool:
         """
         Check to see if a given module is available.
+
+        :param entry: Either a plain import name string or a
+            ``(import_name, pip_spec)`` tuple.
+        :type entry: str | tuple[str, str]
+        :returns: ``True`` if the module can be imported, ``False`` otherwise.
+        :rtype: bool
         """
-        if module in self.mod_list:
+        import_name, _pip_spec = _mod_entry(entry)
+        if import_name in self.mod_list:
             return True
-        if find_spec(module) is not None:
-            self.mod_list.append(module)
+        if find_spec(import_name) is not None:
+            self.mod_list.append(import_name)
             return True
         else:
             return False
@@ -132,15 +159,22 @@ class Requirements:
         """
         return self.check(plugin.requires_gi, plugin.requires_exe, plugin.requires_mod)
 
-    def install(self, addon):
+    def install(self, addon: dict) -> list[str]:
         """
-        Return a list of modules required to be installed.
+        Return a list of pip specs for modules that are not yet installed.
+
+        :param addon: Addon metadata dict, optionally containing an ``"rm"``
+            key whose value is a list of requires_mod entries.
+        :type addon: dict
+        :returns: Pip install specs for any missing modules.
+        :rtype: list[str]
         """
         install_list = []
         if "rm" in addon:
-            for module in addon.get("rm"):
-                if not self.check_mod(module):
-                    install_list.append(module)
+            for entry in addon.get("rm", []):
+                if not self.check_mod(entry):
+                    _import_name, pip_spec = _mod_entry(entry)
+                    install_list.append(pip_spec)
         return install_list
 
     def info(self, addon):
@@ -151,9 +185,15 @@ class Requirements:
         if "rm" in addon:
             info.append(_("Python modules"))
             table = []
-            for module in addon.get("rm"):
-                result = self.check_mod(module)
-                table.append([module, tick_cross(result)])
+            for entry in addon.get("rm"):
+                import_name, pip_spec = _mod_entry(entry)
+                label = (
+                    import_name
+                    if import_name == pip_spec
+                    else f"{import_name} ({pip_spec})"
+                )
+                result = self.check_mod(entry)
+                table.append([label, tick_cross(result)])
             info.append(table)
         if "rg" in addon:
             info.append(_("GObject introspection modules"))

--- a/gramps/gen/utils/test/requirements_test.py
+++ b/gramps/gen/utils/test/requirements_test.py
@@ -1,0 +1,120 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+import unittest
+
+from ..requirements import Requirements, _mod_entry
+
+
+class TestModEntry(unittest.TestCase):
+    def test_string_returns_same_for_both(self):
+        self.assertEqual(_mod_entry("os"), ("os", "os"))
+
+    def test_string_hyphenated_package(self):
+        self.assertEqual(
+            _mod_entry(("gramps_gedcom7", "gramps-gedcom7")),
+            ("gramps_gedcom7", "gramps-gedcom7"),
+        )
+
+    def test_tuple_with_version_constraint(self):
+        self.assertEqual(
+            _mod_entry(("gramps_gedcom7", "gramps-gedcom7>=1.0")),
+            ("gramps_gedcom7", "gramps-gedcom7>=1.0"),
+        )
+
+
+class TestCheckMod(unittest.TestCase):
+    def setUp(self):
+        self.req = Requirements()
+
+    def test_string_present_module(self):
+        self.assertTrue(self.req.check_mod("os"))
+
+    def test_string_absent_module(self):
+        self.assertFalse(self.req.check_mod("_nonexistent_module_xyz"))
+
+    def test_tuple_present_module(self):
+        self.assertTrue(self.req.check_mod(("os", "os-package")))
+
+    def test_tuple_absent_module(self):
+        self.assertFalse(
+            self.req.check_mod(("_nonexistent_module_xyz", "nonexistent-pkg>=1.0"))
+        )
+
+    def test_string_result_cached(self):
+        self.req.check_mod("os")
+        self.assertIn("os", self.req.mod_list)
+
+    def test_tuple_caches_import_name_not_pip_spec(self):
+        self.req.check_mod(("os", "os-package>=1.0"))
+        self.assertIn("os", self.req.mod_list)
+        self.assertNotIn("os-package>=1.0", self.req.mod_list)
+
+
+class TestInstall(unittest.TestCase):
+    def setUp(self):
+        self.req = Requirements()
+
+    def test_string_missing_module_returns_import_name(self):
+        result = self.req.install({"rm": ["_nonexistent_module_xyz"]})
+        self.assertEqual(result, ["_nonexistent_module_xyz"])
+
+    def test_tuple_missing_module_returns_pip_spec(self):
+        result = self.req.install(
+            {"rm": [("_nonexistent_module_xyz", "nonexistent-pkg>=1.0")]}
+        )
+        self.assertEqual(result, ["nonexistent-pkg>=1.0"])
+
+    def test_present_module_not_in_install_list(self):
+        result = self.req.install({"rm": ["os"]})
+        self.assertEqual(result, [])
+
+    def test_mixed_list(self):
+        result = self.req.install(
+            {"rm": ["os", ("_nonexistent_module_xyz", "nonexistent-pkg>=2.0")]}
+        )
+        self.assertEqual(result, ["nonexistent-pkg>=2.0"])
+
+    def test_no_rm_key(self):
+        self.assertEqual(self.req.install({}), [])
+
+
+class TestInfo(unittest.TestCase):
+    def setUp(self):
+        self.req = Requirements()
+
+    def test_string_label_is_plain_name(self):
+        info = self.req.info({"rm": ["os"]})
+        table = info[1]
+        self.assertEqual(table[0][0], "os")
+
+    def test_tuple_label_shows_pip_spec_when_different(self):
+        info = self.req.info({"rm": [("gramps_gedcom7", "gramps-gedcom7>=1.0")]})
+        table = info[1]
+        self.assertIn("gramps_gedcom7", table[0][0])
+        self.assertIn("gramps-gedcom7>=1.0", table[0][0])
+
+    def test_tuple_label_plain_when_same(self):
+        info = self.req.info({"rm": [("os", "os")]})
+        table = info[1]
+        self.assertEqual(table[0][0], "os")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -314,6 +314,7 @@ gramps/gen/utils/test/file_test.py
 gramps/gen/utils/test/grampslocale_test.py
 gramps/gen/utils/test/keyword_test.py
 gramps/gen/utils/test/place_test.py
+gramps/gen/utils/test/requirements_test.py
 #
 # gui - GUI code
 #


### PR DESCRIPTION
## Summary

- `requires_mod` entries (and addon `rm` list entries) can now be either a plain string (existing behaviour, fully backwards compatible) or a `(import_name, pip_spec)` tuple, e.g. `("gramps_gedcom7", "gramps-gedcom7>=1.0")`.
- `check_mod()` uses the import name for `find_spec()`.
- `install()` returns the pip spec so the correct package name and optional version constraint are passed to pip.
- `info()` displays `import_name (pip_spec)` when the two differ.
- 17 unit tests added in `gramps/gen/utils/test/requirements_test.py`.

## Test plan

- [ ] Run `GRAMPS_RESOURCES=. python3 -m unittest gramps.gen.utils.test.requirements_test` — all 17 tests pass.
- [ ] Run `mypy gramps/gen/utils/requirements.py` — no errors.
- [ ] Verify existing plugins that use plain-string `requires_mod` entries are unaffected.
- [ ] Verify a plugin using the new tuple form (e.g. `requires_mod = [("gramps_gedcom7", "gramps-gedcom7>=1.0")]`) is correctly checked and installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)