### PR TITLE
Add order change UI for rules in filter editor

### DIFF
--- a/gramps/gui/editors/filtereditor.py
+++ b/gramps/gui/editors/filtereditor.py
@@ -82,6 +82,7 @@ from ..widgets import DateEntry
 from gramps.gen.datehandler import displayer
 from gramps.gen.config import config
 from gramps.gen.constfunc import mac
+from ..utils import match_primary_mask
 from gramps.gui.widgets.persistenttreeview import PersistentTreeView
 
 # -------------------------------------------------------------------------
@@ -1142,14 +1143,10 @@ class EditFilter(ManagedWindow):
         if event.type == Gdk.EventType.KEY_PRESS:
             keyval = event.keyval
             modifiers = event.get_state()
-            # On Mac/Quartz, Cmd maps to META_MASK; elsewhere use CONTROL_MASK.
-            primary = (
-                Gdk.ModifierType.META_MASK if mac() else Gdk.ModifierType.CONTROL_MASK
-            )
-            if keyval == Gdk.KEY_Up and (modifiers & primary):
+            if keyval == Gdk.KEY_Up and match_primary_mask(modifiers):
                 self.on_up_clicked(widget)
                 return True
-            elif keyval == Gdk.KEY_Down and (modifiers & primary):
+            elif keyval == Gdk.KEY_Down and match_primary_mask(modifiers):
                 self.on_down_clicked(widget)
                 return True
             elif keyval == Gdk.KEY_Up and (modifiers & Gdk.ModifierType.MOD1_MASK):

--- a/gramps/gui/editors/filtereditor.py
+++ b/gramps/gui/editors/filtereditor.py
@@ -938,11 +938,22 @@ class EditFilter(ManagedWindow):
         self.edit_btn = self.get_widget("definition_edit")
         self.del_btn = self.get_widget("definition_delete")
         self.add_btn = self.get_widget("definition_add")
+        self.up_btn = self.get_widget("definition_up")
+        self.down_btn = self.get_widget("definition_down")
+
+        # Initially disable up/down buttons
+        self.up_btn.set_sensitive(False)
+        self.down_btn.set_sensitive(False)
 
         self.ok_btn.connect("clicked", self.on_ok_clicked)
         self.edit_btn.connect("clicked", self.on_edit_clicked)
         self.del_btn.connect("clicked", self.on_delete_clicked)
         self.add_btn.connect("clicked", self.on_add_clicked)
+        self.up_btn.connect("clicked", self.on_up_clicked)
+        self.down_btn.connect("clicked", self.on_down_clicked)
+
+        # Add keyboard support for arrow keys
+        self.rule_list.connect("key-press-event", self.on_key_press)
 
         self.get_widget("definition_help").connect("clicked", self.on_help_clicked)
         self.get_widget("definition_cancel").connect("clicked", self.close_window)
@@ -984,14 +995,24 @@ class EditFilter(ManagedWindow):
         if node:
             self.edit_btn.set_sensitive(True)
             self.del_btn.set_sensitive(True)
+            # Enable up/down buttons based on position
+            row = self.rlist.get_selected_row()
+            self.up_btn.set_sensitive(row > 0)
+            self.down_btn.set_sensitive(
+                row >= 0 and row < len(self.filter.get_rules()) - 1
+            )
         else:
             self.edit_btn.set_sensitive(False)
             self.del_btn.set_sensitive(False)
+            self.up_btn.set_sensitive(False)
+            self.down_btn.set_sensitive(False)
 
     def draw_rules(self):
         self.rlist.clear()
         for r in self.filter.get_rules():
             self.rlist.add([r.name, r.display_values()], r)
+        # Update button states after drawing
+        self.select_row(None)
 
     def on_ok_clicked(self, obj):
         n = str(self.fname.get_text()).strip()
@@ -1072,6 +1093,60 @@ class EditFilter(ManagedWindow):
             gfilter = self.rlist.get_object(node)
             self.filter.delete_rule(gfilter)
             self.draw_rules()
+
+    def on_up_clicked(self, obj):
+        """Move the selected rule up one position."""
+        store, node = self.rlist.get_selected()
+        if node:
+            rule = self.rlist.get_object(node)
+            rules = self.filter.get_rules()
+            pos = rules.index(rule)
+            if pos > 0:
+                # Move rule up
+                del rules[pos]
+                rules.insert(pos - 1, rule)
+                self.filter.set_rules(rules)
+                self.draw_rules()
+                # Reselect the moved rule
+                self.rlist.select_row(pos - 1)
+
+    def on_down_clicked(self, obj):
+        """Move the selected rule down one position."""
+        store, node = self.rlist.get_selected()
+        if node:
+            rule = self.rlist.get_object(node)
+            rules = self.filter.get_rules()
+            pos = rules.index(rule)
+            if pos >= 0 and pos < len(rules) - 1:
+                # Move rule down
+                del rules[pos]
+                rules.insert(pos + 1, rule)
+                self.filter.set_rules(rules)
+                self.draw_rules()
+                # Reselect the moved rule
+                self.rlist.select_row(pos + 1)
+
+    def on_key_press(self, widget, event):
+        """Handle keyboard shortcuts for moving rules."""
+        if event.type == Gdk.EventType.KEY_PRESS:
+            keyval = event.keyval
+            # Check for Up/Down arrow keys with Ctrl or Alt modifier
+            # (similar to how other apps handle reordering)
+            modifiers = event.get_state()
+            if keyval == Gdk.KEY_Up and (modifiers & Gdk.ModifierType.CONTROL_MASK):
+                self.on_up_clicked(widget)
+                return True
+            elif keyval == Gdk.KEY_Down and (modifiers & Gdk.ModifierType.CONTROL_MASK):
+                self.on_down_clicked(widget)
+                return True
+            # Also support Alt+Up/Down
+            elif keyval == Gdk.KEY_Up and (modifiers & Gdk.ModifierType.MOD1_MASK):
+                self.on_up_clicked(widget)
+                return True
+            elif keyval == Gdk.KEY_Down and (modifiers & Gdk.ModifierType.MOD1_MASK):
+                self.on_down_clicked(widget)
+                return True
+        return False
 
     def on_model_row_inserted(self, model, path, iter):
         """

--- a/gramps/gui/editors/filtereditor.py
+++ b/gramps/gui/editors/filtereditor.py
@@ -914,6 +914,22 @@ class EditFilter(ManagedWindow):
             self.on_edit_clicked,
         )
 
+        # Enable drag-and-drop reordering
+        self.rlist.set_reorderable(True)
+        # Monitor model changes to detect when drag-and-drop reordering occurs
+        # GTK reorders by deleting and reinserting rows, so we track these events
+        self.rlist.model.connect("row-inserted", self.on_model_row_inserted)
+        self.rlist.model.connect("row-deleted", self.on_model_row_deleted)
+        self._pending_reorder = False
+        self._reorder_idle_id = None
+
+        # Add visual indicators for drag-and-drop
+        # 1. Change cursor to indicate draggable rows
+        self.rule_list.connect("motion-notify-event", self.on_motion_notify)
+        self.rule_list.add_events(Gdk.EventMask.POINTER_MOTION_MASK)
+
+        # 2. Hint text is now in the Glade file (reorder_hint label)
+
         self.fname = self.get_widget("filter_name")
         self.logical = self.get_widget("rule_apply")
         self.logical_not = self.get_widget("logical_not")
@@ -1056,6 +1072,82 @@ class EditFilter(ManagedWindow):
             gfilter = self.rlist.get_object(node)
             self.filter.delete_rule(gfilter)
             self.draw_rules()
+
+    def on_model_row_inserted(self, model, path, iter):
+        """
+        Called when a row is inserted into the model.
+        Mark that a reorder might be pending and schedule an update.
+        """
+        self._pending_reorder = True
+        self._schedule_reorder_update()
+
+    def on_model_row_deleted(self, model, path):
+        """
+        Called when a row is deleted from the model.
+        Mark that a reorder might be pending and schedule an update.
+        """
+        self._pending_reorder = True
+        self._schedule_reorder_update()
+
+    def _schedule_reorder_update(self):
+        """
+        Schedule an update of the filter order after model changes complete.
+        Uses idle_add to batch multiple row insert/delete operations.
+        """
+        if self._reorder_idle_id is not None:
+            GObject.source_remove(self._reorder_idle_id)
+        self._reorder_idle_id = GObject.idle_add(self._update_filter_order_from_model)
+
+    def _update_filter_order_from_model(self):
+        """
+        Updates the filter's rule list to match the current order in the model.
+        Called after drag-and-drop operations to sync the filter with the UI.
+        """
+        if not self._pending_reorder:
+            self._reorder_idle_id = None
+            return False  # Remove from idle queue
+
+        # Get all rules in the current order from the model
+        new_rules = []
+        current_iter = self.rlist.model.get_iter_first()
+        while current_iter:
+            rule = self.rlist.model.get_value(current_iter, self.rlist.data_index)
+            new_rules.append(rule)
+            current_iter = self.rlist.model.iter_next(current_iter)
+
+        # Only update if the order has actually changed
+        current_rules = self.filter.get_rules()
+        if new_rules != current_rules:
+            # Update the filter's rule list to match the new order
+            self.filter.set_rules(new_rules)
+
+        self._pending_reorder = False
+        self._reorder_idle_id = None
+        return False  # Remove from idle queue
+
+    def on_motion_notify(self, widget, event):
+        """
+        Called when the mouse moves over the rule list.
+        Changes the cursor to indicate that rows can be dragged.
+        """
+        # Check if we're over a row
+        path_info = widget.get_path_at_pos(int(event.x), int(event.y))
+        window = widget.get_window()
+        if window and window.is_visible():
+            if path_info:
+                # We're over a row, show hand cursor to indicate draggable
+                try:
+                    cursor = Gdk.Cursor.new_for_display(
+                        window.get_display(), Gdk.CursorType.HAND2
+                    )
+                    window.set_cursor(cursor)
+                except (AttributeError, TypeError):
+                    # If cursor creation fails, just continue
+                    pass
+            else:
+                # Not over a row, use default cursor
+                window.set_cursor(None)
+        return False  # Allow other handlers to process the event
 
 
 # -------------------------------------------------------------------------

--- a/gramps/gui/editors/filtereditor.py
+++ b/gramps/gui/editors/filtereditor.py
@@ -81,6 +81,7 @@ from gramps.gen.utils.string import conf_strings
 from ..widgets import DateEntry
 from gramps.gen.datehandler import displayer
 from gramps.gen.config import config
+from gramps.gen.constfunc import mac
 from gramps.gui.widgets.persistenttreeview import PersistentTreeView
 
 # -------------------------------------------------------------------------
@@ -727,7 +728,7 @@ class EditRule(ManagedWindow):
             page = self.class2page[self.active_rule.__class__]
             self.notebook.set_current_page(page)
             self.display_values(self.active_rule.__class__)
-            (class_obj, vallist, tlist, use_regex, use_case) = self.page[page]
+            class_obj, vallist, tlist, use_regex, use_case = self.page[page]
             r = list(self.active_rule.values())
             for i in range(0, min(len(tlist), len(r))):
                 tlist[i].set_text(r[i])
@@ -838,7 +839,7 @@ class EditRule(ManagedWindow):
 
         try:
             page = self.notebook.get_current_page()
-            (class_obj, vallist, tlist, use_regex, use_case) = self.page[page]
+            class_obj, vallist, tlist, use_regex, use_case = self.page[page]
             value_list = [str(sclass.get_text()) for sclass in tlist]
             if class_obj.allow_regex:
                 new_rule = class_obj(
@@ -928,7 +929,17 @@ class EditFilter(ManagedWindow):
         self.rule_list.connect("motion-notify-event", self.on_motion_notify)
         self.rule_list.add_events(Gdk.EventMask.POINTER_MOTION_MASK)
 
-        # 2. Hint text is now in the Glade file (reorder_hint label)
+        # 2. Hint label: use Cmd on Mac/Quartz, Ctrl everywhere else
+        key_name = _("Cmd") if mac() else _("Ctrl")
+        self.get_widget("reorder_hint").set_markup(
+            '<span style="italic" size="small">'
+            + _(
+                "To change rule order, use drag and drop, up/down buttons,"
+                " or %s+Arrow keys"
+            )
+            % key_name
+            + "</span>"
+        )
 
         self.fname = self.get_widget("filter_name")
         self.logical = self.get_widget("rule_apply")
@@ -1130,16 +1141,17 @@ class EditFilter(ManagedWindow):
         """Handle keyboard shortcuts for moving rules."""
         if event.type == Gdk.EventType.KEY_PRESS:
             keyval = event.keyval
-            # Check for Up/Down arrow keys with Ctrl or Alt modifier
-            # (similar to how other apps handle reordering)
             modifiers = event.get_state()
-            if keyval == Gdk.KEY_Up and (modifiers & Gdk.ModifierType.CONTROL_MASK):
+            # On Mac/Quartz, Cmd maps to META_MASK; elsewhere use CONTROL_MASK.
+            primary = (
+                Gdk.ModifierType.META_MASK if mac() else Gdk.ModifierType.CONTROL_MASK
+            )
+            if keyval == Gdk.KEY_Up and (modifiers & primary):
                 self.on_up_clicked(widget)
                 return True
-            elif keyval == Gdk.KEY_Down and (modifiers & Gdk.ModifierType.CONTROL_MASK):
+            elif keyval == Gdk.KEY_Down and (modifiers & primary):
                 self.on_down_clicked(widget)
                 return True
-            # Also support Alt+Up/Down
             elif keyval == Gdk.KEY_Up and (modifiers & Gdk.ModifierType.MOD1_MASK):
                 self.on_up_clicked(widget)
                 return True
@@ -1478,7 +1490,7 @@ class FilterEditor(ManagedWindow):
             try:
                 handle_list = filt.apply(self.db, self.get_all_handles())
             except FilterError as msg:
-                (msg1, msg2) = msg.messages()
+                msg1, msg2 = msg.messages()
                 ErrorDialog(msg1, msg2, parent=self.window)
                 return
             ShowResults(

--- a/gramps/gui/glade/rule.glade
+++ b/gramps/gui/glade/rule.glade
@@ -569,7 +569,7 @@
                     <property name="halign">center</property>
                     <property name="margin-top">4</property>
                     <property name="use-markup">True</property>
-                    <property name="label" translatable="yes">&lt;span style=&quot;italic&quot; size=&quot;small&quot;&gt;To change rule order, use drag and drop, up/down buttons, or Ctrl+Arrow keys&lt;/span&gt;</property>
+                    <property name="label"></property>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>

--- a/gramps/gui/glade/rule.glade
+++ b/gramps/gui/glade/rule.glade
@@ -502,6 +502,21 @@
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkLabel" id="reorder_hint">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">center</property>
+                    <property name="margin-top">4</property>
+                    <property name="use-markup">True</property>
+                    <property name="label" translatable="yes">&lt;span style=&quot;italic&quot; size=&quot;small&quot;&gt;Drag and drop rules to change order&lt;/span&gt;</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">5</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkLabel" id="label16">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
@@ -513,7 +528,7 @@
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">5</property>
+                    <property name="top-attach">6</property>
                   </packing>
                 </child>
                 <child>
@@ -599,7 +614,7 @@
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">7</property>
+                    <property name="top-attach">8</property>
                     <property name="width">2</property>
                   </packing>
                 </child>
@@ -618,7 +633,7 @@
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">6</property>
+                    <property name="top-attach">7</property>
                     <property name="width">2</property>
                   </packing>
                 </child>

--- a/gramps/gui/glade/rule.glade
+++ b/gramps/gui/glade/rule.glade
@@ -493,7 +493,68 @@
                       </packing>
                     </child>
                     <child>
-                      <placeholder/>
+                      <object class="GtkButton" id="definition_up">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="can-default">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="tooltip-text" translatable="yes">Move the selected rule up</property>
+                        <signal name="clicked" handler="on_up_clicked" swapped="no"/>
+                        <child>
+                          <object class="GtkImage" id="image5">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="icon-name">go-up</property>
+                            <child internal-child="accessible">
+                              <object class="AtkObject" id="image5-atkobject">
+                                <property name="AtkObject::accessible-description" translatable="yes">Move Up</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <child internal-child="accessible">
+                          <object class="AtkObject" id="definition_up-atkobject">
+                            <property name="AtkObject::accessible-name" translatable="yes">Move Up</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="definition_down">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="can-default">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="tooltip-text" translatable="yes">Move the selected rule down</property>
+                        <signal name="clicked" handler="on_down_clicked" swapped="no"/>
+                        <child>
+                          <object class="GtkImage" id="image6">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="icon-name">go-down</property>
+                            <child internal-child="accessible">
+                              <object class="AtkObject" id="image6-atkobject">
+                                <property name="AtkObject::accessible-description" translatable="yes">Move Down</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <child internal-child="accessible">
+                          <object class="AtkObject" id="definition_down-atkobject">
+                            <property name="AtkObject::accessible-name" translatable="yes">Move Down</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">4</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>
@@ -508,7 +569,7 @@
                     <property name="halign">center</property>
                     <property name="margin-top">4</property>
                     <property name="use-markup">True</property>
-                    <property name="label" translatable="yes">&lt;span style=&quot;italic&quot; size=&quot;small&quot;&gt;Drag and drop rules to change order&lt;/span&gt;</property>
+                    <property name="label" translatable="yes">&lt;span style=&quot;italic&quot; size=&quot;small&quot;&gt;To change rule order, use drag and drop, up/down buttons, or Ctrl+Arrow keys&lt;/span&gt;</property>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>

--- a/gramps/plugins/test/db_undo_and_signals_test.py
+++ b/gramps/plugins/test/db_undo_and_signals_test.py
@@ -184,8 +184,16 @@ class DbTestClassBase(object):
             ),
         ]
         self.assertEqual(sigs, self.sigs, msg="make families")
-        # save state for later undo/redo check
-        step1 = (family1, father1, mother1, family2, father2, mother2)
+        # save state for later undo/redo check; re-read from DB so the
+        # serialized change timestamps match what the DB actually stored.
+        step1 = (
+            self.db.get_family_from_handle(family1.handle),
+            self.db.get_person_from_handle(father1.handle),
+            self.db.get_person_from_handle(mother1.handle),
+            self.db.get_family_from_handle(family2.handle),
+            self.db.get_person_from_handle(father2.handle),
+            self.db.get_person_from_handle(mother2.handle),
+        )
         fam_cnt = self.db.get_number_of_families()
         pers_cnt = self.db.get_number_of_people()
         self.assertEqual(fam_cnt, 2, msg="make families check")


### PR DESCRIPTION
This PR adds the ability to change the order of rules in the filter editor by dragging/dropping, up/down arrow buttons, and keyboard controls.

Visual info is given by a textual hint below the rule list (requires translation), and via changing the mouse-over cursor.

<img width="847" height="613" alt="image" src="https://github.com/user-attachments/assets/8f802e78-47c3-4c86-9006-a73c43123e86" />
 
Thanks to @emyoulation for bringing this issue up.

Note: This PR was written with help from Cursor (various models) and Copilot.

---
*Originally opened on 2025-12-31 as PR #2161.*