### PR TITLE
Re-enable personal map tile provider in geography view

### DIFF
--- a/gramps/plugins/lib/maps/constants.py
+++ b/gramps/plugins/lib/maps/constants.py
@@ -62,7 +62,7 @@ VIRTUAL_EARTH_HYBRID = 13
 YAHOO_STREET = 14
 YAHOO_SATELLITE = 15
 YAHOO_HYBRID = 16
-# PERSONAL = 30
+PERSONAL = 30
 
 TILES_PATH = {
     OPENSTREETMAP: "openstreetmap",
@@ -81,7 +81,7 @@ TILES_PATH = {
     YAHOO_STREET: "yahoostreet",
     YAHOO_SATELLITE: "yahoosat",
     YAHOO_HYBRID: "yahoohybrid",
-    # PERSONAL: "personal",
+    PERSONAL: "personal",
 }
 
 MAP_TITLE = {
@@ -101,7 +101,7 @@ MAP_TITLE = {
     YAHOO_STREET: "Yahoo street",
     YAHOO_SATELLITE: "Yahoo sat",
     YAHOO_HYBRID: "Yahoo hybrid",
-    # PERSONAL: "Personal map",
+    PERSONAL: "Personal map",
 }
 
 MAP_TYPE = {
@@ -115,5 +115,5 @@ MAP_TYPE = {
     VIRTUAL_EARTH_STREET: osmgpsmap.MapSource_t.VIRTUAL_EARTH_STREET,
     VIRTUAL_EARTH_SATELLITE: osmgpsmap.MapSource_t.VIRTUAL_EARTH_SATELLITE,
     VIRTUAL_EARTH_HYBRID: osmgpsmap.MapSource_t.VIRTUAL_EARTH_HYBRID,
-    # PERSONAL: None,
+    PERSONAL: None,
 }

--- a/gramps/plugins/lib/maps/geography.py
+++ b/gramps/plugins/lib/maps/geography.py
@@ -171,8 +171,8 @@ class GeoGraphyView(OsmGps, NavigationView):
                         parent=uistate.window,
                     )
 
-        # if not config.is_set("geography.personal-map"):
-        #     config.set("geography.personal-map", "")
+        if not config.is_set("geography.personal-map"):
+            config.set("geography.personal-map", "")
 
         self.uistate = uistate
         self.uistate.connect("font-changed", self.font_changed)
@@ -1464,35 +1464,33 @@ class GeoGraphyView(OsmGps, NavigationView):
             "geography.use-keypad",
             extra_callback=self.update_shortcuts,
         )
-        # label = configdialog.add_text(
-        #     grid,
-        #     _(
-        #         "If you want to use a specific map provider,"
-        #         " You can set the following field to the"
-        #         " provider's url.\ni.e:\n"
-        #         "http://tile.stadiamaps.com/tiles/stamen_toner/#{z}/#{x}/#{y}{r}.png?api_key=YOUR-API-KEY\n"
-        #         "http://tile.stadiamaps.com/tiles/stamen_toner_lite/#{z}/#{x}/#{y}{r}.png?api_key=YOUR-API-KEY\n"
-        #         "http://tile.stadiamaps.com/tiles/stamen_terrain/#{z}/#{x}/#{y}{r}.png?api_key=YOUR-API-KEY\n"
-        #         "http://tile.stadiamaps.com/tiles/stamen_watercolor/#{z}/#{x}/#{y}{r}.jpg?api_key=YOUR-API-KEY\n"
-        #         "http://tile.xn--pnvkarte-m4a.de/tilegen/#Z/#X/#Y.png\n"
-        #     ),
-        #     6,
-        #     line_wrap=False,
-        # )
-        # # set the possibility to copy/paste the urls
-        # label.set_selectable(True)
-        # start = label.get_text().find("http")
-        # end = label.get_text().find("http", start + 1)
-        # label.select_region(start, end)
-        # url = configdialog.add_entry(
-        #     grid,
-        #     _("Personal map"),
-        #     7,
-        #     "geography.personal-map",
-        #     self.choosen_map,
-        # )
-        # if config.get("geography.personal-map") != "":
-        #     url.set_text(config.get("geography.personal-map"))
+        label = configdialog.add_text(
+            grid,
+            _(
+                "To use a custom tile provider, paste its tile URL below.\n"
+                "Use #Z, #X, #Y as placeholders for zoom, x and y.\ni.e:\n"
+                "https://api.maptiler.com/tiles/uk-osgb1888/#Z/#X/#Y.png?key=YOUR-API-KEY\n"
+                "https://api.maptiler.com/tiles/uk-osgb63k1885/#Z/#X/#Y.png?key=YOUR-API-KEY\n"
+                "https://api.maptiler.com/tiles/uk-osgb25k1937/#Z/#X/#Y.png?key=YOUR-API-KEY\n"
+                "http://tile.xn--pnvkarte-m4a.de/tilegen/#Z/#X/#Y.png\n"
+            ),
+            6,
+            line_wrap=False,
+        )
+        # set the possibility to copy/paste the urls
+        label.set_selectable(True)
+        start = label.get_text().find("http")
+        end = label.get_text().find("http", start + 1)
+        label.select_region(start, end)
+        lwidget = Gtk.Label(label=_("Personal map: "))
+        lwidget.set_halign(Gtk.Align.START)
+        url = Gtk.Entry()
+        url.set_hexpand(True)
+        url.set_text(config.get("geography.personal-map"))
+        url.connect("activate", self.choosen_map)
+        url.connect("focus-out-event", self.choosen_map)
+        grid.attach(lwidget, 1, 7, 1, 1)
+        grid.attach(url, 2, 7, 7, 1)
         return _("The map"), grid
 
     def choosen_map(self, *obj):
@@ -1500,18 +1498,23 @@ class GeoGraphyView(OsmGps, NavigationView):
         Save the provider map path in the config section.
         """
         map_source = obj[0].get_text()
-        # name = constants.TILES_PATH[constants.PERSONAL]
-        # config.set("geography.personal-map", map_source)
-        # self.clear_map(None, name)
+        name = constants.TILES_PATH[constants.PERSONAL]
         if map_source == "":
-            config.set("geography.map_service", constants.OPENSTREETMAP)
-            self.change_map(self.osm, config.get("geography.map_service"))
-            self.reload_tiles()
+            if config.get("geography.map_service") != constants.OPENSTREETMAP:
+                config.set("geography.map_service", constants.OPENSTREETMAP)
+                self.change_map(self.osm, constants.OPENSTREETMAP)
+                self.reload_tiles()
             return
-        # if map_source != config.get("geography.personal-map"):
-        #     config.set("geography.map_service", constants.PERSONAL)
-        #     self.change_new_map(name, map_source)
-        #     self.reload_tiles()
+        if (
+            map_source == config.get("geography.personal-map")
+            and self.current_map == constants.PERSONAL
+        ):
+            return
+        self.clear_map(None, name)
+        config.set("geography.personal-map", map_source)
+        config.set("geography.map_service", constants.PERSONAL)
+        self.change_new_map(name, map_source)
+        self.reload_tiles()
 
     def set_tilepath(self, *obj):
         """

--- a/gramps/plugins/lib/maps/osmgps.py
+++ b/gramps/plugins/lib/maps/osmgps.py
@@ -168,15 +168,15 @@ class OsmGps:
         """
         Change the current map
         """
-        # if map_type == constants.PERSONAL:
-        #     map_source = config.get("geography.pers# onal-map")
-        #     if map_source == "":
-        #         return
-        #     name = constants.TILES_PATH[map_type]
-        #     self.change_new_map(name, map_source)
-        #     config.set("geography.map_service", map_type)
-        #     self.current_map = map_type
-        #     return
+        if map_type == constants.PERSONAL:
+            map_source = config.get("geography.personal-map")
+            if map_source != "":
+                name = constants.TILES_PATH[map_type]
+                self.change_new_map(name, map_source)
+                config.set("geography.map_service", map_type)
+                self.current_map = map_type
+                return
+            map_type = constants.OPENSTREETMAP
         if obj is not None:
             self.osm.layer_remove_all()
             self.osm.image_remove_all()
@@ -266,11 +266,18 @@ class OsmGps:
             self.osm = DummyMapNoGpsPoint()
         else:
             map_type = int(config.get("geography.map_service"))
-            # if map_type == constants.PERSONAL:
-            #     self.osm = osmgpsmap.Map(repo_uri=map_source)
-            # else:
-            #     self.osm = osmgpsmap.Map(map_source=constants.MAP_TYPE[map_type])
-            self.osm = osmgpsmap.Map(map_source=constants.MAP_TYPE[map_type])
+            self.current_map = map_type
+            if map_type == constants.PERSONAL:
+                # Use OPENSTREETMAP_RENDERER as placeholder: its built-in URI is
+                # NULL (service shut down), so OsmGpsMap preserves our repo_uri
+                # and fetches tiles from it. Using map_source=NULL causes OsmGpsMap
+                # to draw gray tiles and ignore repo_uri entirely.
+                self.osm = osmgpsmap.Map(
+                    map_source=osmgpsmap.MapSource_t.OPENSTREETMAP_RENDERER,
+                    repo_uri=map_source,
+                )
+            else:
+                self.osm = osmgpsmap.Map(map_source=constants.MAP_TYPE[map_type])
             if http_proxy:
                 self.osm.set_property("proxy_uri", http_proxy)
             self.osm.set_property("tile_cache", tiles_path)
@@ -315,14 +322,13 @@ class OsmGps:
         pt2 = bbox[1]
         self.zoom = config.get("geography.zoom")
         tile_size = float(256)
-        # if map_idx != constants.PERSONAL:
-        #     # get the file extension depending on the map provider
-        #     img_format = self.osm.source_get_image_format(map_idx)
-        # else:
-        #     filename = config.get("geography.personal-map")
-        #     img_format = os.path.splitext(filename)[1]
-        # get the file extension depending on the map provider
-        img_format = self.osm.source_get_image_format(map_idx)
+        if map_idx == constants.PERSONAL:
+            url = config.get("geography.personal-map")
+            img_format = os.path.splitext(url.split("?")[0])[1].lstrip(".")
+            if not img_format:
+                img_format = "png"
+        else:
+            img_format = self.osm.source_get_image_format(map_idx)
         # calculate the number of images to download in rows and columns
         pt1_x = floor(lon2pixel(self.zoom, pt1.rlon, tile_size) / tile_size)
         pt1_y = floor(lat2pixel(self.zoom, pt1.rlat, tile_size) / tile_size)


### PR DESCRIPTION
Restores support for a user-supplied tile URL in the embedded geography view. The custom URL is entered in Geography preferences using #Z/#X/#Y as coordinate placeholders. Example providers include MapTiler NLS historical Ordnance Survey maps (uk-osgb1888, uk-osgb63k1885, etc.).

OsmGpsMap requires a non-null map-source enum value to honour a custom repo_uri; using map_source=0 (NULL) causes it to render gray tiles and ignore the URL entirely. Fix this by passing OPENSTREETMAP_RENDERER, whose built-in URI is NULL (service defunct), so OsmGpsMap keeps the supplied repo_uri and fetches tiles from it.

Also fixes the image-format lookup for custom URLs, debounces the url entry field so it only fires on Enter or focus-out rather than on every keystroke, and widens the URL input field to span the full grid width.