### PR TITLE
Show date format examples in Preferences Data tab date format menu

### DIFF
--- a/gramps/gen/datehandler/test/date_format_examples_test.py
+++ b/gramps/gen/datehandler/test/date_format_examples_test.py
@@ -1,0 +1,82 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Tests for the date format example rendering used in the Preferences date
+format drop-down (configure.py).
+"""
+
+import unittest
+
+from gramps.gen.lib.date import Date
+from gramps.gen.datehandler import get_date_formats
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+
+
+class TestDateFormatExamples(unittest.TestCase):
+    """Verify that a rendered example can be produced for every date format."""
+
+    GRAMPS_BIRTHDAY = Date(2001, 4, 21)
+
+    def _render_example(self, fmt_index: int) -> str:
+        """Return the rendered example string for the given format index."""
+        tmp_displayer = glocale.date_displayer.__class__(
+            format=fmt_index, blocale=glocale
+        )
+        return tmp_displayer.display(self.GRAMPS_BIRTHDAY)
+
+    def test_all_formats_produce_nonempty_string(self):
+        """Every format index must render to a non-empty string."""
+        formats = get_date_formats()
+        for i, fmt_name in enumerate(formats):
+            with self.subTest(format_index=i, format_name=fmt_name):
+                example = self._render_example(i)
+                self.assertTrue(
+                    example,
+                    f"Format {i} ({fmt_name!r}) rendered an empty string",
+                )
+
+    def test_all_formats_contain_2001(self):
+        """Every rendered example must contain the year 2001."""
+        formats = get_date_formats()
+        for i, fmt_name in enumerate(formats):
+            with self.subTest(format_index=i, format_name=fmt_name):
+                example = self._render_example(i)
+                self.assertIn(
+                    "2001",
+                    example,
+                    f"Format {i} ({fmt_name!r}) example {example!r} missing year",
+                )
+
+    def test_out_of_range_active_clamps_to_zero(self):
+        """Simulate the active >= len(formats) guard used in configure.py."""
+        formats = get_date_formats()
+        active = len(formats) + 99
+        if active >= len(formats):
+            active = 0
+        self.assertEqual(active, 0)
+
+    def test_format_count_is_positive(self):
+        """There must be at least one date format available."""
+        self.assertGreater(len(get_date_formats()), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gen/datehandler/test/date_format_examples_test.py
+++ b/gramps/gen/datehandler/test/date_format_examples_test.py
@@ -65,14 +65,6 @@ class TestDateFormatExamples(unittest.TestCase):
                     f"Format {i} ({fmt_name!r}) example {example!r} missing year",
                 )
 
-    def test_out_of_range_active_clamps_to_zero(self):
-        """Simulate the active >= len(formats) guard used in configure.py."""
-        formats = get_date_formats()
-        active = len(formats) + 99
-        if active >= len(formats):
-            active = 0
-        self.assertEqual(active, 0)
-
     def test_format_count_is_positive(self):
         """There must be at least one date format available."""
         self.assertGreater(len(get_date_formats()), 0)

--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -1804,10 +1804,7 @@ class GrampsPreferences(ConfigureDialog):
         label.set_margin_top(10)
 
         row += 1
-        # Date format:
-        # April 21, 2001 — date of the first public release of GRAMPS
-        # (Genealogical Research and Analysis Management Programming System)
-        # for the RedHat 7.X Linux operating system.
+        # Date format: April 21, 2001 — date of the first public release of GRAMPS.
         _GRAMPS_BIRTHDAY = Date(2001, 4, 21)
         obox = Gtk.ComboBoxText()
         formats = get_date_formats()
@@ -1825,7 +1822,7 @@ class GrampsPreferences(ConfigureDialog):
         lwidget = BasicLabel(_("%s: ") % _("Date format *"))
         grid.attach(lwidget, 1, row, 1, 1)
         grid.attach(obox, 2, row, 2, 1)
-        
+
         # Surname guessing:
         obox = Gtk.ComboBoxText()
         formats = _surname_styles

--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -1669,10 +1669,17 @@ class GrampsPreferences(ConfigureDialog):
         )
 
         row += 1
-        # Date format:
+        # Use 2001-04-21 (first GRAMPS release) so the example always has a
+        # two-digit month (04) and an unambiguous day number (> 12), making
+        # every format visually distinct.
+        gramps_birthday = Date(2001, 4, 21)
         obox = Gtk.ComboBoxText()
         formats = get_date_formats()
-        list(map(obox.append_text, formats))
+        for i, fmt_name in enumerate(formats):
+            # Temporary displayer per format so the global state is never mutated.
+            tmp_displayer = glocale.date_displayer.__class__(format=i, blocale=glocale)
+            example = tmp_displayer.display(gramps_birthday)
+            obox.append_text("%s  (%s)" % (fmt_name, example))
         active = config.get("preferences.date-format")
         if active >= len(formats):
             active = 0
@@ -1804,25 +1811,6 @@ class GrampsPreferences(ConfigureDialog):
         label.set_margin_top(10)
 
         row += 1
-        # Date format: April 21, 2001 — date of the first public release of GRAMPS.
-        _GRAMPS_BIRTHDAY = Date(2001, 4, 21)
-        obox = Gtk.ComboBoxText()
-        formats = get_date_formats()
-        for i, fmt_name in enumerate(formats):
-            # Render the example using a temporary displayer instance so the
-            # global displayer's format state is never mutated.
-            tmp_displayer = glocale.date_displayer.__class__(format=i)
-            example = tmp_displayer.display(_GRAMPS_BIRTHDAY)
-            obox.append_text("%s  (%s)" % (fmt_name, example))
-        active = config.get("preferences.date-format")
-        if active >= len(formats):
-            active = 0
-        obox.set_active(active)
-        obox.connect("changed", self.date_format_changed)
-        lwidget = BasicLabel(_("%s: ") % _("Date format *"))
-        grid.attach(lwidget, 1, row, 1, 1)
-        grid.attach(obox, 2, row, 2, 1)
-
         # Surname guessing:
         obox = Gtk.ComboBoxText()
         formats = _surname_styles

--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -1804,6 +1804,28 @@ class GrampsPreferences(ConfigureDialog):
         label.set_margin_top(10)
 
         row += 1
+        # Date format:
+        # April 21, 2001 — date of the first public release of GRAMPS
+        # (Genealogical Research and Analysis Management Programming System)
+        # for the RedHat 7.X Linux operating system.
+        _GRAMPS_BIRTHDAY = Date(2001, 4, 21)
+        obox = Gtk.ComboBoxText()
+        formats = get_date_formats()
+        for i, fmt_name in enumerate(formats):
+            # Render the example using a temporary displayer instance so the
+            # global displayer's format state is never mutated.
+            tmp_displayer = glocale.date_displayer.__class__(format=i)
+            example = tmp_displayer.display(_GRAMPS_BIRTHDAY)
+            obox.append_text("%s  (%s)" % (fmt_name, example))
+        active = config.get("preferences.date-format")
+        if active >= len(formats):
+            active = 0
+        obox.set_active(active)
+        obox.connect("changed", self.date_format_changed)
+        lwidget = BasicLabel(_("%s: ") % _("Date format *"))
+        grid.attach(lwidget, 1, row, 1, 1)
+        grid.attach(obox, 2, row, 2, 1)
+        
         # Surname guessing:
         obox = Gtk.ComboBoxText()
         formats = _surname_styles

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -70,6 +70,7 @@ gramps/gen/datehandler/_grampslocale.py
 #
 # gen.datehandler.test package
 #
+gramps/gen/datehandler/test/date_format_examples_test.py
 gramps/gen/datehandler/test/datedisplay_test.py
 gramps/gen/datehandler/test/datehandler_test.py
 gramps/gen/datehandler/test/dateparser_test.py


### PR DESCRIPTION
## Summary

- In the Preferences → Data tab, the date format drop-down now shows a rendered example alongside each format name, e.g. `ISO (2001-04-21)` or `Month Day, Year (April 21, 2001)`.
- The example date used is 2001-04-21, the first public release of GRAMPS.
- A temporary displayer instance is constructed for each format so the global displayer's state is never mutated.

## Original author

This work was written by @emyoulation (commits `0a86f9f` and `608985d` from [PR #2287](https://github.com/gramps-project/gramps/pull/2287)). This PR is a clean rebase of that work — original authorship is preserved in the commits.

## Why a new PR was needed

PR #2287 was originally submitted against `maintenance/gramps60`. When @Nick-Hall asked for a rebase onto `master`, @emyoulation used GitHub's web UI base-branch switcher, which only changes what the PR *compares against* — it does not actually rebase commits. As a result, GitHub recalculated the diff and the PR picked up several unrelated commits from `maintenance/gramps60` that are not in `master` (Windows AIO build changes by @hgohel and @edwardralph), while the two actual feature commits were buried.

Since there is no way to push a force-corrected branch to someone else's fork, this new PR cherry-picks only @emyoulation's two commits onto a fresh branch from `master`.

## Test plan

- [ ] Open Preferences → Data tab and confirm the date format drop-down shows format names with rendered examples.
- [ ] Change the selected format and confirm the preference is saved and applied.
- [ ] Confirm no other Preferences behavior is affected.