### PR TITLE
Allow current release of GExiv2

### DIFF
--- a/gramps/grampsapp.py
+++ b/gramps/grampsapp.py
@@ -356,8 +356,9 @@ def show_settings():
         import gi
 
         repository = gi.Repository.get_default()
-        if repository.enumerate_versions("GExiv2"):
-            gi.require_version("GExiv2", "0.10")
+        v_array = repository.enumerate_versions("GExiv2")
+        if v_array:
+            gi.require_version("GExiv2", v_array[-1])
             from gi.repository import GExiv2
 
             try:
@@ -369,8 +370,8 @@ def show_settings():
 
     except ImportError:
         gexiv2_str = "not found"
-    except ValueError:
-        gexiv2_str = "not new enough"
+    except ValueError as err:
+        gexiv2_str = f"Version error: {err}"
 
     try:
         vers_str = Popen(["exiv2", "-V"], stdout=PIPE).communicate(input=None)[0]

--- a/gramps/plugins/gramplet/gramplet.gpr.py
+++ b/gramps/plugins/gramplet/gramplet.gpr.py
@@ -518,10 +518,11 @@ try:
     from gi import Repository
 
     repository = Repository.get_default()
-    if repository.enumerate_versions("GExiv2"):
+    v_array = repository.enumerate_versions("GExiv2")
+    if v_array:
         import gi
 
-        gi.require_version("GExiv2", "0.10")
+        gi.require_version("GExiv2", v_array[-1])
         from gi.repository import GExiv2
 
         available = True

--- a/gramps/plugins/lib/libmetadata.py
+++ b/gramps/plugins/lib/libmetadata.py
@@ -38,7 +38,11 @@ _LOG = logging.getLogger(".libmetadata")
 from gi.repository import Gtk
 import gi
 
-gi.require_version("GExiv2", "0.10")
+repository = gi.Repository.get_default()
+v_array = repository.enumerate_versions("GExiv2")
+if not v_array:
+    raise ValueError("GExiv2 is not installed")
+gi.require_version("GExiv2", v_array[-1])
 from gi.repository import GExiv2
 from gi.repository import Gdk
 from gi.repository import GdkPixbuf


### PR DESCRIPTION
GExiv2's import is currently locked at version 0.10 from 2019. While I can't say that it's completely unavailable, it certainly isn't widely available anymore: The current release is 0.16.0 and most distributions (including UCRT64) [provide either that or 0.14.x.](https://repology.org/project/gexiv2/versions).


