### PR TITLE
Define localAlphabeticIndex in the no-ICU fallback branch

### DIFF
--- a/gramps/plugins/webreport/common.py
+++ b/gramps/plugins/webreport/common.py
@@ -72,7 +72,16 @@ except ImportError:
                 AlphabeticIndex as localAlphabeticIndex,
             )
     except ImportError:
-        pass
+        # Neither icu nor PyICU is available. Fall back to the
+        # in-tree pure-Python AlphabeticIndex so the ``else`` branch
+        # later in this module (``AlphabeticIndex = localAlphabeticIndex``)
+        # finds a defined name. Without this, importing
+        # ``gramps.plugins.webreport.common`` on a system lacking
+        # both icu bindings raises ``NameError: name
+        # 'localAlphabeticIndex' is not defined`` at module load.
+        from gramps.plugins.webreport.alphabeticindex import (
+            AlphabeticIndex as localAlphabeticIndex,
+        )
 
 LOG = logging.getLogger(".NarrativeWeb")
 

--- a/gramps/plugins/webreport/test/common_test.py
+++ b/gramps/plugins/webreport/test/common_test.py
@@ -1,0 +1,97 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Unittest for webreport/common.py module-load resilience."""
+
+import subprocess
+import sys
+import textwrap
+import unittest
+
+
+# ------------------------------------------------------------
+#
+# TestCommonImportsWithoutICU
+#
+# ------------------------------------------------------------
+class TestCommonImportsWithoutICU(unittest.TestCase):
+    """Regression: ``gramps.plugins.webreport.common`` must import
+    cleanly even when neither ``icu`` nor ``PyICU`` is available.
+
+    Historically the module's import-fallback chain only bound
+    ``localAlphabeticIndex`` in the *middle* two fallback paths
+    (icu-but-no-AlphabeticIndex, PyICU-but-no-AlphabeticIndex).
+    The bottom-most fallback — neither icu nor PyICU available —
+    was an empty ``pass``, leaving ``localAlphabeticIndex``
+    undefined. The module's later ``else`` branch then raised
+    ``NameError: name 'localAlphabeticIndex' is not defined`` at
+    module load.
+
+    The April 19 plugin-registration smoke test in addons-source CI
+    surfaced this through ``TimePedigreeHTML``, which imports
+    ``get_gendex_data`` from this module.
+    """
+
+    def test_imports_without_icu_or_pyicu(self):
+        """Block both ``icu`` and ``PyICU`` in a subprocess and
+        verify ``gramps.plugins.webreport.common`` still imports
+        with ``AlphabeticIndex`` defined."""
+        script = textwrap.dedent("""
+            import sys
+
+            # Block both icu bindings before any gramps import so the
+            # try/except chain in common.py routes into the bottom
+            # ``except ImportError`` branch — the one that used to be
+            # an empty ``pass``.
+            sys.modules['icu'] = None
+            sys.modules['PyICU'] = None
+
+            from gramps.plugins.webreport import common
+
+            # AlphabeticIndex must be a usable class regardless of
+            # which fallback branch was taken.
+            assert hasattr(common, 'AlphabeticIndex'), (
+                "AlphabeticIndex must be defined after module load"
+            )
+            # HAVE_ICU and HAVE_ALPHABETICINDEX should both be False
+            # when both bindings are blocked.
+            assert common.HAVE_ICU is False, (
+                "HAVE_ICU should be False without icu/PyICU"
+            )
+            assert common.HAVE_ALPHABETICINDEX is False, (
+                "HAVE_ALPHABETICINDEX should be False without icu/PyICU"
+            )
+            """)
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            "Importing common.py with icu/PyICU blocked must succeed.\n"
+            "stderr:\n%s\nstdout:\n%s" % (result.stderr, result.stdout),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -644,6 +644,10 @@ gramps/plugins/webreport/__init__.py
 gramps/plugins/webreport/citation.py
 gramps/plugins/webreport/common.py
 #
+# plugins/webreport/test directory
+#
+gramps/plugins/webreport/test/common_test.py
+#
 # plugins/webstuff directory
 #
 gramps/plugins/webstuff/__init__.py


### PR DESCRIPTION
## Summary

[`gramps/plugins/webreport/common.py:46-75`](https://github.com/gramps-project/gramps/blob/maintenance/gramps60/gramps/plugins/webreport/common.py#L46-L75) has a three-level try/except chain trying to import an ICU `AlphabeticIndex` (from `icu`, then `PyICU`, falling back to an in-tree pure-Python implementation). The bottom-most branch — when **neither** `icu` nor `PyICU` is installed — was an empty `pass`, so `localAlphabeticIndex` was never bound:

```python
HAVE_ICU = False
HAVE_ALPHABETICINDEX = False
try:
    from icu import Locale
    HAVE_ICU = True
    try:
        from icu import AlphabeticIndex as icuAlphabeticIndex
        HAVE_ALPHABETICINDEX = True
    except ImportError:
        from gramps.plugins.webreport.alphabeticindex import (
            AlphabeticIndex as localAlphabeticIndex,
        )                                                      # ┐ sets localAlphabeticIndex
except ImportError:
    try:
        from PyICU import Locale
        HAVE_ICU = True
        try:
            from PyICU import AlphabeticIndex as icuAlphabeticIndex
            HAVE_ALPHABETICINDEX = True
        except ImportError:
            from gramps.plugins.webreport.alphabeticindex import (
                AlphabeticIndex as localAlphabeticIndex,
            )                                                  # ┘ sets localAlphabeticIndex
    except ImportError:
        pass                                                   # ← never sets localAlphabeticIndex
```

Later in the same module (around line 681):

```python
if HAVE_ALPHABETICINDEX:
    class AlphabeticIndex(icuAlphabeticIndex): ...
else:
    AlphabeticIndex = localAlphabeticIndex   # ← NameError if neither icu/PyICU was available
```

On a host lacking both icu bindings, `HAVE_ALPHABETICINDEX` is False, the `else` branch runs, and importing the module raises:

```
NameError: name 'localAlphabeticIndex' is not defined
```

Every plugin that does `from gramps.plugins.webreport.common import ...` then fails to load. The most visible victim so far is the `TimePedigreeHTML` addon (flagged in the [addons-source plugin-registration smoke tests](https://github.com/gramps-project/addons-source/pull/820)), which imports `get_gendex_data` from this module.

## Fix

Mirror the two middle fallback branches in the bottom one — import the in-tree pure-Python `AlphabeticIndex` when both icu modules are absent:

```diff
     except ImportError:
-        pass
+        # Neither icu nor PyICU is available. Fall back to the
+        # in-tree pure-Python AlphabeticIndex so the ``else`` branch
+        # later in this module (``AlphabeticIndex = localAlphabeticIndex``)
+        # finds a defined name. Without this, importing
+        # ``gramps.plugins.webreport.common`` on a system lacking
+        # both icu bindings raises ``NameError: name
+        # 'localAlphabeticIndex' is not defined`` at module load.
+        from gramps.plugins.webreport.alphabeticindex import (
+            AlphabeticIndex as localAlphabeticIndex,
+        )
```

Behaviour unchanged on hosts where either `icu` or `PyICU` is available; on hosts where neither is, the module now imports cleanly and `AlphabeticIndex` falls back to the in-tree implementation.

## Regression test

Added `gramps/plugins/webreport/test/common_test.py` that subprocesses an import with both `icu` and `PyICU` blocked via `sys.modules` tampering, then verifies the module loads with `AlphabeticIndex` defined and `HAVE_ICU`/`HAVE_ALPHABETICINDEX` set to `False`.

Verified locally:

- **Before fix**: `NameError: name 'localAlphabeticIndex' is not defined` (FAIL)
- **After fix**: 1 test, OK

## Verification

- `GRAMPS_RESOURCES=. python3 -m unittest gramps.plugins.webreport.test.common_test -v` → 1 test, OK.
- `black gramps/plugins/webreport/common.py gramps/plugins/webreport/test/common_test.py` → no formatting changes needed.
- `mypy gramps/plugins/webreport/common.py gramps/plugins/webreport/test/common_test.py` → no issues found.

## Translation files

`gramps/plugins/webreport/test/common_test.py` added to `po/POTFILES.skip`.