### PR TITLE
Ensure date columns are sorted consistently

### DIFF
--- a/gramps/gen/lib/date.py
+++ b/gramps/gen/lib/date.py
@@ -1211,6 +1211,69 @@ class Date(BaseObject):
         """
         return self.sortval
 
+    def get_sort_key(self):
+        """
+        Return an integer sort key that incorporates modifier and quality.
+
+        Unlike :meth:`get_sort_value`, which returns the raw Julian Day Number
+        used for date arithmetic, this value is adjusted so that dates with
+        different modifiers and qualities group correctly in list view columns.
+
+        The return value is ``pos * 12 + modifier_score * 3 + quality_score``.
+
+        Modifier scores:
+
+          0 - MOD_BEFORE
+          1 - MOD_NONE, MOD_FROM, MOD_TO, MOD_SPAN, MOD_RANGE
+          2 - MOD_ABOUT
+          3 - MOD_AFTER
+
+        Quality scores:
+
+          0 - QUAL_NONE
+          1 - QUAL_ESTIMATED
+          2 - QUAL_CALCULATED
+
+        Modifier and quality scores combine independently, so "estimated about
+        1900" (modifier score 2, quality score 1) sorts between plain "about 1900"
+        (2, 0) and "calculated about 1900" (2, 2).
+
+        For year-only MOD_AFTER dates the position advances to the first JDN of
+        the following year so that "after 1900" sorts after every exact date
+        within 1900.  All other modifiers use sortval as the position.
+
+        Use this method when building sort strings for list views.
+        """
+        if self.sortval == 0:
+            return 0
+
+        if self.modifier == Date.MOD_BEFORE:
+            mod_score = 0
+        elif self.modifier == Date.MOD_ABOUT:
+            mod_score = 2
+        elif self.modifier == Date.MOD_AFTER:
+            mod_score = 3
+        else:
+            mod_score = 1
+
+        if self.quality == Date.QUAL_ESTIMATED:
+            qual_score = 1
+        elif self.quality == Date.QUAL_CALCULATED:
+            qual_score = 2
+        else:
+            qual_score = 0
+
+        pos = self.sortval
+        if self.modifier == Date.MOD_AFTER:
+            yr = self.dateval[Date._POS_YR]
+            mon = self.dateval[Date._POS_MON]
+            day = self.dateval[Date._POS_DAY]
+            if day == 0 and mon == 0 and yr != 0:
+                # year-only: advance past the end of the stated year
+                pos = Date._calendar_convert[self.calendar](yr + 1, 1, 1)
+
+        return pos * 12 + mod_score * 3 + qual_score
+
     def get_modifier(self):
         """
         Return an integer indicating the calendar selected.

--- a/gramps/gen/lib/test/date_test.py
+++ b/gramps/gen/lib/test/date_test.py
@@ -1795,5 +1795,98 @@ class AnniversaryDateTest(BaseDateTest):
         self.assertEqual(d.anniversary(1910), (2, 29))
 
 
+class SortKeyTest(BaseDateTest):
+    """Tests for Date.get_sort_key() modifier- and quality-aware sort ordering.
+
+    Formula: position * 12 + modifier_score * 3 + quality_score
+
+    Modifier scores: before=0, none/span/range=1, about=2, after=3
+    Quality scores:  none=0, estimated=1, calculated=2
+    """
+
+    def _make(self, modifier, year=1902, month=0, day=0, quality=Date.QUAL_NONE):
+        d = Date()
+        d.set(quality, modifier, Date.CAL_GREGORIAN, (day, month, year, False))
+        return d
+
+    def test_modifier_score_ordering(self):
+        # before < none < about < after for the same JDN
+        before = self._make(Date.MOD_BEFORE, month=6, day=15)
+        exact = self._make(Date.MOD_NONE, month=6, day=15)
+        about = self._make(Date.MOD_ABOUT, month=6, day=15)
+        after = self._make(Date.MOD_AFTER, month=6, day=15)
+        self.assertLess(before.get_sort_key(), exact.get_sort_key())
+        self.assertLess(exact.get_sort_key(), about.get_sort_key())
+        self.assertLess(about.get_sort_key(), after.get_sort_key())
+
+    def test_span_range_same_modifier_score_as_none(self):
+        # span and range share modifier score 1 with MOD_NONE
+        exact = self._make(Date.MOD_NONE, month=1, day=1)
+        span = Date()
+        span.set(
+            Date.QUAL_NONE,
+            Date.MOD_SPAN,
+            Date.CAL_GREGORIAN,
+            (1, 1, 1902, False, 31, 12, 1902, False),
+        )
+        rng = Date()
+        rng.set(
+            Date.QUAL_NONE,
+            Date.MOD_RANGE,
+            Date.CAL_GREGORIAN,
+            (1, 1, 1902, False, 31, 12, 1902, False),
+        )
+        self.assertEqual(span.get_sort_key(), exact.get_sort_key())
+        self.assertEqual(rng.get_sort_key(), exact.get_sort_key())
+
+    def test_quality_score_ordering(self):
+        # within the same modifier: none < estimated < calculated
+        exact = self._make(Date.MOD_NONE, quality=Date.QUAL_NONE)
+        estimated = self._make(Date.MOD_NONE, quality=Date.QUAL_ESTIMATED)
+        calculated = self._make(Date.MOD_NONE, quality=Date.QUAL_CALCULATED)
+        self.assertLess(exact.get_sort_key(), estimated.get_sort_key())
+        self.assertLess(estimated.get_sort_key(), calculated.get_sort_key())
+
+    def test_all_twelve_combinations_distinct(self):
+        # 4 modifier scores x 3 quality scores must all produce unique sort keys
+        # Use a full date so MOD_AFTER uses the same JDN as the other modifiers
+        dates = [
+            self._make(mod, month=6, day=15, quality=qual)
+            for mod in (Date.MOD_BEFORE, Date.MOD_NONE, Date.MOD_ABOUT, Date.MOD_AFTER)
+            for qual in (Date.QUAL_NONE, Date.QUAL_ESTIMATED, Date.QUAL_CALCULATED)
+        ]
+        keys = [d.get_sort_key() for d in dates]
+        self.assertEqual(len(keys), len(set(keys)))
+
+    def test_quality_varies_within_modifier_score(self):
+        # estimated and calculated about-dates are distinct from plain about
+        about_none = self._make(Date.MOD_ABOUT, quality=Date.QUAL_NONE)
+        about_est = self._make(Date.MOD_ABOUT, quality=Date.QUAL_ESTIMATED)
+        about_calc = self._make(Date.MOD_ABOUT, quality=Date.QUAL_CALCULATED)
+        self.assertLess(about_none.get_sort_key(), about_est.get_sort_key())
+        self.assertLess(about_est.get_sort_key(), about_calc.get_sort_key())
+
+    def test_year_only_after_sorts_past_end_of_year(self):
+        after_year = self._make(Date.MOD_AFTER)  # year-only, month=0, day=0
+        dec31 = self._make(Date.MOD_NONE, month=12, day=31)
+        self.assertGreater(after_year.get_sort_key(), dec31.get_sort_key())
+
+    def test_after_full_date_sorts_after_exact_same_date(self):
+        exact = self._make(Date.MOD_NONE, month=6, day=15)
+        after = self._make(Date.MOD_AFTER, month=6, day=15)
+        self.assertGreater(after.get_sort_key(), exact.get_sort_key())
+
+    # --- edge cases ---
+
+    def test_empty_date_returns_zero(self):
+        self.assertEqual(Date().get_sort_key(), 0)
+
+    def test_sort_value_unaffected_by_modifier(self):
+        # get_sort_value() must remain the raw JDN - used for date arithmetic
+        before = self._make(Date.MOD_BEFORE)
+        exact = self._make(Date.MOD_NONE)
+        self.assertEqual(before.get_sort_value(), exact.get_sort_value())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/gramps/gui/views/treemodels/citationbasemodel.py
+++ b/gramps/gui/views/treemodels/citationbasemodel.py
@@ -77,7 +77,7 @@ class CitationBaseModel:
     def citation_sort_date(self, data):
         if data.date:
             citation = data_to_object(data)
-            retval = "%09d" % citation.get_date_object().get_sort_value()
+            retval = "%09d" % citation.get_date_object().get_sort_key()
             if not get_date_valid(citation):
                 return INVALID_DATE_FORMAT % retval
             else:

--- a/gramps/gui/views/treemodels/eventmodel.py
+++ b/gramps/gui/views/treemodels/eventmodel.py
@@ -166,7 +166,7 @@ class EventModel(FlatBaseModel):
     def sort_date(self, data):
         if data.date:
             event = data_to_object(data)
-            retval = "%09d" % event.get_date_object().get_sort_value()
+            retval = "%09d" % event.get_date_object().get_sort_key()
             if not get_date_valid(event):
                 return INVALID_DATE_FORMAT % retval
             else:

--- a/gramps/gui/views/treemodels/familymodel.py
+++ b/gramps/gui/views/treemodels/familymodel.py
@@ -191,7 +191,7 @@ class FamilyModel(FlatBaseModel):
             family = self.db.get_family_from_handle(data.handle)
             event = get_marriage_or_fallback(self.db, family)
             if event:
-                value = "%09d" % event.date.get_sort_value()
+                value = "%09d" % event.date.get_sort_key()
             else:
                 value = ""
             self.set_cached_value(handle, "SORT_MARRIAGE", value)

--- a/gramps/gui/views/treemodels/mediamodel.py
+++ b/gramps/gui/views/treemodels/mediamodel.py
@@ -142,7 +142,7 @@ class MediaModel(FlatBaseModel):
         obj = data_to_object(data)
         d = obj.get_date_object()
         if d:
-            return "%09d" % d.get_sort_value()
+            return "%09d" % d.get_sort_key()
         else:
             return ""
 

--- a/gramps/gui/views/treemodels/peoplemodel.py
+++ b/gramps/gui/views/treemodels/peoplemodel.py
@@ -240,7 +240,7 @@ class PeopleBaseModel(BaseModel):
                 b = data_to_object(local)
                 birth = self.db.get_event_from_handle(b.ref)
                 if sort_mode:
-                    retval = "%09d" % birth.get_date_object().get_sort_value()
+                    retval = "%09d" % birth.get_date_object().get_sort_key()
                 else:
                     date_str = get_date(birth)
                     if date_str != "":
@@ -263,7 +263,7 @@ class PeopleBaseModel(BaseModel):
                 and date_str != ""
             ):
                 if sort_mode:
-                    retval = "%09d" % event.get_date_object().get_sort_value()
+                    retval = "%09d" % event.get_date_object().get_sort_key()
                 else:
                     retval = "<i>%s</i>" % escape(date_str)
                 if not get_date_valid(event):
@@ -297,7 +297,7 @@ class PeopleBaseModel(BaseModel):
                 ref = data_to_object(local)
                 event = self.db.get_event_from_handle(ref.ref)
                 if sort_mode:
-                    retval = "%09d" % event.get_date_object().get_sort_value()
+                    retval = "%09d" % event.get_date_object().get_sort_key()
                 else:
                     date_str = get_date(event)
                     if date_str != "":
@@ -320,7 +320,7 @@ class PeopleBaseModel(BaseModel):
                 and date_str
             ):
                 if sort_mode:
-                    retval = "%09d" % event.get_date_object().get_sort_value()
+                    retval = "%09d" % event.get_date_object().get_sort_key()
                 else:
                     retval = "<i>%s</i>" % escape(date_str)
                 if not get_date_valid(event):


### PR DESCRIPTION
The original report noted that date columns sort without grouping dates with qualifiers like about, after, before so they appear in an arbitrary order.

This happens because get_sort_value() returns only the Julian Day Number with no modifier or quality information.

This change adds Date.get_sort_key() which creates a sort key based on the JDN adjusted with scores for modifiers and quality

It also updates date sort columns in the list view treemodels (peoplemodel, familymodel, eventmodel, mediamodel, citationbasemodel) to call get_sort_key() instead of get_sort_value().

The key is 'JDN * 12 + modifier_score * 3 + quality_score'

Modifier scores:

  0 - MOD_BEFORE
  1 - MOD_NONE, MOD_FROM, MOD_TO, MOD_SPAN, MOD_RANGE
  2 - MOD_ABOUT
  3 - MOD_AFTER

Quality scores:

  0 - QUAL_NONE
  1 - QUAL_ESTIMATED
  2 - QUAL_CALCULATED

For year-only after-dates the position advances to the first JDN of the following year, which is correct for all supported calendars. This ensures 'after 1823' sorts after '1823-12-31'.

The max sort key for 31 Dec 9999 is 64481819 (JDN 5373484 * 12) which fits in the format string "%09d" used by treemodels.

get_sort_value() is unchanged and continues to be used for date arithmetic, calendar conversion and span calculations throughout the rest of the codebase.

Fixes [#7761](https://gramps-project.org/bugs/view.php?id=7761).