### PR TITLE
Change error message in post-crash Error on restart Dialog

### DIFF
--- a/gramps/cli/arghandler.py
+++ b/gramps/cli/arghandler.py
@@ -177,6 +177,7 @@ class ArgHandler:
         self.open_gui = parser.open_gui
         self.imp_db_path = None
         self.dbman = CLIDbManager(self.dbstate)
+        self.locked = False
         self.force_unlock = parser.force_unlock
         self.cl_bool = False
         self.imports = []
@@ -225,7 +226,8 @@ class ArgHandler:
             # We have a potential database path.
             # Check if it is good.
             if not self.check_db(db_path, self.force_unlock):
-                sys.exit(1)
+                if not (self.gui and self.locked):
+                    sys.exit(1)
             if create:
                 self.__error(
                     _(
@@ -571,6 +573,7 @@ class ArgHandler:
         if force_unlock:
             self.dbman.break_lock(dbpath)
         if self.dbman.is_locked(dbpath):
+            self.locked = True
             self.__error(
                 (_("Database is locked, cannot open it!") + "\n" + _("  Info: %s"))
                 % find_locker_name(dbpath)

--- a/gramps/gui/grampsgui.py
+++ b/gramps/gui/grampsgui.py
@@ -632,7 +632,7 @@ class Gramps:
         if hasattr(self, "_vm"):
             if hasattr(self._vm, "window"):
                 parent = self._vm.window
-        ErrorDialog(_("Error parsing arguments"), string, parent=parent)
+        ErrorDialog(_("Cannot process as requested"), string, parent=parent)
 
 
 # -------------------------------------------------------------------------

--- a/gramps/gui/grampsgui.py
+++ b/gramps/gui/grampsgui.py
@@ -604,7 +604,7 @@ class Gramps:
         arg_h.handle_args_gui()
         if arg_h.open or arg_h.imp_db_path:
             # if we opened or imported something, only show the interface
-            self._vm.post_init_interface(show_manager=False)
+            self._vm.post_init_interface(show_manager=arg_h.locked)
         elif config.get("paths.recent-file") and config.get("behavior.autoload"):
             # if we need to autoload last seen file, do so
             filename = config.get("paths.recent-file")


### PR DESCRIPTION
The dialog title "Error Processing Arguments" (CLI-oriented dialog) when restarting Gramps after a crash is related to a locked Tree.
<img width="345" height="157" alt="image" src="https://github.com/user-attachments/assets/28704fdc-2ea5-4459-be70-3a04a8850c48" />

Suggest patch "Cannot process as requested" until the branching can changed to where the user can immediately address the 'lock' problem. 

See:
Bug 0012640: Add better message when “Error message on Locked Database is not actionable”

Ideal fix would be to show the GUI dialog instead of the CLI dialog. Which selects the locked file row in the Manage Family Trees dialog with the dialog that actually allows the problem to be resolved:
https://gramps.discourse.group/t/error-parsing-arguments-dialog/9378
<img width="837" height="340" alt="image" src="https://github.com/user-attachments/assets/e61d06f0-02d6-4fd0-8437-d4d18f8e8150" />
