### PR TITLE
Remove leftover mingw64 entry from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ docs/_build/
 
 # Gramps AIO build artifacts
 aio/grampsaio64.nsi
-aio/mingw-w64-x86_64-db-*.pkg.tar.xz
 aio/ucrt64
 *.egg-info
 


### PR DESCRIPTION
now that we have switched to ucrt64 this entry is no longer required