### PR TITLE
Show date format examples in Preferences Data tab date format menu

### DIFF
--- a/.github/workflows/windows-aio-pyinstaller.yml
+++ b/.github/workflows/windows-aio-pyinstaller.yml
@@ -54,4 +54,5 @@ jobs:
         name: GrampsAIO-PyInstaller
         path: D:\a\gramps\gramps\aio-pyinstaller\dist\grampsaio\src\GrampsAIO-*.exe
         if-no-files-found: error
+        compression-level: 0 # no compression
         retention-days: 7

--- a/.github/workflows/windows-aio-pyinstaller.yml
+++ b/.github/workflows/windows-aio-pyinstaller.yml
@@ -49,8 +49,9 @@ jobs:
       run: |
         cd aio-pyinstaller
         ./build.sh ${{ inputs.cleanup }} ${{ inputs.build-number }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: GrampsAIO-PyInstaller
         path: D:\a\gramps\gramps\aio-pyinstaller\dist\grampsaio\src\GrampsAIO-*.exe
+        if-no-files-found: error
         retention-days: 7

--- a/.github/workflows/windows-aio.yml
+++ b/.github/workflows/windows-aio.yml
@@ -53,4 +53,5 @@ jobs:
       with:
         name: GrampsAIO
         path: D:\a\gramps\gramps\aio\mingw64\src\GrampsAIO-*.exe
+        if-no-files-found: error
         retention-days: 7

--- a/.github/workflows/windows-aio.yml
+++ b/.github/workflows/windows-aio.yml
@@ -54,4 +54,5 @@ jobs:
         name: GrampsAIO
         path: D:\a\gramps\gramps\aio\mingw64\src\GrampsAIO-*.exe
         if-no-files-found: error
+        compression-level: 0 # no compression
         retention-days: 7

--- a/aio/build.sh
+++ b/aio/build.sh
@@ -182,6 +182,33 @@ cd aio
 cat grampsaio64.nsi.template | sed "s/yourVersion/$appversion/;s/yourBuild/$appbuild/" >grampsaio64.nsi
 # build cx_freeze executables
 python setup.py build_exe
+
+# Smoke test the frozen pip before packaging so stdlib-coverage gaps are
+# caught here instead of by end users running the Addon Manager.
+# $MSYSTEM is MINGW64/UCRT64/etc.; the matching build tree is the
+# lowercase equivalent, so the command below works across environments
+# without needing to be edited when the rest of the script is modernized.
+echo "Smoke-testing bundled pip..."
+msys_dir="${MSYSTEM,,}"
+smoke_fail=0
+for cmd in "./${msys_dir}/pip.exe --version" "./${msys_dir}/pip.exe install --dry-run --ignore-installed certifi"; do
+    echo "--- $cmd ---"
+    smoke_out=$($cmd 2>&1) || true
+    echo "$smoke_out"
+    if echo "$smoke_out" | grep -qiE "ImportError|ModuleNotFoundError|Traceback"; then
+        echo "ERROR: Frozen pip emitted an error or traceback running: $cmd"
+        smoke_fail=1
+    fi
+done
+if [ "$smoke_fail" -ne 0 ]; then
+    echo "ERROR: pip smoke test failed; aborting build before NSIS."
+    echo "  Likely cause: a stdlib submodule pip (or one of its vendored"
+    echo "  libraries) imports lazily was not picked up by cx_Freeze's"
+    echo "  static scan. Add the missing module to INCLUDES or its parent"
+    echo "  package to PACKAGES in aio/setup.py and rebuild."
+    exit 1
+fi
+
 # build installer
 cd mingw64/src
 makensis grampsaio64.nsi

--- a/aio/setup.py
+++ b/aio/setup.py
@@ -66,7 +66,19 @@ else:
 
 INCLUDE_DLL_PATH = os.path.join(sys.base_exec_prefix, "bin")
 INCLUDE_FILES = []
-INCLUDES = ["gi", "colorsys", "site"]
+# Simple (single-file) stdlib modules pip's vendored libraries import
+# lazily and therefore cx_Freeze's static scan misses.
+INCLUDES = [
+    "gi",
+    "colorsys",
+    "site",
+    "getpass",
+]
+# Bundle these stdlib packages in full. pip and its vendored libraries
+# (truststore, rich, urllib3, distlib) import submodules conditionally
+# or lazily, and cx_Freeze's static scan misses them. Listing the parent
+# package here pulls in every submodule, so addon installation no longer
+# crashes on the first un-frozen import.
 PACKAGES = [
     "gi",
     "cairo",
@@ -90,6 +102,12 @@ PACKAGES = [
     "pydot",
     "orjson",
     "selenium",
+    "ctypes",
+    "encodings",
+    "email",
+    "http",
+    "urllib",
+    "importlib",
 ]
 EXCLUDES = [
     "tkinter",

--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -1670,6 +1670,28 @@ class GrampsPreferences(ConfigureDialog):
         label.set_margin_top(10)
 
         row += 1
+        # Date format:
+        # April 21, 2001 — date of the first public release of GRAMPS
+        # (Genealogical Research and Analysis Management Programming System)
+        # for the RedHat 7.X Linux operating system.
+        _GRAMPS_BIRTHDAY = Date(2001, 4, 21)
+        obox = Gtk.ComboBoxText()
+        formats = get_date_formats()
+        for i, fmt_name in enumerate(formats):
+            # Render the example using a temporary displayer instance so the
+            # global displayer's format state is never mutated.
+            tmp_displayer = glocale.date_displayer.__class__(format=i)
+            example = tmp_displayer.display(_GRAMPS_BIRTHDAY)
+            obox.append_text("%s  (%s)" % (fmt_name, example))
+        active = config.get("preferences.date-format")
+        if active >= len(formats):
+            active = 0
+        obox.set_active(active)
+        obox.connect("changed", self.date_format_changed)
+        lwidget = BasicLabel(_("%s: ") % _("Date format *"))
+        grid.attach(lwidget, 1, row, 1, 1)
+        grid.attach(obox, 2, row, 2, 1)
+        
         # Surname guessing:
         obox = Gtk.ComboBoxText()
         formats = _surname_styles

--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -1670,10 +1670,7 @@ class GrampsPreferences(ConfigureDialog):
         label.set_margin_top(10)
 
         row += 1
-        # Date format:
-        # April 21, 2001 — date of the first public release of GRAMPS
-        # (Genealogical Research and Analysis Management Programming System)
-        # for the RedHat 7.X Linux operating system.
+        # Date format: April 21, 2001 — date of the first public release of GRAMPS.
         _GRAMPS_BIRTHDAY = Date(2001, 4, 21)
         obox = Gtk.ComboBoxText()
         formats = get_date_formats()
@@ -1691,7 +1688,7 @@ class GrampsPreferences(ConfigureDialog):
         lwidget = BasicLabel(_("%s: ") % _("Date format *"))
         grid.attach(lwidget, 1, row, 1, 1)
         grid.attach(obox, 2, row, 2, 1)
-        
+
         # Surname guessing:
         obox = Gtk.ComboBoxText()
         formats = _surname_styles


### PR DESCRIPTION
addresses [0013266](https://gramps-project.org/bugs/view.php?id=13266): Add Date format preview to Preferences (2024)

Append a live-rendered example to each entry in the Date format drop-down in Edit → Preferences → Data. The example date is 21 April 2001, the date of the first public release of GRAMPS (Genealogical Research and Analysis Management Programming System) for the RedHat 7.X Linux operating system. Each format is rendered by instantiating a temporary locale-specific DateDisplay (format=i) so the global displayer is never mutated. No new imports are required.

Conforms to the 'Date format:' menu design of the Kinship Report in Report Option (2). But uses a fixed date instead of Today() to ensure a leading zero month number and unambiguous (had to be larger than 12) day number.

<img width="49%" alt="image" src="https://github.com/user-attachments/assets/78872ab7-a149-4f6a-8152-d8fed66741de" />  <img width="49%" alt="image" src="https://github.com/user-attachments/assets/fd53fdba-ae01-4129-b3d1-13e500f7a2b2" />

Generated-by: Claude Sonnet 4.6, Anthropic (claude-sonnet-4-6), via claude.ai chat interface.
Prompts: “find where the list of menu items to select dateformat is generated. Suggest a surgical change to append an example of the menu item’s format (using the date April 21, 2001) in each menu item.” The full code for the module can be read at: [URL]. please give the surgical change for that code.

Constraints: 
* gramps-project.org/wiki/index.php/Howto:_Contribute_to_Gramps#AI_generated_code 
*  gramps/AGENTS.md at master · gramps-project/gramps · GitHub