### PR TITLE
Trap AIO Build Errors

### DIFF
--- a/aio/build.sh
+++ b/aio/build.sh
@@ -23,6 +23,24 @@
 #   clean-up     : [true|false]. clean the python venv on completion
 #   build-number : the build number to use when DEV_VERSION is not True
 #
+handle_error() {
+    # Get information about the error
+    local error_code=$?
+    local error_line=$BASH_LINENO
+    local error_command=$BASH_COMMAND
+
+    # Log the error details
+    echo "$BASH_ARGV0: Error on line $error_line"
+    echo "    command: $error_command"
+    echo "    exit code: $error_code"
+
+    # exit with the same error code
+    exit $error_code
+}
+
+# trap any non-zero exit code from commands and handle
+trap 'handle_error' ERR
+
 # install prerequisites
 ## prerequisites in msys packages
 pacman -S --needed --noconfirm \


### PR DESCRIPTION
Use a trap to catch all non-zero exit codes during execution of `aio\build.sh`. 

If an error is trapped:
- log information to help diagnose the problem
- exit the script with the non-zero exit code

The non-zero exit code will cause subsequent workflow steps to not run

Example workflow output using this PR and orjson 3.11.8, which at the time of writing, fails to compile on Window MSYS UCRT64
<img width="1272" height="530" alt="image" src="https://github.com/user-attachments/assets/3c5f3b7b-f137-49ff-8c23-41e4f3652890" />

