### PR TITLE
Allow gui.clipboard to import without a default screen

### DIFF
--- a/gramps/gui/clipboard.py
+++ b/gramps/gui/clipboard.py
@@ -79,7 +79,13 @@ clipdb = None  # current db to avoid different transient dbs during db change
 # -------------------------------------------------------------------------
 
 theme = Gtk.IconTheme.get_default()
-LINK_PIC = theme.load_icon("stock_link", 16, 0)
+# Gtk.IconTheme.get_default() returns None when no default screen is
+# available (headless containers, plugin-registration smoke tests run
+# without a display, etc.). Fall back to a None LINK_PIC and an empty
+# ICONS dict in that case so this module imports cleanly. Any actual
+# UI rendering still requires a display, but that is gated by GTK
+# elsewhere — module import on its own should not raise.
+LINK_PIC = theme.load_icon("stock_link", 16, 0) if theme is not None else None
 OBJ2ICON = {
     "media": "gramps-media",
     "note": "gramps-notes",
@@ -105,8 +111,16 @@ def obj2icon(target):
 
 
 ICONS = {}
-for name, icon in OBJ2ICON.items():
-    ICONS[name] = theme.load_icon(icon, 16, 0)
+if theme is not None:
+    for name, icon in OBJ2ICON.items():
+        ICONS[name] = theme.load_icon(icon, 16, 0)
+else:
+    # Headless fallback: populate every expected key with None so
+    # the class-body lookups below (``ICON = ICONS["address"]`` etc.)
+    # don't KeyError. Real icon rendering is gated by GTK at the
+    # widget level, which itself requires a display.
+    for name in OBJ2ICON:
+        ICONS[name] = None
 
 
 # -------------------------------------------------------------------------

--- a/gramps/gui/test/clipboard_test.py
+++ b/gramps/gui/test/clipboard_test.py
@@ -1,0 +1,78 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Unittest for clipboard.py module-load resilience."""
+
+import importlib
+import sys
+import unittest
+from unittest.mock import patch
+
+# clipboard.py uses Gdk.atom_intern which is GTK-3-only (removed in
+# GTK 4). Pin the GTK version before any test imports clipboard so
+# the binding is available — matches what gramps.grampsapp does at
+# startup. Skip cleanly if GTK 3 is not available.
+try:
+    import gi
+
+    gi.require_version("Gtk", "3.0")
+    gi.require_version("Gdk", "3.0")
+except (ImportError, ValueError) as err:
+    raise unittest.SkipTest("GTK 3.0 / PyGObject not available: %s" % err)
+
+
+# ------------------------------------------------------------
+#
+# TestClipboardImportsHeadless
+#
+# ------------------------------------------------------------
+class TestClipboardImportsHeadless(unittest.TestCase):
+    """Regression: clipboard.py must import cleanly when no default
+    Gtk screen is available.
+
+    ``Gtk.IconTheme.get_default()`` returns ``None`` in headless
+    containers (no DISPLAY, plugin-registration smoke tests run
+    outside an X server, etc.). Historically the module-level
+    ``theme.load_icon(...)`` calls then raised
+    ``AttributeError: 'NoneType' object has no attribute 'load_icon'``
+    and the whole module failed to import — breaking every addon
+    that did ``from gramps.gui.clipboard import ...``.
+    """
+
+    def test_loads_when_theme_is_none(self):
+        """Force ``IconTheme.get_default`` to return ``None`` and
+        verify the module still imports, with sane fallbacks for
+        ``LINK_PIC`` and ``ICONS``."""
+        # Drop any cached import so the module-level code re-runs
+        # under the patched IconTheme.
+        sys.modules.pop("gramps.gui.clipboard", None)
+        with patch("gi.repository.Gtk.IconTheme") as mock_theme:
+            mock_theme.get_default.return_value = None
+            mod = importlib.import_module("gramps.gui.clipboard")
+        self.assertIsNone(mod.LINK_PIC)
+        # In headless mode every OBJ2ICON key is populated with None
+        # so class-body lookups like ``ICON = ICONS["address"]``
+        # do not KeyError during module load.
+        self.assertEqual(set(mod.ICONS.keys()), set(mod.OBJ2ICON.keys()))
+        self.assertTrue(all(v is None for v in mod.ICONS.values()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -432,6 +432,7 @@ gramps/gui/selectors/selectorfactory.py
 #
 # gui.test package
 #
+gramps/gui/test/clipboard_test.py
 gramps/gui/test/display_test.py
 gramps/gui/test/user_test.py
 #


### PR DESCRIPTION
## Summary
**User impact:** On a computer with no graphical display available — for example an automated test machine — Gramps' clipboard code fails to load. Any add-on that depends on it then fails to register. In practice this breaks the Collections Clipboard add-on in headless plugin-registration tests.

This lets that clipboard code load without a display by falling back to empty icons, so the add-ons that depend on it register cleanly in headless runs.

Origin: fix driven by addons-source CI work — no Mantis tracker ticket (see gramps-project/addons-source#820).

## What to look at
Three module-level `theme.load_icon(...)` calls in `gramps/gui/clipboard.py` run at import time and crash when there is no default icon theme. The fix guards them so the module imports with `None` icon placeholders instead. To try it: import `gramps.gui.clipboard` with no `DISPLAY` (or with `Gtk.IconTheme.get_default` patched to return `None`) and confirm it loads.

## Root cause
Three module-level statements in `gramps/gui/clipboard.py` (lines 81-109) call `theme.load_icon(...)` where `theme = Gtk.IconTheme.get_default()`. In headless contexts (no `DISPLAY`, plugin-registration smoke tests run outside an X server, etc.) `Gtk.IconTheme.get_default()` returns `None`, so the calls raise `AttributeError: 'NoneType' object has no attribute 'load_icon'` at `clipboard.py:82` and the whole module fails to load. Every addon that does `from gramps.gui.clipboard import ...` then fails at registration. The most user-visible consequence is the `Collections Clipboard Gramplet` addon failing in plugin-registration smoke tests run by addons-source CI (gramps-project/addons-source#820).

## Fix
Guard the icon-loading paths with `if theme is not None`. When the default theme is unavailable, `LINK_PIC = None` and `ICONS` is populated with `None` values for every key in `OBJ2ICON`. The class bodies later in the file look up `ICONS[name]` at module load to set `ICON` class attributes (`ClipAddress.ICON = ICONS["address"]` etc.); the `None` placeholders keep those lookups from raising `KeyError`. Real icon rendering is gated by GTK at the widget level, which itself requires a display, so the fallback values are never used to draw anything. Behaviour with a default screen present is unchanged. `gramps/gui/test/clipboard_test.py` is added to `po/POTFILES.skip` alongside the sibling `gui/test` files.

## Verification
- **Claim:** `gramps.gui.clipboard` imports without a default screen (falling back to `None` icons); with a screen present behaviour is unchanged.
- **Checked:** `gramps/gui/clipboard.py:81-109` on master (the branch this PR targets) — icon loads guarded on `theme is not None`, with `LINK_PIC = None` and all-`None` `ICONS`.
- **Test:** `gramps/gui/test/clipboard_test.py` (new) patches `Gtk.IconTheme.get_default` to return `None`, re-imports the module, and asserts `LINK_PIC` is `None` and `ICONS` is keyed identically to `OBJ2ICON` with all-`None` values. Fails on the unfixed tree with the exact `AttributeError: 'NoneType' object has no attribute 'load_icon'` at `clipboard.py:82`, and passes after the patch. The test pins `gi` to GTK 3 / Gdk 3 (`clipboard.py` uses `Gdk.atom_intern`, removed in GTK 4) and skips cleanly on hosts without GTK 3 / PyGObject. `GRAMPS_RESOURCES=. python3 -m unittest gramps.gui.test.clipboard_test -v` → 1 test, OK; `black` and `mypy` clean on both files.

No Mantis tracker ticket — fix originates from addons-source CI work (gramps-project/addons-source#820).
