### PR TITLE
Fix editor title showing "New X" when editing existing Citation or Source

### DIFF
--- a/gramps/gui/editors/editcitation.py
+++ b/gramps/gui/editors/editcitation.py
@@ -122,25 +122,26 @@ class EditCitation(EditPrimary):
         """
         return Citation()
 
-    def get_menu_title(self):
+    def get_menu_title(self) -> str:
         """
         Construct the menu title, which may include the name of the object that
         contains a reference to this citation.
+
+        :returns: The window/menu title for this citation editor.
+        :rtype: str
         """
-        title = self.obj.get_page()
-        if title:
+        if self.obj.get_handle():
+            page = self.obj.get_page()
             if self.callertitle:
                 title = _("Citation") + (
-                    ": %(id)s - %(context)s"
-                    % {"id": title, "context": self.callertitle}
+                    ": %(id)s - %(context)s" % {"id": page, "context": self.callertitle}
                 )
             else:
-                title = _("Citation") + ": " + title
+                title = _("Citation") + (": " + page if page else "")
         else:
             if self.callertitle:
                 title = _("New Citation") + (
-                    ": %(id)s - %(context)s"
-                    % {"id": title, "context": self.callertitle}
+                    ": %(context)s" % {"context": self.callertitle}
                 )
             else:
                 title = _("New Citation")

--- a/gramps/gui/editors/editsource.py
+++ b/gramps/gui/editors/editsource.py
@@ -92,10 +92,16 @@ class EditSource(EditPrimary):
     def empty_object(self):
         return Source()
 
-    def get_menu_title(self):
-        title = self.obj.get_title()
-        if title:
-            title = _("Source") + ": " + title
+    def get_menu_title(self) -> str:
+        """
+        Construct the menu title for this source editor.
+
+        :returns: The window/menu title for this source editor.
+        :rtype: str
+        """
+        if self.obj.get_handle():
+            name = self.obj.get_title()
+            title = _("Source") + (": " + name if name else "")
         else:
             title = _("New Source")
         return title


### PR DESCRIPTION
## Summary

### Before

_Note the "New" in the window title._

<img width="616" height="503" alt="image" src="https://github.com/user-attachments/assets/8a5a4942-9c25-4729-bd07-5c57bd58013f" />


### After

<img width="616" height="503" alt="image" src="https://github.com/user-attachments/assets/5ff90e2d-84f1-4597-a5a8-6e145c3519f2" />

### Changes

- `EditCitation.get_menu_title()` checked `self.obj.get_page()` to decide
  whether to show `"New Citation"` in the window title. An existing citation
  whose *Volume/Page* field is blank therefore showed `"New Citation"` when
  opened for editing.
- `EditSource.get_menu_title()` had the same bug: it checked
  `self.obj.get_title()`, so an existing source with no title showed
  `"New Source"` while being edited.
- Both are fixed to use `self.obj.get_handle()` instead — the same pattern
  already used correctly by `EditNote`, `EditRepository`, `EditMedia`,
  `EditPerson`, `EditEvent`, `EditFamily`, and `EditPlace`.
- A secondary fix in `EditCitation`: the `"New Citation with caller context"`
  branch was substituting the empty page string as `%(id)s`, producing
  `"New Citation:  - <context>"`. The new branch uses `%(context)s` only.

## Test plan

- [ ] Open an existing Citation that has no Volume/Page set — title should now
      show `"Citation"`, not `"New Citation"`.
- [ ] Open an existing Source that has no title set — title should now show
      `"Source"`, not `"New Source"`.
- [ ] Open a Citation or Source that does have content in those fields —
      title should still show the content as before.
- [ ] Create a brand-new Citation or Source — title should still show
      `"New Citation"` / `"New Source"` while the record is unsaved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)