### PR TITLE
Add 'New' button to Place, Source, and Citation selector dialogs

### DIFF
--- a/gramps/gui/glade/baseselector.glade
+++ b/gramps/gui/glade/baseselector.glade
@@ -66,6 +66,23 @@
                 <property name="secondary">True</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkButton" id="newbutton">
+                <property name="label" translatable="yes">_New</property>
+                <property name="visible">False</property>
+                <property name="no-show-all">True</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">3</property>
+                <property name="secondary">True</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/gramps/gui/selectors/baseselector.py
+++ b/gramps/gui/selectors/baseselector.py
@@ -125,6 +125,8 @@ class BaseSelector(ManagedWindow):
         self.define_help_button(
             self.glade.get_object("help"), self.WIKI_HELP_PAGE, self.WIKI_HELP_SEC
         )
+        self.new_button = self.glade.get_object("newbutton")
+        self.new_button.connect("clicked", self.cb_new_button_clicked)
 
         # connect to signal for custom interactive-search
         self.searchbox = InteractiveSearchBox(self.tree)
@@ -261,6 +263,24 @@ class BaseSelector(ManagedWindow):
 
     def _on_row_activated(self, treeview, path, view_col):
         self.window.response(Gtk.ResponseType.OK)
+
+    def enable_new_button(self) -> None:
+        """
+        Show the 'New' button. Call from ``_local_init()`` in subclasses
+        that want to offer in-place object creation.
+        """
+        self.new_button.show()
+
+    def cb_new_button_clicked(self, obj: Gtk.Button) -> None:
+        """
+        Handle a click on the 'New' button.
+
+        The default implementation is a no-op.  Subclasses should override
+        this to open the appropriate editor for creating a new object.
+
+        :param obj: The 'New' button that was clicked.
+        :type obj: Gtk.Button
+        """
 
     def _local_init(self):
         # define selector-specific init routine

--- a/gramps/gui/selectors/baseselector.py
+++ b/gramps/gui/selectors/baseselector.py
@@ -45,6 +45,7 @@ from ..glade import Glade
 from ..widgets.interactivesearchbox import InteractiveSearchBox
 from ..display import display_help
 from gramps.gen.const import URL_MANUAL_PAGE
+from gramps.gen.dbstate import DbState
 from gramps.gen.filters import GenericFilter
 from gramps.gui.widgets.persistenttreeview import PersistentTreeView
 from gramps.gui.widgets.multitreeview import MultiTreeView
@@ -96,6 +97,7 @@ class BaseSelector(ManagedWindow):
         self.track_ref_for_deletion("renderer")
         self.renderer.set_property("ellipsize", Pango.EllipsizeMode.END)
 
+        self.dbstate: DbState = dbstate
         self.db = dbstate.db
         self.tree = None
         self.model = None

--- a/gramps/gui/selectors/baseselector.py
+++ b/gramps/gui/selectors/baseselector.py
@@ -223,8 +223,20 @@ class BaseSelector(ManagedWindow):
             self.columns.append(column)
             tree.append_column(column)
 
-    def build_menu_names(self, obj):
-        return (self.title, None)
+    def build_menu_names(self, obj: object) -> tuple[str, str]:
+        """
+        Return the menu label and submenu label for the Windows menu.
+
+        Returning a non-None submenu label registers this window as a
+        branch in the GrampsWindowManager tree, which allows child
+        windows (such as the editor opened by the 'New' button) to be
+        attached to it.
+
+        :param obj: Unused; required by the ManagedWindow interface.
+        :returns: Tuple of (menu_label, submenu_label).
+        :rtype: tuple[str, str]
+        """
+        return (self.title, self.title)
 
     def get_selected_ids(self):
         mlist = []

--- a/gramps/gui/selectors/baseselector.py
+++ b/gramps/gui/selectors/baseselector.py
@@ -425,6 +425,7 @@ class BaseSelector(ManagedWindow):
         Finalize rest
         """
         self.clear_model()
+        self.dbstate = None
         self.db = None
         self.tree = None
         self.columns = None

--- a/gramps/gui/selectors/selectcitation.py
+++ b/gramps/gui/selectors/selectcitation.py
@@ -41,6 +41,7 @@ _ = glocale.translation.sgettext
 from gramps.gen.const import URL_MANUAL_SECT2
 from gramps.gen.errors import WindowActiveError
 from gramps.gen.lib import Citation, Source
+from ..editors import EditCitation, EditSource
 from ..views.treemodels import CitationTreeModel
 from .baseselector import BaseSelector
 
@@ -97,8 +98,6 @@ class SelectCitation(BaseSelector):
         """
         Open the Edit Source dialog to create a new source.
         """
-        from gramps.gui.editors import EditSource
-
         try:
             EditSource(
                 self.dbstate,
@@ -114,8 +113,6 @@ class SelectCitation(BaseSelector):
         """
         Open the Edit Citation dialog to create a new citation.
         """
-        from gramps.gui.editors import EditCitation
-
         try:
             EditCitation(
                 self.dbstate,

--- a/gramps/gui/selectors/selectcitation.py
+++ b/gramps/gui/selectors/selectcitation.py
@@ -25,21 +25,24 @@ SelectCitation class for Gramps.
 
 # -------------------------------------------------------------------------
 #
-# internationalization
+# GTK/Gnome modules
 #
 # -------------------------------------------------------------------------
+from gi.repository import Gtk
 
 # -------------------------------------------------------------------------
 #
-# gramps modules
+# Gramps modules
 #
 # -------------------------------------------------------------------------
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 
 _ = glocale.translation.sgettext
+from gramps.gen.const import URL_MANUAL_SECT2
+from gramps.gen.errors import WindowActiveError
+from gramps.gen.lib import Citation, Source
 from ..views.treemodels import CitationTreeModel
 from .baseselector import BaseSelector
-from gramps.gen.const import URL_MANUAL_SECT2
 
 # -------------------------------------------------------------------------
 #
@@ -50,23 +53,115 @@ from gramps.gen.const import URL_MANUAL_SECT2
 
 # -------------------------------------------------------------------------
 #
-# SelectSource
+# SelectCitation
 #
 # -------------------------------------------------------------------------
 class SelectCitation(BaseSelector):
-    def _local_init(self):
+    def _local_init(self) -> None:
         """
-        Perform local initialisation for this class
+        Perform local initialisation for this class.
         """
         self.setup_configs("interface.source-sel", 600, 450)
+        self.enable_new_button()
 
-    def get_window_title(self):
+    def cb_new_button_clicked(self, obj: Gtk.Button) -> None:
+        """
+        Ask the user whether to create a new Source or Citation, then
+        open the appropriate editor.
+
+        Citations are children of Sources, so the user must choose which
+        kind of object to create.  After a successful save the tree is
+        rebuilt and the new object is selected.
+
+        :param obj: The 'New' button that was clicked.
+        :type obj: Gtk.Button
+        """
+        dialog = Gtk.MessageDialog(
+            transient_for=self.window,
+            modal=True,
+            message_type=Gtk.MessageType.QUESTION,
+            buttons=Gtk.ButtonsType.NONE,
+            text=_("What would you like to create?"),
+        )
+        dialog.add_button(_("New _Source"), 1)
+        dialog.add_button(_("New _Citation"), 2)
+        dialog.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
+        response = dialog.run()
+        dialog.destroy()
+        if response == 1:
+            self._new_source()
+        elif response == 2:
+            self._new_citation()
+
+    def _new_source(self) -> None:
+        """
+        Open the Edit Source dialog to create a new source.
+        """
+        from gramps.gui.editors import EditSource
+
+        try:
+            EditSource(
+                self.dbstate,
+                self.uistate,
+                self.track,
+                Source(),
+                self.cb_after_new_saved,
+            )
+        except WindowActiveError:
+            pass
+
+    def _new_citation(self) -> None:
+        """
+        Open the Edit Citation dialog to create a new citation.
+        """
+        from gramps.gui.editors import EditCitation
+
+        try:
+            EditCitation(
+                self.dbstate,
+                self.uistate,
+                self.track,
+                Citation(),
+                callback=self.cb_after_new_saved,
+            )
+        except WindowActiveError:
+            pass
+
+    def cb_after_new_saved(self, obj: Source | Citation) -> None:
+        """
+        Rebuild the selector tree and select the newly created object.
+
+        :param obj: The newly created Source or Citation object.
+        :type obj: Source | Citation
+        """
+        self.build_tree()
+        self.goto_handle(obj.get_handle())
+
+    def get_window_title(self) -> str:
+        """
+        Return the window title for this selector.
+
+        :returns: Translated window title.
+        :rtype: str
+        """
         return _("Select Source or Citation")
 
-    def get_model_class(self):
+    def get_model_class(self) -> type:
+        """
+        Return the tree model class used to populate the selector.
+
+        :returns: CitationTreeModel class.
+        :rtype: type
+        """
         return CitationTreeModel
 
-    def get_column_titles(self):
+    def get_column_titles(self) -> list:
+        """
+        Return column definitions for the selector tree view.
+
+        :returns: List of (header, width, type, model_column) tuples.
+        :rtype: list
+        """
         return [
             (_("Source: Title or Citation: Volume/Page"), 350, BaseSelector.TEXT, 0),
             (_("Abbreviation"), 100, BaseSelector.TEXT, 8),
@@ -74,16 +169,36 @@ class SelectCitation(BaseSelector):
             (_("Last Change"), 150, BaseSelector.TEXT, 6),
         ]
 
-    def get_from_handle_func(self):
+    def get_from_handle_func(self) -> object:
+        """
+        Return the function used to retrieve a Source or Citation by handle.
+
+        :returns: Callable that takes a handle and returns a Source or Citation.
+        :rtype: callable
+        """
         return self.get_source_or_citation
 
-    def get_source_or_citation(self, handle):
+    def get_source_or_citation(self, handle: str) -> Source | Citation:
+        """
+        Return the Source or Citation object for the given handle.
+
+        :param handle: The handle to look up.
+        :type handle: str
+        :returns: The Source or Citation identified by *handle*.
+        :rtype: Source | Citation
+        """
         if self.db.has_source_handle(handle):
             return self.db.get_source_from_handle(handle)
         else:
             return self.db.get_citation_from_handle(handle)
 
-    def get_config_name(self):
+    def get_config_name(self) -> str:
+        """
+        Return the config key used to persist column widths and positions.
+
+        :returns: Module name used as config key.
+        :rtype: str
+        """
         return __name__
 
     WIKI_HELP_PAGE = URL_MANUAL_SECT2

--- a/gramps/gui/selectors/selectplace.py
+++ b/gramps/gui/selectors/selectplace.py
@@ -21,21 +21,24 @@
 
 # -------------------------------------------------------------------------
 #
-# internationalization
+# GTK/Gnome modules
 #
 # -------------------------------------------------------------------------
+from gi.repository import Gtk
 
 # -------------------------------------------------------------------------
 #
-# gramps modules
+# Gramps modules
 #
 # -------------------------------------------------------------------------
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 
 _ = glocale.translation.sgettext
+from gramps.gen.const import URL_MANUAL_SECT2
+from gramps.gen.errors import WindowActiveError
+from gramps.gen.lib import Place
 from ..views.treemodels.placemodel import PlaceTreeModel
 from .baseselector import BaseSelector
-from gramps.gen.const import URL_MANUAL_SECT2
 
 # -------------------------------------------------------------------------
 #
@@ -50,19 +53,71 @@ from gramps.gen.const import URL_MANUAL_SECT2
 #
 # -------------------------------------------------------------------------
 class SelectPlace(BaseSelector):
-    def _local_init(self):
+    def _local_init(self) -> None:
         """
-        Perform local initialisation for this class
+        Perform local initialisation for this class.
         """
         self.setup_configs("interface.place-sel", 600, 450)
+        self.enable_new_button()
 
-    def get_window_title(self):
+    def cb_new_button_clicked(self, obj: Gtk.Button) -> None:
+        """
+        Open the Edit Place dialog to create a new place.
+
+        On save the tree is rebuilt and the new place is selected so
+        the user can confirm with OK without closing the selector first.
+
+        :param obj: The 'New' button that was clicked.
+        :type obj: Gtk.Button
+        """
+        from gramps.gui.editors import EditPlace
+
+        try:
+            EditPlace(
+                self.dbstate,
+                self.uistate,
+                self.track,
+                Place(),
+                self.cb_after_new_saved,
+            )
+        except WindowActiveError:
+            pass
+
+    def cb_after_new_saved(self, place: Place) -> None:
+        """
+        Rebuild the selector tree and select the newly created place.
+
+        :param place: The newly created Place object.
+        :type place: Place
+        """
+        self.build_tree()
+        self.goto_handle(place.get_handle())
+
+    def get_window_title(self) -> str:
+        """
+        Return the window title for this selector.
+
+        :returns: Translated window title.
+        :rtype: str
+        """
         return _("Select Place")
 
-    def get_model_class(self):
+    def get_model_class(self) -> type:
+        """
+        Return the tree model class used to populate the selector.
+
+        :returns: PlaceTreeModel class.
+        :rtype: type
+        """
         return PlaceTreeModel
 
-    def get_column_titles(self):
+    def get_column_titles(self) -> list:
+        """
+        Return column definitions for the selector tree view.
+
+        :returns: List of (header, width, type, model_column) tuples.
+        :rtype: list
+        """
         return [
             (_("Name"), 200, BaseSelector.TEXT, 0),
             (_("ID"), 75, BaseSelector.TEXT, 1),
@@ -71,14 +126,22 @@ class SelectPlace(BaseSelector):
             (_("Last Change"), 150, BaseSelector.TEXT, 9),
         ]
 
-    def get_from_handle_func(self):
+    def get_from_handle_func(self) -> object:
+        """
+        Return the database function for retrieving a place by handle.
+
+        :returns: Callable that takes a handle and returns a Place.
+        :rtype: callable
+        """
         return self.db.get_place_from_handle
 
-    def setup_searches(self):
-        """Build the default searches and add them to the search bar.
-        This overrides the baseselector method because we use the hidden
-        COL_SEARCH (11) that has alt names as well as primary name for name
-        searching"""
+    def setup_searches(self) -> None:
+        """
+        Build the default searches and add them to the search bar.
+
+        Overrides the base class method to use the hidden COL_SEARCH (11)
+        column that includes alternate names as well as the primary name.
+        """
         cols = [
             (pair[3], pair[1] if pair[1] else 11, pair[0] in self.exact_search())
             for pair in self.column_order()
@@ -86,7 +149,13 @@ class SelectPlace(BaseSelector):
         ]
         self.search_bar.setup_searches(cols)
 
-    def get_config_name(self):
+    def get_config_name(self) -> str:
+        """
+        Return the config key used to persist column widths and positions.
+
+        :returns: Module name used as config key.
+        :rtype: str
+        """
         return __name__
 
     WIKI_HELP_PAGE = URL_MANUAL_SECT2

--- a/gramps/gui/selectors/selectplace.py
+++ b/gramps/gui/selectors/selectplace.py
@@ -99,9 +99,10 @@ class SelectPlace(BaseSelector):
         # events so the rows are realised, then scroll again.
         while Gtk.events_pending():
             Gtk.main_iteration()
-        iter_ = self.model.get_iter_from_handle(handle)
-        if iter_:
-            self.tree.scroll_to_cell(self.model.get_path(iter_), None, True, 0.5, 0)
+        if self.model and self.tree:
+            iter_ = self.model.get_iter_from_handle(handle)
+            if iter_:
+                self.tree.scroll_to_cell(self.model.get_path(iter_), None, True, 0.5, 0)
 
     def get_window_title(self) -> str:
         """

--- a/gramps/gui/selectors/selectplace.py
+++ b/gramps/gui/selectors/selectplace.py
@@ -31,15 +31,15 @@ from gi.repository import Gtk
 # Gramps modules
 #
 # -------------------------------------------------------------------------
-from gramps.gen.const import GRAMPS_LOCALE as glocale
-
-_ = glocale.translation.sgettext
 from gramps.gen.const import URL_MANUAL_SECT2
 from gramps.gen.errors import WindowActiveError
 from gramps.gen.lib import Place
 from ..editors import EditPlace
 from ..views.treemodels.placemodel import PlaceTreeModel
 from .baseselector import BaseSelector
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+
+_ = glocale.translation.sgettext
 
 # -------------------------------------------------------------------------
 #

--- a/gramps/gui/selectors/selectplace.py
+++ b/gramps/gui/selectors/selectplace.py
@@ -37,6 +37,7 @@ _ = glocale.translation.sgettext
 from gramps.gen.const import URL_MANUAL_SECT2
 from gramps.gen.errors import WindowActiveError
 from gramps.gen.lib import Place
+from ..editors import EditPlace
 from ..views.treemodels.placemodel import PlaceTreeModel
 from .baseselector import BaseSelector
 
@@ -70,8 +71,6 @@ class SelectPlace(BaseSelector):
         :param obj: The 'New' button that was clicked.
         :type obj: Gtk.Button
         """
-        from gramps.gui.editors import EditPlace
-
         try:
             EditPlace(
                 self.dbstate,

--- a/gramps/gui/selectors/selectplace.py
+++ b/gramps/gui/selectors/selectplace.py
@@ -89,8 +89,19 @@ class SelectPlace(BaseSelector):
         :param place: The newly created Place object.
         :type place: Place
         """
+        handle = place.get_handle()
         self.build_tree()
-        self.goto_handle(place.get_handle())
+        while Gtk.events_pending():
+            Gtk.main_iteration()
+        self.goto_handle(handle)
+        # goto_handle expands parent rows then immediately calls
+        # scroll_to_cell before GTK finishes the expansion.  Flush
+        # events so the rows are realised, then scroll again.
+        while Gtk.events_pending():
+            Gtk.main_iteration()
+        iter_ = self.model.get_iter_from_handle(handle)
+        if iter_:
+            self.tree.scroll_to_cell(self.model.get_path(iter_), None, True, 0.5, 0)
 
     def get_window_title(self) -> str:
         """

--- a/gramps/gui/selectors/selectsource.py
+++ b/gramps/gui/selectors/selectsource.py
@@ -20,21 +20,24 @@
 
 # -------------------------------------------------------------------------
 #
-# internationalization
+# GTK/Gnome modules
 #
 # -------------------------------------------------------------------------
+from gi.repository import Gtk
 
 # -------------------------------------------------------------------------
 #
-# gramps modules
+# Gramps modules
 #
 # -------------------------------------------------------------------------
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 
 _ = glocale.translation.sgettext
+from gramps.gen.const import URL_MANUAL_SECT2
+from gramps.gen.errors import WindowActiveError
+from gramps.gen.lib import Source
 from ..views.treemodels import SourceModel
 from .baseselector import BaseSelector
-from gramps.gen.const import URL_MANUAL_SECT2
 
 # -------------------------------------------------------------------------
 #
@@ -49,19 +52,71 @@ from gramps.gen.const import URL_MANUAL_SECT2
 #
 # -------------------------------------------------------------------------
 class SelectSource(BaseSelector):
-    def _local_init(self):
+    def _local_init(self) -> None:
         """
-        Perform local initialisation for this class
+        Perform local initialisation for this class.
         """
         self.setup_configs("interface.source-sel", 600, 450)
+        self.enable_new_button()
 
-    def get_window_title(self):
+    def cb_new_button_clicked(self, obj: Gtk.Button) -> None:
+        """
+        Open the Edit Source dialog to create a new source.
+
+        On save the tree is rebuilt and the new source is selected so
+        the user can confirm with OK without closing the selector first.
+
+        :param obj: The 'New' button that was clicked.
+        :type obj: Gtk.Button
+        """
+        from gramps.gui.editors import EditSource
+
+        try:
+            EditSource(
+                self.dbstate,
+                self.uistate,
+                self.track,
+                Source(),
+                self.cb_after_new_saved,
+            )
+        except WindowActiveError:
+            pass
+
+    def cb_after_new_saved(self, source: Source) -> None:
+        """
+        Rebuild the selector tree and select the newly created source.
+
+        :param source: The newly created Source object.
+        :type source: Source
+        """
+        self.build_tree()
+        self.goto_handle(source.get_handle())
+
+    def get_window_title(self) -> str:
+        """
+        Return the window title for this selector.
+
+        :returns: Translated window title.
+        :rtype: str
+        """
         return _("Select Source")
 
-    def get_model_class(self):
+    def get_model_class(self) -> type:
+        """
+        Return the tree model class used to populate the selector.
+
+        :returns: SourceModel class.
+        :rtype: type
+        """
         return SourceModel
 
-    def get_column_titles(self):
+    def get_column_titles(self) -> list:
+        """
+        Return column definitions for the selector tree view.
+
+        :returns: List of (header, width, type, model_column) tuples.
+        :rtype: list
+        """
         return [
             (_("Title"), 350, BaseSelector.TEXT, 0),
             (_("Abbreviation"), 100, BaseSelector.TEXT, 3),
@@ -70,10 +125,22 @@ class SelectSource(BaseSelector):
             (_("Last Change"), 150, BaseSelector.TEXT, 7),
         ]
 
-    def get_from_handle_func(self):
+    def get_from_handle_func(self) -> object:
+        """
+        Return the database function for retrieving a source by handle.
+
+        :returns: Callable that takes a handle and returns a Source.
+        :rtype: callable
+        """
         return self.db.get_source_from_handle
 
-    def get_config_name(self):
+    def get_config_name(self) -> str:
+        """
+        Return the config key used to persist column widths and positions.
+
+        :returns: Module name used as config key.
+        :rtype: str
+        """
         return __name__
 
     WIKI_HELP_PAGE = URL_MANUAL_SECT2

--- a/gramps/gui/selectors/selectsource.py
+++ b/gramps/gui/selectors/selectsource.py
@@ -36,6 +36,7 @@ _ = glocale.translation.sgettext
 from gramps.gen.const import URL_MANUAL_SECT2
 from gramps.gen.errors import WindowActiveError
 from gramps.gen.lib import Source
+from ..editors import EditSource
 from ..views.treemodels import SourceModel
 from .baseselector import BaseSelector
 
@@ -69,8 +70,6 @@ class SelectSource(BaseSelector):
         :param obj: The 'New' button that was clicked.
         :type obj: Gtk.Button
         """
-        from gramps.gui.editors import EditSource
-
         try:
             EditSource(
                 self.dbstate,

--- a/gramps/gui/selectors/test/baseselector_test.py
+++ b/gramps/gui/selectors/test/baseselector_test.py
@@ -74,6 +74,8 @@ def _make_selector(cls):
     sel.build_tree = MagicMock()
     sel.goto_handle = MagicMock()
     sel.window = MagicMock()
+    sel.model = None
+    sel.tree = None
     return sel
 
 

--- a/gramps/gui/selectors/test/baseselector_test.py
+++ b/gramps/gui/selectors/test/baseselector_test.py
@@ -1,0 +1,290 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Tests for the 'New' button logic added to the selector classes.
+
+These tests bypass GTK initialisation by instantiating selector objects
+via ``object.__new__`` and injecting mock attributes, so they run without
+a display.  When the GTK widget stack cannot be imported (e.g. a GTK4
+environment where ``Gtk.IconSize.MENU`` is absent), the test cases are
+skipped rather than erroring.
+"""
+
+# -------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import unittest
+from unittest.mock import MagicMock, patch
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+try:
+    from gramps.gui.selectors.baseselector import BaseSelector
+    from gramps.gui.selectors.selectplace import SelectPlace
+    from gramps.gui.selectors.selectsource import SelectSource
+    from gramps.gui.selectors.selectcitation import SelectCitation
+
+    _IMPORT_OK = True
+except Exception:
+    _IMPORT_OK = False
+
+_SKIP_MSG = "GTK widget stack unavailable (likely GTK4 environment)"
+
+
+def _make_selector(cls):
+    """
+    Return a bare instance of *cls* without calling ``__init__``.
+
+    A ``new_button`` mock and the minimum attributes needed for the
+    'New' button methods are injected onto the instance.
+
+    :param cls: A BaseSelector subclass.
+    :type cls: type
+    :returns: Partially-initialised selector instance.
+    :rtype: cls
+    """
+    sel = object.__new__(cls)
+    sel.new_button = MagicMock()
+    sel.dbstate = MagicMock()
+    sel.uistate = MagicMock()
+    sel.track = []
+    sel.build_tree = MagicMock()
+    sel.goto_handle = MagicMock()
+    sel.window = MagicMock()
+    return sel
+
+
+# -------------------------------------------------------------------------
+#
+# TestEnableNewButton
+#
+# -------------------------------------------------------------------------
+@unittest.skipUnless(_IMPORT_OK, _SKIP_MSG)
+class TestEnableNewButton(unittest.TestCase):
+    """enable_new_button() must call show() on new_button."""
+
+    def test_enable_calls_show(self):
+        """enable_new_button shows the button."""
+        sel = _make_selector(SelectPlace)
+        sel.enable_new_button()
+        sel.new_button.show.assert_called_once()
+
+    def test_base_cb_new_button_clicked_is_noop(self):
+        """BaseSelector.cb_new_button_clicked does nothing by default."""
+        sel = _make_selector(SelectPlace)
+        BaseSelector.cb_new_button_clicked(sel, MagicMock())
+
+
+# -------------------------------------------------------------------------
+#
+# TestSelectPlaceNewButton
+#
+# -------------------------------------------------------------------------
+@unittest.skipUnless(_IMPORT_OK, _SKIP_MSG)
+class TestSelectPlaceNewButton(unittest.TestCase):
+    """Tests for SelectPlace 'New' button callbacks."""
+
+    def test_cb_after_new_saved_rebuilds_tree(self):
+        """cb_after_new_saved rebuilds the tree."""
+        sel = _make_selector(SelectPlace)
+        place = MagicMock()
+        place.get_handle.return_value = "P0001"
+        sel.cb_after_new_saved(place)
+        sel.build_tree.assert_called_once()
+
+    def test_cb_after_new_saved_navigates_to_handle(self):
+        """cb_after_new_saved navigates to the new place's handle."""
+        sel = _make_selector(SelectPlace)
+        place = MagicMock()
+        place.get_handle.return_value = "P0001"
+        sel.cb_after_new_saved(place)
+        sel.goto_handle.assert_called_once_with("P0001")
+
+    def test_cb_new_button_clicked_opens_editor(self):
+        """cb_new_button_clicked opens EditPlace."""
+        sel = _make_selector(SelectPlace)
+        with patch("gramps.gui.selectors.selectplace.EditPlace") as MockEdit:
+            sel.cb_new_button_clicked(MagicMock())
+            MockEdit.assert_called_once()
+
+    def test_cb_new_button_clicked_swallows_window_active_error(self):
+        """cb_new_button_clicked ignores WindowActiveError (editor already open)."""
+        from gramps.gen.errors import WindowActiveError
+
+        sel = _make_selector(SelectPlace)
+        with patch(
+            "gramps.gui.selectors.selectplace.EditPlace",
+            side_effect=WindowActiveError("already open"),
+        ):
+            sel.cb_new_button_clicked(MagicMock())
+
+
+# -------------------------------------------------------------------------
+#
+# TestSelectSourceNewButton
+#
+# -------------------------------------------------------------------------
+@unittest.skipUnless(_IMPORT_OK, _SKIP_MSG)
+class TestSelectSourceNewButton(unittest.TestCase):
+    """Tests for SelectSource 'New' button callbacks."""
+
+    def test_cb_after_new_saved_rebuilds_tree(self):
+        """cb_after_new_saved rebuilds the tree."""
+        sel = _make_selector(SelectSource)
+        source = MagicMock()
+        source.get_handle.return_value = "S0001"
+        sel.cb_after_new_saved(source)
+        sel.build_tree.assert_called_once()
+
+    def test_cb_after_new_saved_navigates_to_handle(self):
+        """cb_after_new_saved navigates to the new source's handle."""
+        sel = _make_selector(SelectSource)
+        source = MagicMock()
+        source.get_handle.return_value = "S0001"
+        sel.cb_after_new_saved(source)
+        sel.goto_handle.assert_called_once_with("S0001")
+
+    def test_cb_new_button_clicked_opens_editor(self):
+        """cb_new_button_clicked opens EditSource."""
+        sel = _make_selector(SelectSource)
+        with patch("gramps.gui.selectors.selectsource.EditSource") as MockEdit:
+            sel.cb_new_button_clicked(MagicMock())
+            MockEdit.assert_called_once()
+
+    def test_cb_new_button_clicked_swallows_window_active_error(self):
+        """cb_new_button_clicked ignores WindowActiveError."""
+        from gramps.gen.errors import WindowActiveError
+
+        sel = _make_selector(SelectSource)
+        with patch(
+            "gramps.gui.selectors.selectsource.EditSource",
+            side_effect=WindowActiveError("already open"),
+        ):
+            sel.cb_new_button_clicked(MagicMock())
+
+
+# -------------------------------------------------------------------------
+#
+# TestSelectCitationNewButton
+#
+# -------------------------------------------------------------------------
+@unittest.skipUnless(_IMPORT_OK, _SKIP_MSG)
+class TestSelectCitationNewButton(unittest.TestCase):
+    """Tests for SelectCitation 'New' button callbacks."""
+
+    def test_cb_after_new_saved_rebuilds_tree(self):
+        """cb_after_new_saved rebuilds the tree."""
+        sel = _make_selector(SelectCitation)
+        obj = MagicMock()
+        obj.get_handle.return_value = "C0001"
+        sel.cb_after_new_saved(obj)
+        sel.build_tree.assert_called_once()
+
+    def test_cb_after_new_saved_navigates_to_handle(self):
+        """cb_after_new_saved navigates to the new object's handle."""
+        sel = _make_selector(SelectCitation)
+        obj = MagicMock()
+        obj.get_handle.return_value = "C0001"
+        sel.cb_after_new_saved(obj)
+        sel.goto_handle.assert_called_once_with("C0001")
+
+    def test_new_source_opens_editor(self):
+        """_new_source opens EditSource."""
+        sel = _make_selector(SelectCitation)
+        with patch("gramps.gui.selectors.selectcitation.EditSource") as MockEdit:
+            sel._new_source()
+            MockEdit.assert_called_once()
+
+    def test_new_source_swallows_window_active_error(self):
+        """_new_source ignores WindowActiveError."""
+        from gramps.gen.errors import WindowActiveError
+
+        sel = _make_selector(SelectCitation)
+        with patch(
+            "gramps.gui.selectors.selectcitation.EditSource",
+            side_effect=WindowActiveError("already open"),
+        ):
+            sel._new_source()
+
+    def test_new_citation_opens_editor(self):
+        """_new_citation opens EditCitation."""
+        sel = _make_selector(SelectCitation)
+        with patch("gramps.gui.selectors.selectcitation.EditCitation") as MockEdit:
+            sel._new_citation()
+            MockEdit.assert_called_once()
+
+    def test_new_citation_swallows_window_active_error(self):
+        """_new_citation ignores WindowActiveError."""
+        from gramps.gen.errors import WindowActiveError
+
+        sel = _make_selector(SelectCitation)
+        with patch(
+            "gramps.gui.selectors.selectcitation.EditCitation",
+            side_effect=WindowActiveError("already open"),
+        ):
+            sel._new_citation()
+
+    def test_cb_new_button_clicked_new_source_path(self):
+        """cb_new_button_clicked calls _new_source when user picks 'New Source'."""
+        sel = _make_selector(SelectCitation)
+        sel._new_source = MagicMock()
+        sel._new_citation = MagicMock()
+        with patch("gramps.gui.selectors.selectcitation.Gtk.MessageDialog") as MockDlg:
+            instance = MockDlg.return_value
+            instance.run.return_value = 1
+            sel.cb_new_button_clicked(MagicMock())
+        sel._new_source.assert_called_once()
+        sel._new_citation.assert_not_called()
+
+    def test_cb_new_button_clicked_new_citation_path(self):
+        """cb_new_button_clicked calls _new_citation when user picks 'New Citation'."""
+        sel = _make_selector(SelectCitation)
+        sel._new_source = MagicMock()
+        sel._new_citation = MagicMock()
+        with patch("gramps.gui.selectors.selectcitation.Gtk.MessageDialog") as MockDlg:
+            instance = MockDlg.return_value
+            instance.run.return_value = 2
+            sel.cb_new_button_clicked(MagicMock())
+        sel._new_citation.assert_called_once()
+        sel._new_source.assert_not_called()
+
+    def test_cb_new_button_clicked_cancel(self):
+        """cb_new_button_clicked does nothing when user cancels."""
+        from gi.repository import Gtk as _Gtk
+
+        sel = _make_selector(SelectCitation)
+        sel._new_source = MagicMock()
+        sel._new_citation = MagicMock()
+        with patch("gramps.gui.selectors.selectcitation.Gtk.MessageDialog") as MockDlg:
+            instance = MockDlg.return_value
+            instance.run.return_value = _Gtk.ResponseType.CANCEL
+            sel.cb_new_button_clicked(MagicMock())
+        sel._new_source.assert_not_called()
+        sel._new_citation.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -429,6 +429,8 @@ gramps/gui/selectors/__init__.py
 gramps/gui/selectors/baseselector.py
 gramps/gui/selectors/selectorexceptions.py
 gramps/gui/selectors/selectorfactory.py
+gramps/gui/selectors/test/__init__.py
+gramps/gui/selectors/test/baseselector_test.py
 #
 # gui.test package
 #


### PR DESCRIPTION
## Motivation

The "Select Place", "Select Source", and "Select Source or Citation" dialogs are
unfriendly when the object a user needs does not yet exist.  The current
workflow forces them to:

1. Open the selector and search — find nothing.
2. Cancel the selector.
3. Navigate elsewhere to create the object.
4. Return and re-open the selector.

This is particularly disruptive because users often do not know in advance
whether an object exists; they open the selector to find out.  The fix is
to let users create the missing object without ever leaving the selector.

## Design (Phase 1 of planned improvement)

`BaseSelector` gains an optional **New** button (hidden by default, shown
only by subclasses that opt in).  Clicking it opens the appropriate editor
as a child window.  When the editor is saved, a callback rebuilds the
selector tree and pre-selects the newly created object, so the user can
confirm with **OK** in one uninterrupted flow.  If the editor is cancelled,
the selector simply stays open.

Here's where the New button will appear:                                                                                              
   
**Select Place dialog opens from:**                                                                                                       
  1. Event editor — the place field (via PlaceEntry in objectentries.py). When you click the select-place button next to the place field on an event.                                                                                                                         
  2. Place editor → Enclosed By tab — selecting a parent place in the place hierarchy (placerefembedlist.py).
  3. PlaceEntry widget (placeentry.py) — any inline place entry field across the app (address tabs, etc.).                              
  4. Report/filter options (_guioptions.py) — place picker in report dialogs.                                                           
                                                                                                                                        
**Select Source or Citation dialog opens from:**                                                                                          
  1. Any editor with a Citations tab — the "Share" (link) button in the citations embed list (citationembedlist.py). This appears on Person, Family, Event, Place, Media, and Repository editors.                                                                          
                                                            
**Select Source dialog opens from:**                                                                                                      
  1. Source entry fields (objectentries.py) — less common, used in specific contexts where only a source (not a citation) is being linked.                                                                                                                               
         
In all cases the New button appears at the bottom-left of the dialog alongside the existing Help button, leaving Cancel and OK on the right unchanged.           

<img width="699" height="501" alt="Screenshot from 2026-04-26 07-23-28" src="https://github.com/user-attachments/assets/1d559e31-9bfa-46d2-825a-245730bb0807" />

<img width="1432" height="887" alt="image" src="https://github.com/user-attachments/assets/5341823d-8ad0-4a26-af97-72b984ac6831" />

For the citation selector, a small prompt first asks whether the user wants
a new **Source** or a new **Citation** (since citations are always children
of a source).

A later phase will add comma-separated place string parsing (e.g.
"Paris, France") directly in the Place selector and in inline place
entry fields.

## Summary of changes

- Adds a hidden `newbutton` to `baseselector.glade` and wires it up in `BaseSelector` via `enable_new_button()` and `cb_new_button_clicked()`.
- `SelectPlace` and `SelectSource` enable the button and open `EditPlace` / `EditSource` on click; on save the tree is rebuilt and the new object is pre-selected.
- `SelectCitation` prompts the user to choose between a new Source or new Citation before opening the appropriate editor.
- All new methods follow AGENTS.md conventions: `cb_` callback prefix, type hints, Sphinx docstrings, import section headers.
- Tests added in `gramps/gui/selectors/test/baseselector_test.py`; they skip gracefully when the GTK3 widget stack is unavailable (GTK4 environment).

## Test plan

- [ ] Open an event editor and click the place selector — confirm a **New** button appears at the bottom left.
- [ ] Click **New**, fill in a place name, save — confirm the selector tree refreshes and the new place is highlighted.
- [ ] Click **OK** — confirm the new place is applied to the event.
- [ ] Repeat for the Source and Citation selectors.
- [ ] In the Citation selector, click **New** and choose **Cancel** in the prompt — confirm the selector stays open unchanged.
- [ ] Open a second selector while an editor is already open — confirm `WindowActiveError` is swallowed silently.
- [ ] Run `GRAMPS_RESOURCES=. python3 -m unittest gramps.gui.selectors.test.baseselector_test -v` — all 19 tests should show as skipped (not failed) on GTK4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)