### PR TITLE
Specify the required Gtk version

### DIFF
--- a/gramps/gui/__init__.py
+++ b/gramps/gui/__init__.py
@@ -21,6 +21,10 @@
 Package init for the gui package.
 """
 
+import gi
+
+gi.require_version("Gtk", "3.0")
+
 # DO NOT IMPORT METHODS/CLASSES FROM src/gui HERE ! Only __all__
 
 __all__ = ["editors", "filters", "logger", "merge", "selectors", "views", "widgets"]


### PR DESCRIPTION
This prevents a runtime warning
`/gramps/gui/plug/_guioptions.py:44: PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '3.0') before import to ensure that the right version gets loaded.`

when running the unittest
`python -m unittest gramps.plugins.export.test.exportvcard_test.VCardCheck`