### PR TITLE
Attempt to load berkeleydb with bsddb3 as a fallback.

### DIFF
--- a/gramps/grampsapp.py
+++ b/gramps/grampsapp.py
@@ -465,7 +465,7 @@ def show_settings():
         geocodeglib_ver = _("not found")
 
     try:
-        import bsddb3 as bsddb
+        import berkeleydb as bsddb
 
         bsddb_str = bsddb.__version__
         bsddb_db_str = (
@@ -474,7 +474,7 @@ def show_settings():
         bsddb_location_str = bsddb.__file__
     except:
         try:
-            import berkeleydb as bsddb
+            import bsddb3 as bsddb
 
             bsddb_str = bsddb.__version__
             bsddb_db_str = (

--- a/gramps/gui/aboutdialog.py
+++ b/gramps/gui/aboutdialog.py
@@ -77,12 +77,12 @@ def ellipses(text):
 
 
 try:
-    import bsddb3 as bsddb  ## ok, in try/except
+    import berkeleydb as bsddb  ## ok, in try/except
 
     BSDDB_STR = ellipses(str(bsddb.__version__) + " " + str(bsddb.db.version()))
 except:
     try:
-        import berkeleydb as bsddb
+        import bsddb3 as bsddb
 
         BSDDB_STR = ellipses(str(bsddb.__version__) + " " + str(bsddb.db.version()))
     except:

--- a/gramps/gui/logger/_errorreportassistant.py
+++ b/gramps/gui/logger/_errorreportassistant.py
@@ -33,12 +33,12 @@ import sys, os
 import platform
 
 try:
-    import bsddb3 as bsddb  # ok, in try/except
+    import berkeleydb as bsddb  # ok, in try/except
 
     BSDDB_STR = str(bsddb.__version__) + " " + str(bsddb.db.version())
 except:
     try:
-        import berkeleydb as bsddb
+        import bsddb3 as bsddb
 
         BSDDB_STR = str(bsddb.__version__) + " " + str(bsddb.db.version())
     except:

--- a/gramps/plugins/db/bsddb/bsddb.py
+++ b/gramps/plugins/db/bsddb/bsddb.py
@@ -28,8 +28,11 @@
 import os
 import pickle
 import logging
-from bsddb3.db import DB, DB_DUP, DB_HASH, DB_RDONLY
 
+try:
+    from berkeleydb.db import DB, DB_DUP, DB_HASH, DB_RDONLY
+except:
+    from bsddb3.db import DB, DB_DUP, DB_HASH, DB_RDONLY
 # -------------------------------------------------------------------------
 #
 # Gramps modules

--- a/gramps/plugins/gramplet/leak.py
+++ b/gramps/plugins/gramplet/leak.py
@@ -185,10 +185,10 @@ class Leak(Gramplet):
 
     def display(self):
         try:
-            from bsddb3.db import DBError
+            from berkeleydb.db import DBError
         except:
             try:
-                from berkeleydb.db import DBError
+                from bsddb3.db import DBError
             except:
 
                 class DBError(Exception):


### PR DESCRIPTION
Most importantly, this fixes a regression introduced in https://github.com/gramps-project/gramps/commit/b52c118673292b21a63613489c966eea8f5bfa59 which didn't include importing berkeleydb if importing bsddb3 failed as was done in all of the other imports of bsddb3. This regression broke BerkeleyDB use in the macOS bundle (which has used `berkeleydb` since 

Background: 
The Python BerkeleyDB wrapper maintainer [changed the name and version numbering in 2020](https://docs.jcea.es/berkeleydb/latest/changelog.html#id16) and deprecated the `bsddb3` name. The [last release of bsddb3](https://docs.jcea.es/berkeleydb/latest/changelog-bsddb3.html#id1) coincided with that change.  He writes that [`bsddb3` supports python up through Python 3.9 and that `berkeleydb` is required for Python 3.10 and later](https://www.jcea.es/programacion/pybsddb.htm). However, the macOS bundle continued to provide `bsddb3` until a year ago (in spite of my [adding support](https://github.com/gramps-project/gramps/commit/36d03137ddd8765b2c3a2de337c63e619552c737) for `berkeleydb` in 2020!)

Apparently not many users are still trying to access BerkeleyDB databases because nobody noticed [until today](https://gramps-project.org/bugs/view.php?id=14218).
