### PR TITLE
Fix bug in check and repair: tag doesn't have gramps_id

### DIFF
--- a/gramps/plugins/tool/check.py
+++ b/gramps/plugins/tool/check.py
@@ -1409,7 +1409,11 @@ class CheckIntegrity:
                         '    FAIL: the "%(cls)s" [%(gid)s] '
                         'has a "%(cls2)s" reference'
                         " with no corresponding backlink.",
-                        {"gid": pri_obj.gramps_id, "cls": key[0], "cls2": item[0]},
+                        {
+                            "gid": getattr(pri_obj, "gramps_id", key[1]),
+                            "cls": key[0],
+                            "cls2": item[0],
+                        },
                     )
 
         # Now we go through the db table and make checks against ours
@@ -1428,7 +1432,11 @@ class CheckIntegrity:
                         '    FAIL: the "%(cls)s" [%(gid)s] '
                         "has a backlink to a missing"
                         ' "%(cls2)s" object.',
-                        {"gid": pri_obj.gramps_id, "cls": key[0], "cls2": item[0]},
+                        {
+                            "gid": getattr(pri_obj, "gramps_id", key[1]),
+                            "cls": key[0],
+                            "cls2": item[0],
+                        },
                     )
                     continue
                 # Check if the object has a reference to the backlinked one
@@ -1440,7 +1448,11 @@ class CheckIntegrity:
                         '    FAIL: the "%(cls)s" [%(gid)s] '
                         'has a backlink to a "%(cls2)s"'
                         " with no corresponding reference.",
-                        {"gid": pri_obj.gramps_id, "cls": key[0], "cls2": item[0]},
+                        {
+                            "gid": getattr(pri_obj, "gramps_id", key[1]),
+                            "cls": key[0],
+                            "cls2": item[0],
+                        },
                     )
 
     def callback(self, *args):


### PR DESCRIPTION
When check & repair encounters a backlink reference problem involving a tag, it crashes because the log message tries to write `tag.gramps_id`, which doesn't exist.

Surfaced here:
https://github.com/gramps-project/gramps-web-api/issues/520

Fix: use the handle as fallback (it's only for the log message, not user-facing).