### PR TITLE
Fix mypy errors on windows

### DIFF
--- a/gramps/gen/datehandler/_grampslocale.py
+++ b/gramps/gen/datehandler/_grampslocale.py
@@ -48,7 +48,7 @@ codeset = glocale.encoding  # TODO I don't think "codeset" is used anymore
 
 try:
     if sys.platform == "win32":
-        raise locale.Error # local.nl_langinfo is not supported on Windows
+        raise locale.Error  # local.nl_langinfo is not supported on Windows
 
     # here only for the upgrade tool, see _datestrings.py __main__
     _deprecated_long_months = (

--- a/gramps/gen/datehandler/_grampslocale.py
+++ b/gramps/gen/datehandler/_grampslocale.py
@@ -25,6 +25,7 @@
 #
 # -------------------------------------------------------------------------
 import locale
+import sys
 
 # -------------------------------------------------------------------------
 #
@@ -46,6 +47,9 @@ set, we have to convert to unicode.
 codeset = glocale.encoding  # TODO I don't think "codeset" is used anymore
 
 try:
+    if sys.platform == "win32":
+        raise locale.Error # local.nl_langinfo is not supported on Windows
+
     # here only for the upgrade tool, see _datestrings.py __main__
     _deprecated_long_months = (
         "",

--- a/gramps/gen/datehandler/_grampslocale.py
+++ b/gramps/gen/datehandler/_grampslocale.py
@@ -25,6 +25,7 @@
 #
 # -------------------------------------------------------------------------
 import locale
+import sys
 
 # -------------------------------------------------------------------------
 #
@@ -46,6 +47,9 @@ set, we have to convert to unicode.
 codeset = glocale.encoding  # TODO I don't think "codeset" is used anymore
 
 try:
+    if sys.platform == "win32":
+        raise locale.Error  # locale.nl_langinfo is not supported on Windows
+
     # here only for the upgrade tool, see _datestrings.py __main__
     _deprecated_long_months = (
         "",

--- a/gramps/grampsapp.py
+++ b/gramps/grampsapp.py
@@ -235,7 +235,7 @@ except ImportError:
 #
 # -------------------------------------------------------------------------
 try:
-    signal.signal(signal.SIGCHLD, signal.SIG_DFL)
+    signal.signal(signal.SIGCHLD, signal.SIG_DFL)  # type: ignore[attr-defined] # SIGCHLD is not defined on all platforms
 except:
     pass
 

--- a/gramps/grampsapp.py
+++ b/gramps/grampsapp.py
@@ -235,7 +235,9 @@ except ImportError:
 #
 # -------------------------------------------------------------------------
 try:
-    signal.signal(signal.SIGCHLD, signal.SIG_DFL)  # type: ignore[attr-defined] # SIGCHLD is not defined on all platforms
+    # signal.SIGCHLD is only available on Unix
+    if sys.platform != "win32":
+        signal.signal(signal.SIGCHLD, signal.SIG_DFL)
 except:
     pass
 

--- a/gramps/grampsapp.py
+++ b/gramps/grampsapp.py
@@ -235,7 +235,9 @@ except ImportError:
 #
 # -------------------------------------------------------------------------
 try:
-    signal.signal(signal.SIGCHLD, signal.SIG_DFL)
+    # signal.SIGCHLD is only available on Unix
+    if sys.platform != "win32":
+        signal.signal(signal.SIGCHLD, signal.SIG_DFL)
 except:
     pass
 


### PR DESCRIPTION
Some python module attributes are not available on all platforms. 
If an attribute is not available, mypy reports an error. For example, On Windows
```bash
gramps/gen/datehandler/_grampslocale.py:91: error: Module has no attribute "nl_langinfo"  [attr-defined]
```

This PR fixes mypy's `attr-defined` error for
- [`locale.nl_langinfo`](https://docs.python.org/3/library/locale.html#locale.nl_langinfo)
- [`signal.SIGCHLD`](https://docs.python.org/3/library/signal.html#signal.SIGCHLD)

neither of which is available on Windows

Two approaches were considered and I settled on the second
1. Add `# type: ignore[attr-defined]` to relevant lines
    there are many lines to change and it clutters the code
    it suppresses the error for all platforms
2. protect relevant code with `sys.platform` checks
    fewer lines to change
    recognised by mypy - but not if Gramps `win()` function is used

    