### PR TITLE
Fix calls to get_relationship_calculator

### DIFF
--- a/gramps/plugins/quickview/all_relations.py
+++ b/gramps/plugins/quickview/all_relations.py
@@ -62,7 +62,7 @@ class AllRelReport:
         self.person = person
         self.sdb = SimpleAccess(database)
         self.sdoc = SimpleDoc(document)
-        self.rel_class = get_relationship_calculator(glocale)
+        self.rel_class = get_relationship_calculator()
 
         self.msg_list = []
 

--- a/gramps/plugins/quickview/siblings.py
+++ b/gramps/plugins/quickview/siblings.py
@@ -40,7 +40,7 @@ def run(database, document, person):
     sdb = SimpleAccess(database)
     sdoc = SimpleDoc(document)
     stab = QuickTable(sdb)
-    rel_class = get_relationship_calculator(glocale)
+    rel_class = get_relationship_calculator()
 
     # display the title
     # feature request 2356: avoid genitive form

--- a/gramps/plugins/tool/relcalc.py
+++ b/gramps/plugins/tool/relcalc.py
@@ -98,7 +98,7 @@ class RelCalc(tool.Tool, ManagedWindow):
                 self.colord.append((0, col, size))
 
         self.dbstate = dbstate
-        self.relationship = get_relationship_calculator(glocale)
+        self.relationship = get_relationship_calculator()
         self.relationship.connect_db_signals(dbstate)
 
         self.glade = Glade()


### PR DESCRIPTION
`get_relationship_calculator` is defined as
`def get_relationship_calculator(reinit=False, clocale=glocale):`

Adjust the code so that `glocale` is not passed as the first argument, avoiding unnecessary reinitialisation.
As the default value for `clocale` is `glocale`, simply remove the argument