### PR TITLE
Web Report - improvements to dates in family tables on the individual page

### DIFF
--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -566,16 +566,21 @@ class BasePage:
                 children = add_birthdate(self.r_db, childlist, self.rlocale)
                 if birthorder:
                     children = sorted(children)
-
-                tbody.extend(
-                    (
-                        Html("tr", inline=True)
-                        + Html("td", inline=True, close=False)
-                        + self.display_child_link(chandle)
-                        + Html("td", birth, inline=True)
-                        + Html("td", death, inline=True)
-                    )
-                    for birth_date, birth, death, chandle in children
+                
+                for birth_date, birth, birth_fallback, death, death_fallback, chandle in children:
+                    if birth_fallback:
+                        birth = Html("em", birth, inline=True)
+                    if death_fallback:
+                        death = Html("em", death, inline=True)
+                    tbody.extend(
+                        (
+                            Html("tr", inline=True)
+                            + Html("td", inline=True, close=False)
+                            + self.display_child_link(chandle)
+                            + Html("td", birth, inline=True)
+                            + Html("td", death, inline=True)
+                        )
+                    
                 )
             trow += table2
 

--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -567,7 +567,14 @@ class BasePage:
                 if birthorder:
                     children = sorted(children)
                 
-                for birth_date, birth, birth_fallback, death, death_fallback, chandle in children:
+                for (
+                    birth_date,
+                    birth,
+                    birth_fallback,
+                    death,
+                    death_fallback,
+                    chandle,
+                ) in children:
                     if birth_fallback:
                         birth = Html("em", birth, inline=True)
                     if death_fallback:
@@ -580,8 +587,7 @@ class BasePage:
                             + Html("td", birth, inline=True)
                             + Html("td", death, inline=True)
                         )
-                    
-                )
+                    )
             trow += table2
 
         # family LDS ordinance list

--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -566,7 +566,7 @@ class BasePage:
                 children = add_birthdate(self.r_db, childlist, self.rlocale)
                 if birthorder:
                     children = sorted(children)
-                
+
                 for (
                     birth_date,
                     birth,

--- a/gramps/plugins/webreport/common.py
+++ b/gramps/plugins/webreport/common.py
@@ -37,7 +37,6 @@ from xml.sax.saxutils import escape
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.display.name import displayer as _nd
 from gramps.gen.display.place import displayer as _pd
-from gramps.gen.utils.db import get_birth_or_fallback, get_death_or_fallback
 from gramps.gen.lib import EventType, Date
 from gramps.gen.plug import BasePluginManager
 from gramps.plugins.lib.libgedcom import make_gedcom_date, DATE_QUALITY
@@ -875,7 +874,9 @@ def add_birthdate(dbase, ppl_handle_list, rlocale):
     For each entry in the list, we'll have :
          birth date
          The transtated birth date for the configured locale
+         Whether the birth date is a fallback
          The transtated death date for the configured locale
+         Whether the death date is a fallback
          The handle for the child
 
     @param: dbase           -- The database to use
@@ -887,16 +888,18 @@ def add_birthdate(dbase, ppl_handle_list, rlocale):
         birth_date = 0  # dummy value in case none is found
         person = dbase.get_person_from_handle(person_handle)
         if person:
-            birth_event = get_birth_or_fallback(dbase, person)
-            if birth_event:
-                birth = rlocale.get_date(birth_event.get_date_object())
-                birth_date = birth_event.get_date_object().get_sort_value()
-            death_event = get_death_or_fallback(dbase, person)
-            if death_event:
-                death = rlocale.get_date(death_event.get_date_object())
+            birth = _find_birth_date(dbase, person)
+            if birth:
+                birth1 = rlocale.get_date(birth)
+                birth_date = birth.get_sort_value()
+                birth_fallback = birth.fallback
+            death = _find_death_date(dbase, person)
+            if death:
+                death1 = rlocale.get_date(death)
+                death_fallback = death.fallback
             else:
-                death = ""
-        sortable_individuals.append((birth_date, birth, death, person_handle))
+                death1 = ""
+        sortable_individuals.append((birth_date, birth1, birth_fallback, death1, death_fallback, person_handle))
 
     # return a list of handles with the individual's birthdate attached
     return sortable_individuals

--- a/gramps/plugins/webreport/common.py
+++ b/gramps/plugins/webreport/common.py
@@ -37,7 +37,7 @@ from xml.sax.saxutils import escape
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.display.name import displayer as _nd
 from gramps.gen.display.place import displayer as _pd
-from gramps.gen.utils.db import get_death_or_fallback
+from gramps.gen.utils.db import get_birth_or_fallback, get_death_or_fallback
 from gramps.gen.lib import EventType, Date
 from gramps.gen.plug import BasePluginManager
 from gramps.plugins.lib.libgedcom import make_gedcom_date, DATE_QUALITY
@@ -887,19 +887,16 @@ def add_birthdate(dbase, ppl_handle_list, rlocale):
         birth_date = 0  # dummy value in case none is found
         person = dbase.get_person_from_handle(person_handle)
         if person:
-            birth_ref = person.get_birth_ref()
-            birth1 = ""
-            if birth_ref:
-                birth = dbase.get_event_from_handle(birth_ref.ref)
-                if birth:
-                    birth1 = rlocale.get_date(birth.get_date_object())
-                    birth_date = birth.get_date_object().get_sort_value()
+            birth_event = get_birth_or_fallback(dbase, person)
+            if birth_event:
+                birth = rlocale.get_date(birth_event.get_date_object())
+                birth_date = birth_event.get_date_object().get_sort_value()
             death_event = get_death_or_fallback(dbase, person)
             if death_event:
                 death = rlocale.get_date(death_event.get_date_object())
             else:
                 death = ""
-        sortable_individuals.append((birth_date, birth1, death, person_handle))
+        sortable_individuals.append((birth_date, birth, death, person_handle))
 
     # return a list of handles with the individual's birthdate attached
     return sortable_individuals

--- a/gramps/plugins/webreport/common.py
+++ b/gramps/plugins/webreport/common.py
@@ -901,7 +901,9 @@ def add_birthdate(dbase, ppl_handle_list, rlocale):
             if death:
                 death1 = rlocale.get_date(death)
                 death_fallback = death.fallback
-        sortable_individuals.append((birth_date, birth1, birth_fallback, death1, death_fallback, person_handle))
+        sortable_individuals.append(
+            (birth_date, birth1, birth_fallback, death1, death_fallback, person_handle)
+        )
 
     # return a list of handles with the individual's birthdate attached
     return sortable_individuals

--- a/gramps/plugins/webreport/common.py
+++ b/gramps/plugins/webreport/common.py
@@ -886,6 +886,10 @@ def add_birthdate(dbase, ppl_handle_list, rlocale):
     sortable_individuals = []
     for person_handle in ppl_handle_list:
         birth_date = 0  # dummy value in case none is found
+        birth1 = ""
+        death1 = ""
+        birth_fallback = False
+        death_fallback = False
         person = dbase.get_person_from_handle(person_handle)
         if person:
             birth = _find_birth_date(dbase, person)
@@ -897,8 +901,6 @@ def add_birthdate(dbase, ppl_handle_list, rlocale):
             if death:
                 death1 = rlocale.get_date(death)
                 death_fallback = death.fallback
-            else:
-                death1 = ""
         sortable_individuals.append((birth_date, birth1, birth_fallback, death1, death_fallback, person_handle))
 
     # return a list of handles with the individual's birthdate attached

--- a/gramps/plugins/webreport/person.py
+++ b/gramps/plugins/webreport/person.py
@@ -96,7 +96,7 @@ from gramps.plugins.webreport.common import (
     DROPMASTERS,
     FAMILYLINKS,
     get_surname_from_person,
-    AlphabeticIndex
+    AlphabeticIndex,
 )
 from gramps.plugins.webreport.layout import LayoutTree
 from gramps.plugins.webreport.buchheim import buchheim
@@ -1696,7 +1696,14 @@ class PersonPages(BasePage):
                 if birthorder:
                     children = sorted(children)
 
-                for dummy_birthdate, dummy_birth, dummy_birth_fallback, dummy_death, dummy_death_fallback, handle in children:
+                for (
+                    dummy_birthdate,
+                    dummy_birth,
+                    dummy_birth_fallback,
+                    dummy_death,
+                    dummy_death_fallback,
+                    handle,
+                ) in children:
                     if handle == self.person.get_handle():
                         child_ped(ol_html)
                     elif handle:

--- a/gramps/plugins/webreport/person.py
+++ b/gramps/plugins/webreport/person.py
@@ -96,7 +96,7 @@ from gramps.plugins.webreport.common import (
     DROPMASTERS,
     FAMILYLINKS,
     get_surname_from_person,
-    AlphabeticIndex,
+    AlphabeticIndex
 )
 from gramps.plugins.webreport.layout import LayoutTree
 from gramps.plugins.webreport.buchheim import buchheim
@@ -1696,7 +1696,7 @@ class PersonPages(BasePage):
                 if birthorder:
                     children = sorted(children)
 
-                for dummy_birthdate, dummy_birth, dummy_death, handle in children:
+                for dummy_birthdate, dummy_birth, dummy_birth_fallback, dummy_death, dummy_death_fallback, handle in children:
                     if handle == self.person.get_handle():
                         child_ped(ol_html)
                     elif handle:
@@ -2186,12 +2186,16 @@ class PersonPages(BasePage):
                     tcell += self.display_child_link(child_handle)
 
                 birth = death = ""
-                bd_event = get_birth_or_fallback(self.r_db, child)
-                if bd_event:
-                    birth = self.rlocale.get_date(bd_event.get_date_object())
-                dd_event = get_death_or_fallback(self.r_db, child)
-                if dd_event:
-                    death = self.rlocale.get_date(dd_event.get_date_object())
+                bd = _find_birth_date(self.r_db, child)
+                if bd:
+                    birth = self.rlocale.get_date(bd)
+                    if bd.fallback:
+                        birth = Html("em", birth, inline=True)
+                dd = _find_death_date(self.r_db, child)
+                if dd:
+                    death = self.rlocale.get_date(dd)
+                    if dd.fallback:
+                        death = Html("em", death, inline=True)
 
                 tcell2 = Html("td", birth, class_="ColumnDate", inline=True)
 


### PR DESCRIPTION
This PR makes two small adjustments to the way dates are displayed in the family tables on the individual page of the Narrated Web Site report.

1. In the spouse and children table, fallback birth dates are now included for children that don't have a Birth event.
2. In all family tables (parents and siblings / spouse and children), fallback birth and death dates are rendered in italics.