### PR TITLE
Remove checks for PyICU identifier, replaced and deprecated in 2015

### DIFF
--- a/gramps/gen/utils/grampslocale.py
+++ b/gramps/gen/utils/grampslocale.py
@@ -63,18 +63,13 @@ try:
     from icu import Locale, Collator, ICUError
 
     HAVE_ICU = True
-except ImportError:
-    try:
-        from PyICU import Locale, Collator, ICUError
-
-        HAVE_ICU = True
-    except ImportError as err:
-        ERRSTR = str(err)
-        # No logger, save the warning message for later.
-        _ICU_ERR = (
-            f"ICU not loaded because {ERRSTR}. Localization will be "
-            "impaired. Use your package manager to install PyICU"
-        )
+except ImportError as err:
+    ERRSTR = str(err)
+    # No logger, save the warning message for later.
+    _ICU_ERR = (
+        f"ICU not loaded because {ERRSTR}. Localization will be "
+        "impaired. Use your package manager to install PyICU"
+    )
 
 ICU_LOCALES = None
 if HAVE_ICU:

--- a/gramps/gen/utils/test/grampslocale_test.py
+++ b/gramps/gen/utils/test/grampslocale_test.py
@@ -26,12 +26,7 @@ try:
 
     HAVE_ICU = True
 except ImportError:
-    try:
-        from PyICU import Collator
-
-        HAVE_ICU = True
-    except ImportError:
-        HAVE_ICU = False
+    HAVE_ICU = False
 
 
 class LexGettextTest(unittest.TestCase):
@@ -217,10 +212,7 @@ class SortKeyTest(unittest.TestCase):
         system locale of the test runner.  (Swedish, for example, places
         Ö *after* Z — that behaviour is covered in SortKeyLocaleTest.)
         """
-        try:
-            from icu import Locale, Collator
-        except ImportError:
-            from PyICU import Locale, Collator
+        from icu import Locale, Collator
 
         en_collator = Collator.createInstance(Locale("en"))
         with patch.object(self.glocale, "collator", en_collator):
@@ -250,10 +242,7 @@ class SortKeyTest(unittest.TestCase):
 
         Uses a fixed 'en' collator so the result is locale-independent.
         """
-        try:
-            from icu import Locale, Collator
-        except ImportError:
-            from PyICU import Locale, Collator
+        from icu import Locale, Collator
 
         en_collator = Collator.createInstance(Locale("en"))
         with patch.object(self.glocale, "collator", en_collator):
@@ -281,10 +270,7 @@ class SortKeyLocaleTest(unittest.TestCase):
         from gramps.gen.const import GRAMPS_LOCALE as glocale
 
         self.glocale = glocale
-        try:
-            from icu import Locale, Collator
-        except ImportError:
-            from PyICU import Locale, Collator
+        from icu import Locale, Collator
 
         self._Locale = Locale
         self._Collator = Collator

--- a/gramps/grampsapp.py
+++ b/gramps/grampsapp.py
@@ -389,11 +389,11 @@ def show_settings():
         vers_str = _("not found because exiv2 is not installed")
 
     try:
-        import PyICU
+        import icu
 
         try:
-            pyicu_str = PyICU.VERSION
-            icu_str = PyICU.ICU_VERSION
+            pyicu_str = icu.VERSION
+            icu_str = icu.ICU_VERSION
         except:  # any failure to 'get' the version
             pyicu_str = "unknown version"
             icu_str = "unknown version"
@@ -401,13 +401,6 @@ def show_settings():
     except ImportError:
         pyicu_str = "not found"
         icu_str = "not found"
-
-    try:
-        import icu
-
-        icu_str = icu.PY_VERSION
-    except Exception:
-        icu_str = _("not found")
 
     try:
         import PIL

--- a/gramps/plugins/webreport/alphabeticindex.py
+++ b/gramps/plugins/webreport/alphabeticindex.py
@@ -45,12 +45,7 @@ try:
 
     HAVE_ICU = True
 except ImportError:
-    try:
-        from PyICU import Locale, Collator
-
-        HAVE_ICU = True
-    except ImportError:
-        pass
+    pass
 
 LOG = logging.getLogger(".NarrativeWeb")
 COLLATE_LANG = glocale.collation

--- a/gramps/plugins/webreport/common.py
+++ b/gramps/plugins/webreport/common.py
@@ -59,20 +59,7 @@ try:
             AlphabeticIndex as localAlphabeticIndex,
         )
 except ImportError:
-    try:
-        from PyICU import Locale
-
-        HAVE_ICU = True
-        try:
-            from PyICU import AlphabeticIndex as icuAlphabeticIndex
-
-            HAVE_ALPHABETICINDEX = True
-        except ImportError:
-            from gramps.plugins.webreport.alphabeticindex import (
-                AlphabeticIndex as localAlphabeticIndex,
-            )
-    except ImportError:
-        pass
+    pass
 
 LOG = logging.getLogger(".NarrativeWeb")
 

--- a/gramps/plugins/webreport/common.py
+++ b/gramps/plugins/webreport/common.py
@@ -45,21 +45,15 @@ from gramps.gen.plug.report import utils
 from gramps.plugins.lib.libhtml import Html
 
 HAVE_ICU = False
-HAVE_ALPHABETICINDEX = False  # separate check as this is only in ICU 4.6+
 try:
     from icu import Locale
 
     HAVE_ICU = True
-    try:
-        from icu import AlphabeticIndex as icuAlphabeticIndex
-
-        HAVE_ALPHABETICINDEX = True
-    except ImportError:
-        from gramps.plugins.webreport.alphabeticindex import (
-            AlphabeticIndex as localAlphabeticIndex,
-        )
+    from icu import AlphabeticIndex as icuAlphabeticIndex
 except ImportError:
-    pass
+    from gramps.plugins.webreport.alphabeticindex import (
+        AlphabeticIndex as localAlphabeticIndex,
+    )
 
 LOG = logging.getLogger(".NarrativeWeb")
 
@@ -634,7 +628,7 @@ def __get_place_keyname(dbase, handle):
     return utils.place_name(dbase, handle)
 
 
-if HAVE_ALPHABETICINDEX:
+if HAVE_ICU:
 
     class AlphabeticIndex(icuAlphabeticIndex):
         """

--- a/mac/Info.plist
+++ b/mac/Info.plist
@@ -7,7 +7,7 @@
     <key>CFBundleExecutable</key>
     <string>Gramps</string>
     <key>CFBundleGetInfoString</key>
-    <string>Gramps-6.1.0-beta1-2, (C) 1997-2026 The Gramps Team http://www.gramps-project.org</string>
+    <string>Gramps-6.1.0-req-mod-1, (C) 1997-2026 The Gramps Team http://www.gramps-project.org</string>
     <key>CFBundleIconFile</key>
     <string>gramps.icns</string>
     <key>CFBundleIdentifier</key>
@@ -17,11 +17,11 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>Gramps-6.1.0-beta1-2</string>
+    <string>Gramps-6.1.0-req-mod-1</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleVersion</key>
-    <string>Gramps-6.1.0-beta1-2</string>
+    <string>Gramps-6.1.0-req-mod-1</string>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright 1997 - 2026 The Gramps Team, GNU General Public License.</string>
     <key>LSMinimumSystemVersion</key>

--- a/mac/gramps.bundle
+++ b/mac/gramps.bundle
@@ -62,7 +62,7 @@
   </binary>
 
   <binary>
-    ${prefix}/lib/libgexiv2.dylib
+    ${prefix}/lib/libgexiv2-0.16.dylib
   </binary>
 
   <binary>

--- a/mypy.ini
+++ b/mypy.ini
@@ -41,8 +41,5 @@ ignore_missing_imports = True
 [mypy-pycountry.*]
 ignore_missing_imports = True
 
-[mypy-PyICU.*]
-ignore_missing_imports = True
-
 [mypy-sets.*]
 ignore_missing_imports = True


### PR DESCRIPTION
and removed in 2022.