### PR TITLE
Add citation filter name support

### DIFF
--- a/gramps/gen/filters/rules/__init__.py
+++ b/gramps/gen/filters/rules/__init__.py
@@ -49,6 +49,7 @@ _MatchesFilterBase           Object matches another filter
 _RegExpldBase                Object has Gramps Id matching regular expression
 
 Match on related objects
+_MatchesCitationFilterBase   Object matches another filter on direct citations
 _MatchesFilterEventBase      Object has an event that matches another filter
 _MatchesSourceConfidenceBase Object with specific confidence on direct sources
 _MatchesSourceFilterBase     Object matches another filter on direct sources
@@ -76,6 +77,7 @@ from ._ispublic import IsPublic
 from ._hastextmatchingsubstringof import HasTextMatchingSubstringOf
 from ._hastextmatchingregexpof import HasTextMatchingRegexpOf
 from ._matchesfilterbase import MatchesFilterBase
+from ._matchescitationfilterbase import MatchesCitationFilterBase
 from ._matcheseventfilterbase import MatchesEventFilterBase
 from ._matchessourceconfidencebase import MatchesSourceConfidenceBase
 from ._matchessourcefilterbase import MatchesSourceFilterBase

--- a/gramps/gen/filters/rules/_matchescitationfilterbase.py
+++ b/gramps/gen/filters/rules/_matchescitationfilterbase.py
@@ -1,0 +1,55 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Ian Davis
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+from ...const import GRAMPS_LOCALE as glocale
+
+_ = glocale.translation.gettext
+
+from . import MatchesFilterBase
+
+from ...lib.citationbase import CitationBase
+from ...db import Database
+
+
+class MatchesCitationFilterBase(MatchesFilterBase):
+    """Rule that checks against a citation filter."""
+
+    labels = [_("Citation filter name:")]
+    name = "Objects with citation matching the <citation filter>"
+    description = (
+        "Matches objects with citations that match the "
+        "specified citation filter name"
+    )
+    category = _("Citation/source filters")
+
+    namespace = "Citation"
+
+    def prepare(self, db: Database, user):
+        MatchesFilterBase.prepare(self, db, user)
+        self.MCF_filt = self.find_filter()
+
+    def apply_to_one(self, db: Database, object: CitationBase) -> bool:
+        if self.MCF_filt is None:
+            return False
+
+        for citation_handle in object.citation_list:
+            citation = db.get_citation_from_handle(citation_handle)
+            if self.MCF_filt.apply_to_one(db, citation):
+                return True
+        return False

--- a/gramps/gui/editors/filtereditor.py
+++ b/gramps/gui/editors/filtereditor.py
@@ -574,6 +574,8 @@ class EditRule(ManagedWindow):
                     t = MyFilters(self.filterdb.get_filters("Repository"))
                 elif v == _("Place filter name:"):
                     t = MyFilters(self.filterdb.get_filters("Place"))
+                elif v == _("Citation filter name:"):
+                    t = MyFilters(self.filterdb.get_filters("Citation"))
                 elif v in _name2typeclass:
                     additional = None
                     if v in (

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -42,6 +42,7 @@ gramps/gen/filters/rules/_hastagbase.py
 gramps/gen/filters/rules/_hastextmatchingsubstringof.py
 gramps/gen/filters/rules/_isprivate.py
 gramps/gen/filters/rules/_ispublic.py
+gramps/gen/filters/rules/_matchescitationfilterbase.py
 gramps/gen/filters/rules/_matcheseventfilterbase.py
 gramps/gen/filters/rules/_matchesfilterbase.py
 gramps/gen/filters/rules/_matchessourceconfidencebase.py


### PR DESCRIPTION
The filter editor dispatch in filtereditor.py was missing a branch for "Citation filter name:", causing rules that reference a citation filter to render a plain text box instead of a filter dropdown.

Adds the missing elif branch and a new MatchesCitationFilterBase class (parallel to MatchesSourceFilterBase) for rules that match objects by their associated citations.

Fixes [#13534](https://gramps-project.org/bugs/view.php?id=13534).