### PR TITLE
Fix AIO workflow for Gramps 6.1

### DIFF
--- a/.github/workflows/windows-aio.yml
+++ b/.github/workflows/windows-aio.yml
@@ -50,8 +50,10 @@ jobs:
         cd aio
         ./build.sh ${{ inputs.cleanup }} ${{ inputs.build-number }}
     - name: Run unit test suite
+      if: ${{ ! inputs.cleanup }} # can only run unit tests if python venv was preserved
       run: |
         export GRAMPS_RESOURCES=build/share
+        source /tmp/grampspythonenv/bin/activate
         python3 -m unittest discover -p "*_test.py"
     - uses: actions/upload-artifact@v6
       with:

--- a/aio/build.sh
+++ b/aio/build.sh
@@ -80,7 +80,7 @@ source $pythonvenv/bin/activate
 
 ## prerequisites in pip packages
 python -m pip install --upgrade pip
-pip install --upgrade orjson pydot pydotplus pygraphviz requests selenium
+pip install --upgrade orjson==3.11.7 pydot pydotplus pygraphviz requests selenium
 
 ## download dictionaries
 mkdir -p /ucrt64/share/enchant/hunspell


### PR DESCRIPTION
The gramps 6.1 workflow is failing to build, with errors compiling orjson 3.11.8. See below for selected log messages.
Fix this by pinning orjson to version 3.11.7 (for Windows AIO builds only)

Update the AIO unit test workflows so that the unit test suite
- is only run if the python venv is available
- activates the venv before running the tests

```
Building wheels for collected packages: orjson, pydotplus, pygraphviz
  Building wheel for orjson (pyproject.toml): started
  Building wheel for orjson (pyproject.toml): finished with status 'error'
  error: subprocess-exited-with-error
  
  Building wheel for orjson (pyproject.toml) did not run successfully.
  exit code: 1
```

```
For more information about this error, try `rustc --explain E0554`.
  error: could not compile `orjson` (lib) due to 1 previous error
  💥 maturin failed
    Caused by: Failed to build a native library through cargo
    Caused by: Cargo build finished with "exit code: 101": `"cargo" "rustc" "--profile" "release" "--message-format" "json-render-diagnostics" "--manifest-path" "D:\\a\\_temp\\msys64\\tmp\\pip-install-q7sxd6tt\\orjson_7d41824dfa354d46a6bb6b4952d6757b\\Cargo.toml" "--lib"`
  Error: command ['maturin', 'pep517', 'build-wheel', '-i', 'D:/a/_temp/msys64/tmp/grampspythonenv/bin/python.exe', '--compatibility', 'off'] returned non-zero exit status 1
  [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for orjson
```