### PR TITLE
Callback improvements

### DIFF
--- a/gramps/gen/utils/callback.py
+++ b/gramps/gen/utils/callback.py
@@ -284,7 +284,8 @@ class Callback:
         with the signal is emitted. The callable must accept the argument
         types declared in the signals signature.
 
-        returns a unique key that can be passed to :meth:`disconnect`.
+        returns a unique key that can be passed to :meth:`disconnect` or
+        None on failure.
         """
         # Check that signal exists.
         if signal_name not in self.__signal_map:

--- a/gramps/gen/utils/callback.py
+++ b/gramps/gen/utils/callback.py
@@ -196,7 +196,7 @@ class Callback:
 
     # If this True no signals will be emitted from any instance of
     # any class derived from this class. This should be toggled using
-    # the class methods, dissable_all_signals() and enable_all_signals().
+    # the class methods, disable_all_signals() and enable_all_signals().
     __BLOCK_ALL_SIGNALS = False
     __LOG_ALL = False
 
@@ -255,7 +255,7 @@ class Callback:
         # Set to None to prevent a memory leak in this recursive function
         trav = None
 
-        # self.__signal_map now contains the connonical list
+        # self.__signal_map now contains the canonical list
         # of signals that this instance can emit.
 
         self._log(

--- a/gramps/gen/utils/callback.py
+++ b/gramps/gen/utils/callback.py
@@ -386,7 +386,7 @@ class Callback:
                 )
                 return
 
-            for i in range(0, len(arg_types)):
+            for i in range(len(arg_types)):
                 if not isinstance(args[i], arg_types[i]):
                     self._warn(
                         "Signal emitted with "

--- a/gramps/gen/utils/callback.py
+++ b/gramps/gen/utils/callback.py
@@ -325,12 +325,7 @@ class Callback:
         """
         Disconnect all callbacks.
         """
-        for signal_name in self.__callback_map:
-            keymap = copy.copy(self.__callback_map[signal_name])
-            for key in keymap:
-                self.__callback_map[signal_name].remove(key)
-            self.__callback_map[signal_name] = []
-        self.__callback_map = {}
+        self.__callback_map.clear()
 
     def emit(self, signal_name: str, args: tuple = tuple()) -> None:
         """

--- a/gramps/gen/utils/callback.py
+++ b/gramps/gen/utils/callback.py
@@ -308,18 +308,15 @@ class Callback:
         """
         Disconnect a callback.
         """
-
-        # Find the key in the callback map.
-        for signal_name in self.__callback_map:
-            for cb in self.__callback_map[signal_name]:
-                skey, fn = cb
-                if skey == key:
-                    # delete the callback from the map.
+        for signal_name, callbacks in self.__callback_map.items():
+            for i, (cb_key, cb) in enumerate(callbacks):
+                if cb_key == key:
                     self._log(
                         "Disconnecting callback from signal"
-                        ": %s with key: %s\n" % (signal_name, str(key))
+                        ": %s with key: %s\n" % (signal_name, key)
                     )
-                    self.__callback_map[signal_name].remove(cb)
+                    del callbacks[i]
+                    return  # key maps to exactly one callback so break early
 
     def disconnect_all(self) -> None:
         """

--- a/gramps/gen/utils/callback.py
+++ b/gramps/gen/utils/callback.py
@@ -310,7 +310,10 @@ class Callback:
                     )
                     self.__callback_map[signal_name].remove(cb)
 
-    def disconnect_all(self):  # Find the key in the callback map.
+    def disconnect_all(self) -> None:
+        """
+        Disconnect all callbacks.
+        """
         for signal_name in self.__callback_map:
             keymap = copy.copy(self.__callback_map[signal_name])
             for key in keymap:

--- a/gramps/gen/utils/callback.py
+++ b/gramps/gen/utils/callback.py
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2000-2005  Donald N. Allingham
 # Copyright (C) 2009       Gary Burton
+# Copyright (C) 2026       Steve Youngs
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -251,9 +252,7 @@ class Callback:
                 if k in self.__signal_map:
                     # signal name clash
                     sys.stderr.write("Warning: signal name clash: %s\n" % str(k))
-                self.__signal_map[k] = v
-        # Set to None to prevent a memory leak in this recursive function
-        trav = None
+                self.__signal_map[k] = v if v is not None else ()
 
         # self.__signal_map now contains the canonical list
         # of signals that this instance can emit.
@@ -377,7 +376,7 @@ class Callback:
 
             # type check arguments
             arg_types = self.__signal_map[signal_name]
-            if arg_types is None and len(args) > 0:
+            if len(args) != len(arg_types):
                 self._warn(
                     "Signal emitted with "
                     "wrong number of args: %s\n"
@@ -387,34 +386,23 @@ class Callback:
                 )
                 return
 
-            if len(args) > 0:
-                if len(args) != len(arg_types):
+            for i in range(0, len(arg_types)):
+                if not isinstance(args[i], arg_types[i]):
                     self._warn(
                         "Signal emitted with "
-                        "wrong number of args: %s\n"
+                        "wrong arg types: %s\n"
                         "         from: file: %s\n"
                         "               line: %d\n"
-                        "               func: %s\n" % ((str(signal_name),) + frame_info)
+                        "               func: %s\n"
+                        "    arg passed was: %s, type of arg passed %s,  type should be: %s\n"
+                        % (
+                            (str(signal_name),)
+                            + frame_info
+                            + (args[i], repr(type(args[i])), repr(arg_types[i]))
+                        )
                     )
                     return
 
-                if arg_types is not None:
-                    for i in range(0, len(arg_types)):
-                        if not isinstance(args[i], arg_types[i]):
-                            self._warn(
-                                "Signal emitted with "
-                                "wrong arg types: %s\n"
-                                "         from: file: %s\n"
-                                "               line: %d\n"
-                                "               func: %s\n"
-                                "    arg passed was: %s, type of arg passed %s,  type should be: %s\n"
-                                % (
-                                    (str(signal_name),)
-                                    + frame_info
-                                    + (args[i], repr(type(args[i])), repr(arg_types[i]))
-                                )
-                            )
-                            return
             if signal_name in self.__callback_map:
                 self._log("emitting signal: %s\n" % (signal_name,))
                 # Don't bother if there are no callbacks.

--- a/gramps/gen/utils/callback.py
+++ b/gramps/gen/utils/callback.py
@@ -34,11 +34,15 @@ to communicate events to any callback methods in either the database code
 or the UI code.
 """
 
-import sys
-import types
+# -------------------------------------------------------------------------
+#
+# Standard python modules
+#
+# -------------------------------------------------------------------------
 import traceback
 import inspect
-import copy
+import sys
+import types
 
 log = sys.stderr.write
 
@@ -198,10 +202,17 @@ class Callback:
     # If this True no signals will be emitted from any instance of
     # any class derived from this class. This should be toggled using
     # the class methods, disable_all_signals() and enable_all_signals().
-    __BLOCK_ALL_SIGNALS = False
-    __LOG_ALL = False
+    __BLOCK_ALL_SIGNALS: bool = False
+    __LOG_ALL: bool = False
 
-    def __init__(self):
+    __enable_logging: bool
+    __block_instance_signals: bool
+    __callback_map: dict[str, list[tuple[int, types.FunctionType | types.MethodType]]]
+    __signal_map: dict[str, tuple]
+    _current_key: int
+    _current_signals: list[str]
+
+    def __init__(self) -> None:
         self.__enable_logging = False  # controls whether lots of debug
         # information will be produced.
         self.__block_instance_signals = False  # controls the blocking of
@@ -230,10 +241,11 @@ class Callback:
         # are consolidated into a single dictionary.
         # The signals can't change so we only need to do this once.
 
-        def trav(cls):
+        def trav(cls) -> list[dict[str, tuple]]:
             """A traversal function to walk through all the classes in
             the inheritance tree. The return is a list of all the
             __signals__ dictionaries."""
+            signal_list: list[dict[str, tuple]]
             if "__signals__" in cls.__dict__:
                 signal_list = [cls.__signals__]
             else:
@@ -264,7 +276,9 @@ class Callback:
             )
         )
 
-    def connect(self, signal_name, callback):
+    def connect(
+        self, signal_name: str, callback: types.FunctionType | types.MethodType
+    ) -> int | None:
         """
         Connect a callable to a signal_name. The callable will be called
         with the signal is emitted. The callable must accept the argument
@@ -290,7 +304,7 @@ class Callback:
 
         return self._current_key
 
-    def disconnect(self, key):
+    def disconnect(self, key: int) -> None:
         """
         Disconnect a callback.
         """
@@ -315,10 +329,10 @@ class Callback:
             keymap = copy.copy(self.__callback_map[signal_name])
             for key in keymap:
                 self.__callback_map[signal_name].remove(key)
-            self.__callback_map[signal_name] = None
+            self.__callback_map[signal_name] = []
         self.__callback_map = {}
 
-    def emit(self, signal_name, args=tuple()):
+    def emit(self, signal_name: str, args: tuple = tuple()) -> None:
         """
         Emit the signal called signal_name. The args must be a tuple of
         arguments that match the types declared for the signals signature.
@@ -329,9 +343,13 @@ class Callback:
 
         # Check signal exists
         frame = inspect.currentframe()
-        c_frame = frame.f_back
-        c_code = c_frame.f_code
-        frame_info = (c_code.co_filename, c_frame.f_lineno, c_code.co_name)
+        c_frame = frame.f_back if frame is not None else None
+        c_code = c_frame.f_code if c_frame is not None else None
+        frame_info = (
+            c_code.co_filename if c_code is not None else "Unknown",
+            c_frame.f_lineno if c_frame is not None else 0,
+            c_code.co_name if c_code is not None else "Unknown",
+        )
         if signal_name not in self.__signal_map:
             self._warn(
                 "Attempt to emit to unknown signal: %s\n"
@@ -427,25 +445,25 @@ class Callback:
     #
     # instance signals control methods
     #
-    def disable_signals(self):
+    def disable_signals(self) -> None:
         self.__block_instance_signals = True
 
-    def enable_signals(self):
+    def enable_signals(self) -> None:
         self.__block_instance_signals = False
 
     # logging methods
 
-    def disable_logging(self):
+    def disable_logging(self) -> None:
         self.__enable_logging = False
 
-    def enable_logging(self):
+    def enable_logging(self) -> None:
         self.__enable_logging = True
 
-    def _log(self, msg):
+    def _log(self, msg: str) -> None:
         if self.__LOG_ALL or self.__enable_logging:
             log("%s: %s" % (self.__class__.__name__, str(msg)))
 
-    def _warn(self, msg):
+    def _warn(self, msg: str) -> None:
         log("Warning: %s: %s" % (self.__class__.__name__, str(msg)))
 
     #
@@ -453,13 +471,13 @@ class Callback:
     #
 
     @classmethod
-    def log_all(cls, enable):
+    def log_all(cls, enable: bool) -> None:
         cls.__LOG_ALL = enable
 
     @classmethod
-    def disable_all_signals(cls):
+    def disable_all_signals(cls) -> None:
         cls.__BLOCK_ALL_SIGNALS = True
 
     @classmethod
-    def enable_all_signals(cls):
+    def enable_all_signals(cls) -> None:
         cls.__BLOCK_ALL_SIGNALS = False

--- a/gramps/gen/utils/callback.py
+++ b/gramps/gen/utils/callback.py
@@ -414,7 +414,9 @@ class Callback:
             if signal_name in self.__callback_map:
                 self._log("emitting signal: %s\n" % (signal_name,))
                 # Don't bother if there are no callbacks.
-                for key, fn in self.__callback_map[signal_name]:
+                for key, fn in list(
+                    self.__callback_map[signal_name]
+                ):  # copy for safe iteration
                     self._log("Calling callback with key: %s\n" % (key,))
                     try:
                         if isinstance(fn, types.FunctionType) or isinstance(

--- a/gramps/gen/utils/callback.py
+++ b/gramps/gen/utils/callback.py
@@ -274,10 +274,8 @@ class Callback:
         """
         # Check that signal exists.
         if signal_name not in self.__signal_map:
-            self._log(
-                "Warning: attempt to connect to unknown signal: %s\n" % str(signal_name)
-            )
-            return
+            self._warn("attempt to connect to unknown signal: %s\n" % str(signal_name))
+            return None
 
         # Add callable to callback_map
         if signal_name not in self.__callback_map:


### PR DESCRIPTION
Improve the code in `Callback` and add comprehensive type hints

Some background discussion on the `disconnect_all` change [here](https://gramps.discourse.group/t/callback-disconnect-all-implementation/9391/3)

Claude's summary of the changes:

<ul>
<li><code>disconnect()</code> — <code>del callbacks[i]</code> with early <code>return</code> is correct and O(n)</li>
<li><code>disconnect_all()</code> — <code>.clear()</code> is correct given <code>emit()</code> iterates a copy</li>
<li><code>emit()</code> — <code>list(...)</code> copy before iteration closes the safe-iteration gap</li>
<li>Argument validation — correctly simplified now that no-arg signals are normalised to <code>()</code> at storage time</li>
<li>Frame null safety — correct for non-CPython implementations</li>
<li><code>trav = None</code> removal — correct, the comment was wrong</li>
<li>Type annotations — comprehensive and consistent throughout</li>
<li><code>copy</code> import removed — correct, no longer used</li>
<li>All method return types annotated — including classmethods</li>
</ul>

Full Claude review:

<html>
<body>
<!--StartFragment--><html><head></head><body><p>This is a clean, complete diff. All issues raised in the previous review have been addressed. Here's the full review.</p>
<hr>
<h2>Full assessment</h2>
<p>Every change in this diff is correct and well-motivated:</p>
<ul>
<li><code>disconnect()</code> — <code>del callbacks[i]</code> with early <code>return</code> is correct and O(n)</li>
<li><code>disconnect_all()</code> — <code>.clear()</code> is correct given <code>emit()</code> iterates a copy</li>
<li><code>emit()</code> — <code>list(...)</code> copy before iteration closes the safe-iteration gap</li>
<li>Argument validation — correctly simplified now that no-arg signals are normalised to <code>()</code> at storage time</li>
<li>Frame null safety — correct for non-CPython implementations</li>
<li><code>trav = None</code> removal — correct, the comment was wrong</li>
<li>Type annotations — comprehensive and consistent throughout</li>
<li><code>copy</code> import removed — correct, no longer used</li>
<li>All method return types annotated — including classmethods</li>
</ul>
<hr>
<h2>Remaining items</h2>
<p>These are not regressions — none existed in the original — but are worth noting as follow-up:</p>
<p><strong>Silent <code>None</code> from <code>connect()</code> on unknown signal.</strong> The warning is now correctly routed through <code>_warn</code>, which is good. However the return value is still <code>None</code>, and a caller who ignores it will silently pass <code>None</code> to <code>disconnect()</code> later. This is hard to fully solve without changing the API contract, but a comment in the docstring noting that <code>None</code> indicates failure would help callers.</p>
<p><strong>Weak references.</strong> <code>types.MethodType</code> callbacks hold strong references to their owning widgets. Until explicitly disconnected, those widgets cannot be garbage collected. This is the most significant remaining structural limitation and is worth a follow-up issue.</p>
<hr>
<h2>Summary</h2>

Area | Status
-- | --
disconnect() | ✅
disconnect_all() | ✅
emit() safe iteration | ✅
Argument validation | ✅
Frame null safety | ✅
Type annotations | ✅
copy import removed | ✅
dissable typo | ✅
range(0, ...) | ✅
connect() unknown signal → _warn | ✅
connect() None return undocumented | ⚠️ Follow-up
Weak references | ⚠️ Follow-up


<p><strong>Ready to merge.</strong></p></body></html><!--EndFragment-->
</body>
</html>