### PR TITLE
Add Python PyPI wheel installer for addon module dependencies

### DIFF
--- a/.github/workflows/gramps-ci.yml
+++ b/.github/workflows/gramps-ci.yml
@@ -85,3 +85,20 @@ jobs:
           echo "ERROR - A new file is not listed in either POTFILES.in or POTFILES.skip";
           exit 1;
         fi
+
+  pypi-installer:
+    name: PyPI installer tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, windows-latest, macos-latest]
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Create minimal resource directory
+      run: python -c "import os, shutil; os.makedirs('build/share/gramps', exist_ok=True); shutil.copy('data/authors.xml', 'build/share/gramps/authors.xml')"
+    - name: Run PyPI installer tests
+      run: python -m unittest gramps.gen.utils.test.pypi_test -v

--- a/gramps/gen/utils/pypi.py
+++ b/gramps/gen/utils/pypi.py
@@ -1,0 +1,1312 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Stdlib-only wheel installer for PyPI packages.
+
+Downloads and installs wheels from PyPI into a target directory using only the
+Python standard library.  No pip, no certifi, no external dependencies.  SSL
+uses the system trust store via ssl.create_default_context().
+
+This installer is used in two distinct situations:
+
+* **Frozen bundles** (cx_Freeze Windows AIO, macOS .app): pip is not available
+  as a subprocess.  Both pure-Python and compiled wheels are supported; the
+  compiled-wheel path selects the best wheel for the current Python version and
+  platform (Windows ``win_amd64``/``win_arm64``/``win32``; macOS
+  ``macosx_X_Y_arm64|x86_64|universal2``).
+
+* **Source / snap installs with pip**: pip is available and is used instead
+  (see ``gramps/gui/plug/_windows.py``).  ``install_package()`` is not called
+  in this code path.
+
+* **Flatpak / pip-less environments**: Flathub and other sandboxed runtimes
+  strip ``pip`` from the Python installation.  ``_pip_available()`` detects
+  this and routes to ``install_package()`` exactly as for frozen bundles.
+
+Limitations:
+  - No support for VCS URLs or local paths.
+  - Constraint gathering uses the *latest* release's dep list from the PyPI
+    JSON API; if an older version is resolved, its actual transitive deps
+    may differ slightly (tier-2 limitation).
+"""
+
+# -------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import ctypes
+import email.parser
+import functools
+import hashlib
+import importlib
+import importlib.metadata
+import io
+import json
+import logging
+import os
+import platform
+import re
+import ssl
+import subprocess
+import sys
+import urllib.request
+import zipfile
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from ..const import GRAMPS_LOCALE as glocale
+
+_ = glocale.translation.sgettext
+
+LOG = logging.getLogger(__name__)
+
+_PYPI_JSON_URL = "https://pypi.org/pypi/{package}/json"
+_PURE_TAGS = {"py3-none-any", "py2.py3-none-any"}
+
+# Cached result of _compatible_tags() so it is only computed once.
+_COMPAT_TAGS: tuple[set[str], set[str], set[str]] | None = None
+
+# Mapping from Python import names to their PyPI distribution names.
+# Many packages have an import name that differs from the PyPI package name.
+# Addon authors declare requires_mod using the import name; this table lets
+# install_package() and pip look up the correct installable name.
+#
+# Only add entries where the import name would either:
+#  - return a 404 from PyPI (e.g. "cv2", "yaml"),
+#  - resolve to a completely different package (e.g. "serial" → a JSON lib),
+#  - or resolve to a dead/stub package with no wheels (e.g. "PIL", "sklearn").
+#
+# Do NOT add entries where the import name already maps correctly, even with
+# different capitalisation — PyPI normalises case and underscores/hyphens.
+_IMPORT_TO_PYPI: dict[str, str] = {
+    # Image processing
+    "PIL": "Pillow",
+    "cv2": "opencv-python",
+    # Data / science
+    "sklearn": "scikit-learn",
+    "yaml": "PyYAML",
+    "dateutil": "python-dateutil",
+    # Web / network
+    "bs4": "beautifulsoup4",
+    "serial": "pyserial",
+    "usb": "pyusb",
+    # Cryptography
+    "nacl": "PyNaCl",
+    "Crypto": "pycryptodome",
+    "OpenSSL": "pyOpenSSL",
+    # GUI (unlikely in headless addons, but common mismatch)
+    "wx": "wxPython",
+}
+
+# Architecture sets for manylinux legacy tag aliases (PEP 513/571/599).
+_MANYLINUX1_ARCHS: frozenset[str] = frozenset({"x86_64", "i686"})
+_MANYLINUX2010_ARCHS: frozenset[str] = frozenset({"x86_64", "i686"})
+_MANYLINUX2014_ARCHS: frozenset[str] = frozenset(
+    {"x86_64", "i686", "aarch64", "armv7l", "ppc64", "ppc64le", "s390x"}
+)
+
+# Compiled pattern for parsing a PEP 508 requirement string.
+# Captures: name, optional extras (without brackets), version spec, optional marker.
+_REQ_RE: re.Pattern[str] = re.compile(
+    r"^\s*"
+    r"(?P<name>[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)"
+    r"\s*(?:\[(?P<extras>[^\]]*)\])?\s*"
+    r"(?P<spec>[^;]*)"
+    r"(?:;\s*(?P<marker>.+))?"
+    r"\s*$"
+)
+
+# Marker variables compared using version ordering rather than string ordering.
+_VERSION_VARS: frozenset[str] = frozenset(
+    {
+        "python_version",
+        "python_full_version",
+        "implementation_version",
+    }
+)
+
+
+# -------------------------------------------------------------------------
+#
+# Bundle detection
+#
+# -------------------------------------------------------------------------
+def is_frozen() -> bool:
+    """Return True when running inside a frozen bundle where sys.executable
+    is not a usable Python interpreter for spawning pip.
+
+    Most bundlers set sys.frozen, but some do not:
+    - macOS .app packagers may leave sys.frozen unset; we detect them by
+      checking whether sys.executable points into a .app bundle.
+    - Windows bundlers such as Nuitka and PyOxidizer produce a named app
+      binary (e.g. Gramps.exe) rather than a python*.exe interpreter; we
+      detect those by checking the executable basename.
+    """
+    if getattr(sys, "frozen", False):
+        return True
+    exe = sys.executable or ""
+    # macOS .app bundle: sys.executable is e.g. '/Foo.app' or
+    # '/Foo.app/Contents/MacOS/Gramps'
+    if exe.endswith(".app") or ".app/" in exe:
+        return True
+    # Windows bundle (Nuitka, PyOxidizer, …): sys.executable is the app
+    # binary (Gramps.exe), not a python*.exe interpreter.
+    if sys.platform == "win32":
+        basename = os.path.basename(exe).lower()
+        return not (basename.startswith("python") or basename.startswith("pypy"))
+    return False
+
+
+# -------------------------------------------------------------------------
+#
+# PyPIInstaller
+#
+# -------------------------------------------------------------------------
+class PyPIInstallError(Exception):
+    """Raised when a package cannot be installed from PyPI."""
+
+
+# -------------------------------------------------------------------------
+#
+# Internal helpers
+#
+# -------------------------------------------------------------------------
+def _ssl_context() -> ssl.SSLContext:
+    """
+    Return an SSL context that trusts the system certificate store.
+
+    On macOS the standard Python.org installer does not wire OpenSSL to the
+    macOS Keychain, so ``ssl.create_default_context()`` alone cannot verify
+    PyPI's certificate.  If the ``certifi`` package is importable its CA
+    bundle is used instead, which resolves the issue transparently.
+    """
+    try:
+        import certifi  # optional; absent in frozen bundles without certifi
+
+        return ssl.create_default_context(cafile=certifi.where())
+    except ImportError:
+        return ssl.create_default_context()
+
+
+def _ssl_cert_hint(exc: Exception) -> str:
+    """
+    Return a platform-specific hint when *exc* looks like an SSL cert error.
+
+    Returns an empty string for non-SSL errors.
+    """
+    cause = getattr(exc, "reason", exc)
+    if not (
+        isinstance(cause, ssl.SSLError) and "CERTIFICATE_VERIFY_FAILED" in str(cause)
+    ):
+        return ""
+    if platform.system() == "Darwin":
+        return _(
+            "\n\nOn macOS, Python may not have access to the system SSL "
+            "certificates.  Try one of the following:\n"
+            "  1. python.org installer: run 'Install Certificates.command' "
+            "in your Python installation folder "
+            "(e.g. /Applications/Python 3.x/).\n"
+            "  2. pyenv / Homebrew / non-system Python: set the SSL_CERT_FILE "
+            "environment variable before starting Gramps:\n"
+            "       export SSL_CERT_FILE=/etc/ssl/cert.pem\n"
+            "  3. Install the certifi package:  pip install certifi"
+        )
+    return _(
+        "\n\nSSL certificate verification failed.  This is common with "
+        "non-system Python installations (pyenv, conda) whose bundled "
+        "OpenSSL does not know where system certificates are stored.  "
+        "Try one of the following:\n"
+        "  1. Install the certifi package:  pip install certifi\n"
+        "  2. Set SSL_CERT_FILE to your system CA bundle before starting "
+        "Gramps, e.g.:\n"
+        "       export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt  "
+        "(Debian/Ubuntu)\n"
+        "       export SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt    "
+        "(RHEL/Fedora)"
+    )
+
+
+@functools.cache
+def _glibc_version() -> tuple[int, int] | None:
+    """Return ``(major, minor)`` of the system glibc, or ``None`` if not glibc.
+
+    Tries the ctypes ``gnu_get_libc_version`` symbol first (most reliable),
+    then falls back to ``platform.libc_ver()``.
+    """
+    # Primary: call gnu_get_libc_version() via ctypes.
+    try:
+        process_namespace = ctypes.CDLL(None)
+        gnu_get_libc_version = process_namespace.gnu_get_libc_version
+        gnu_get_libc_version.restype = ctypes.c_char_p
+        ver_bytes = gnu_get_libc_version()
+        if ver_bytes:
+            parts = ver_bytes.decode("ascii").split(".")
+            return int(parts[0]), int(parts[1])
+    except Exception:
+        pass
+    # Fallback: platform.libc_ver() reads the libc binary.
+    try:
+        libc_name, libc_ver = platform.libc_ver()
+        if libc_name == "glibc" and libc_ver:
+            parts = libc_ver.split(".")
+            return int(parts[0]), int(parts[1])
+    except Exception:
+        pass
+    return None
+
+
+@functools.cache
+def _musl_version() -> tuple[int, int] | None:
+    """Return ``(major, minor)`` of musl libc, or ``None`` if not a musl system.
+
+    Detects musl by looking for its dynamic linker at
+    ``/lib/ld-musl-{arch}.so.1`` and running it to parse the version line.
+    """
+    machine = platform.machine()
+    # musl uses "arm" for all 32-bit ARM variants (armv7l, armv6l, …).
+    musl_arch = "arm" if machine.startswith("armv") else machine
+    candidate = f"/lib/ld-musl-{musl_arch}.so.1"
+    if not os.path.exists(candidate):
+        return None
+    try:
+        result = subprocess.run(
+            [candidate],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+        output = result.stdout + result.stderr
+        m = re.search(r"Version\s+(\d+)\.(\d+)", output)
+        if m:
+            return int(m.group(1)), int(m.group(2))
+    except Exception:
+        pass
+    return None
+
+
+def _manylinux_platform_tags(
+    machine: str, glibc_major: int, glibc_minor: int
+) -> set[str]:
+    """Return all manylinux platform tags compatible with the given glibc version.
+
+    Generates PEP 600 perennial tags (``manylinux_X_Y_{arch}`` for all Y the
+    system satisfies) and the three legacy aliases where the architecture
+    qualifies (manylinux1, manylinux2010, manylinux2014).
+
+    :param machine: Value from ``platform.machine()``.
+    :param glibc_major: Major version of the system glibc.
+    :param glibc_minor: Minor version of the system glibc.
+    :returns: Set of compatible manylinux platform tag strings.
+    """
+    tags: set[str] = set()
+    if glibc_major != 2:
+        # glibc 3 does not exist yet; nothing to generate.
+        return tags
+    # PEP 600: include manylinux_2_Y for every Y the system satisfies.
+    # Oldest practical minimum is 2.5 (manylinux1).
+    for mn in range(5, glibc_minor + 1):
+        tags.add(f"manylinux_{glibc_major}_{mn}_{machine}")
+    # Legacy aliases are only defined for specific architectures.
+    if glibc_minor >= 5 and machine in _MANYLINUX1_ARCHS:
+        tags.add(f"manylinux1_{machine}")
+    if glibc_minor >= 12 and machine in _MANYLINUX2010_ARCHS:
+        tags.add(f"manylinux2010_{machine}")
+    if glibc_minor >= 17 and machine in _MANYLINUX2014_ARCHS:
+        tags.add(f"manylinux2014_{machine}")
+    return tags
+
+
+def _compatible_tags() -> tuple[set[str], set[str], set[str]]:
+    """
+    Return (python_tags, abi_tags, platform_tags) for the running interpreter.
+
+    Used to select compiled wheels on platforms where pip is unavailable
+    (cx_Freeze Windows AIO, macOS .app bundles, Flatpak).
+    """
+    global _COMPAT_TAGS
+    if _COMPAT_TAGS is not None:
+        return _COMPAT_TAGS
+
+    major = sys.version_info.major
+    minor = sys.version_info.minor
+
+    # All cp3X tags for X <= current minor (covers abi3 wheels declaring an
+    # older minimum CPython version), plus generic py3 / py2.py3 tags.
+    py_tags: set[str] = {f"py{major}", "py3", "py2.py3"}
+    for m in range(2, minor + 1):
+        py_tags.add(f"cp{major}{m}")
+        py_tags.add(f"py{major}{m}")
+
+    abi_tags: set[str] = {f"cp{major}{minor}", "abi3", "none"}
+
+    # "any" is always compatible — covers pure-Python wheels on every platform.
+    plat_tags: set[str] = {"any"}
+    system = platform.system()
+    machine = platform.machine()
+
+    if system == "Windows":
+        if machine == "AMD64":
+            plat_tags.add("win_amd64")
+        elif machine == "ARM64":
+            plat_tags.add("win_arm64")
+        else:
+            plat_tags.add("win32")
+
+    elif system == "Darwin":
+        try:
+            ver_str = platform.mac_ver()[0]  # e.g. "14.4.0"
+            parts = ver_str.split(".")
+            cur_major = int(parts[0])
+            cur_minor = int(parts[1]) if len(parts) > 1 else 0
+        except (ValueError, IndexError):
+            # mac_ver() can return an empty string in some environments
+            # (Docker, certain CI setups).  Fall back to pure wheels only.
+            LOG.warning(
+                "Could not determine macOS version from platform.mac_ver(); "
+                "compiled wheels will not be matched."
+            )
+            cur_major = cur_minor = 0
+        if cur_major >= 10:
+            # universal2 wheels run on both arm64 and x86_64.
+            archs = {machine, "universal2"}
+            for arch in archs:
+                for maj in range(10, cur_major + 1):
+                    minor_start = 4 if maj == 10 else 0
+                    minor_end = cur_minor + 1 if maj == cur_major else 16
+                    for mn in range(minor_start, minor_end):
+                        plat_tags.add(f"macosx_{maj}_{mn}_{arch}")
+
+    else:
+        # Linux: generate manylinux/musllinux tags when the libc version is
+        # detectable; always include the bare linux_{arch} tag as a fallback.
+        glibc = _glibc_version()
+        if glibc is not None:
+            plat_tags.update(_manylinux_platform_tags(machine, *glibc))
+        musl = _musl_version()
+        if musl is not None:
+            musl_major, musl_minor = musl
+            for mn in range(1, musl_minor + 1):
+                plat_tags.add(f"musllinux_{musl_major}_{mn}_{machine}")
+        plat_tags.add(f"linux_{machine}")
+
+    _COMPAT_TAGS = (py_tags, abi_tags, plat_tags)
+    return _COMPAT_TAGS
+
+
+def _is_compatible_wheel(file_info: dict) -> bool:
+    """
+    Return True if *file_info* describes a wheel compatible with the current
+    Python interpreter and platform.
+
+    Handles multi-tag filenames (dot-joined fields, e.g.
+    ``macosx_11_0_arm64.macosx_10_12_universal2``) by treating each
+    dot-separated token as an alternative; a wheel matches when at least one
+    token from each of the three tag fields is in the compatible set.
+    """
+    filename = file_info.get("filename", "")
+    if not filename.endswith(".whl"):
+        return False
+    parts = filename[:-4].split("-")
+    if len(parts) < 5:
+        return False
+    # Dot-joined multi-tags: any token matching is sufficient.
+    whl_py = set(parts[-3].split("."))
+    whl_abi = set(parts[-2].split("."))
+    whl_plat = set(parts[-1].split("."))
+    compat_py, compat_abi, compat_plat = _compatible_tags()
+    return bool(whl_py & compat_py and whl_abi & compat_abi and whl_plat & compat_plat)
+
+
+_FETCH_TIMEOUT = 30  # seconds; applied to both metadata and wheel downloads
+
+
+def _fetch_url(url: str) -> bytes:
+    """Download *url* and return the raw bytes.
+
+    Raises ``urllib.error.URLError`` (or a subclass) on network error, and
+    ``TimeoutError`` if the server does not respond within ``_FETCH_TIMEOUT``
+    seconds.
+    """
+    ctx = _ssl_context()
+    with urllib.request.urlopen(url, context=ctx, timeout=_FETCH_TIMEOUT) as resp:
+        return resp.read()
+
+
+@functools.cache
+def _pypi_metadata(package: str) -> dict:
+    """Return the PyPI JSON metadata dict for *package*.
+
+    Results are cached per package name so that the gather pass and the
+    install pass share the same response without a second network round-trip.
+    """
+    url = _PYPI_JSON_URL.format(package=package)
+    LOG.debug("Fetching PyPI metadata: %s", url)
+    try:
+        data = _fetch_url(url)
+    except Exception as exc:
+        raise PyPIInstallError(
+            _("Cannot reach PyPI for package '%s': %s") % (package, exc)
+            + _ssl_cert_hint(exc)
+        ) from exc
+    return json.loads(data)
+
+
+def _version_sort_key(version: str) -> tuple[int, ...]:
+    """
+    Return a numeric sort key for a version string.
+
+    Splits on dots and dashes and converts leading digit runs to ints so that
+    ``"1.10"`` sorts after ``"1.9"``.  Not fully PEP 440 compliant (pre-release
+    suffixes sort as zero) but sufficient for picking the newest release.
+    """
+    parts = []
+    for segment in re.split(r"[.\-]", version):
+        if not segment:
+            continue
+        m = re.match(r"^(\d+)", segment)
+        parts.append(int(m.group(1)) if m else 0)
+    return tuple(parts)
+
+
+# PEP 440 pre-release segment pattern: aN, bN, rcN directly after a digit;
+# .devN, .alphaN, .betaN, .previewN with a separator prefix.
+# Post-releases (.postN) are NOT pre-releases and must not be excluded.
+_PRERELEASE_RE: re.Pattern[str] = re.compile(
+    r"(?<=\d)(?:a|b|rc)\d+"  # aN / bN / rcN attached directly after a digit
+    r"|[._-](?:dev|alpha|beta|preview)\d*",  # spelled-out forms with separator
+    re.IGNORECASE,
+)
+
+
+def _is_prerelease(version: str) -> bool:
+    """Return True if *version* is a PEP 440 pre-release or dev release.
+
+    Recognises the suffixes ``aN``, ``bN``, ``rcN``, ``.devN``, ``.alphaN``,
+    and ``.betaN``.  Post-releases (``.postN``) are *not* pre-releases.
+    """
+    return bool(_PRERELEASE_RE.search(version))
+
+
+def _is_yanked(file_info: dict) -> bool:
+    """Return True if the PyPI file entry is marked as yanked."""
+    return bool(file_info.get("yanked", False))
+
+
+def _requires_python_ok(file_info: dict) -> bool:
+    """Return True if the wheel's ``requires_python`` is satisfied by the
+    running interpreter, or if no ``requires_python`` field is present.
+
+    Uses ``_satisfies_spec`` so the comparison is numeric, not lexicographic.
+    """
+    spec = file_info.get("requires_python") or ""
+    if not spec:
+        return True
+    current = f"{sys.version_info.major}.{sys.version_info.minor}"
+    return _satisfies_spec(current, spec)
+
+
+def _pick_wheel(meta: dict, package: str, version: str | None = None) -> dict:
+    """
+    Return the file entry for the best wheel in *meta* for the current platform.
+
+    When *version* is given only files listed under that release in
+    ``meta["releases"]`` are searched.  Otherwise the preference order is:
+    pure-Python wheel from the latest release, then a platform-compatible
+    compiled wheel from the latest release, then the same two searches
+    across older releases newest-first.
+
+    Yanked files and files whose ``requires_python`` the running interpreter
+    does not satisfy are skipped in all search paths.
+
+    :param meta: PyPI JSON metadata dict for the package.
+    :param package: Package name (used only in error messages).
+    :param version: Exact version string to pin, or ``None`` for latest.
+    :raises PyPIInstallError: if no compatible wheel is found.
+    """
+    if version is not None:
+        candidates = [
+            f
+            for f in meta.get("releases", {}).get(version, [])
+            if not _is_yanked(f) and _requires_python_ok(f)
+        ]
+        for file_info in candidates:
+            if _is_pure_wheel(file_info):
+                return file_info
+        for file_info in candidates:
+            if _is_compatible_wheel(file_info):
+                return file_info
+        raise PyPIInstallError(
+            _("No compatible wheel found for '%s==%s' on this platform.")
+            % (package, version)
+        )
+    # 1. Pure wheel in latest release.
+    for file_info in meta.get("urls", []):
+        if not _is_yanked(file_info) and _requires_python_ok(file_info):
+            if _is_pure_wheel(file_info):
+                return file_info
+    # 2. Compiled wheel matching the current platform in latest release.
+    for file_info in meta.get("urls", []):
+        if not _is_yanked(file_info) and _requires_python_ok(file_info):
+            if _is_compatible_wheel(file_info):
+                return file_info
+    # urls only covers the latest release; search all releases newest-first.
+    sorted_releases = sorted(
+        meta.get("releases", {}).items(),
+        key=lambda item: _version_sort_key(item[0]),
+        reverse=True,
+    )
+    for _ver, files in sorted_releases:
+        candidates = [f for f in files if not _is_yanked(f) and _requires_python_ok(f)]
+        # 3. Pure wheel in older release.
+        for file_info in candidates:
+            if _is_pure_wheel(file_info):
+                return file_info
+        # 4. Compiled wheel in older release.
+        for file_info in candidates:
+            if _is_compatible_wheel(file_info):
+                return file_info
+    raise PyPIInstallError(
+        _("No compatible wheel found for '%s' on this platform.") % package
+    )
+
+
+def _is_pure_wheel(file_info: dict) -> bool:
+    """Return True if *file_info* describes a pure-Python wheel."""
+    filename = file_info.get("filename", "")
+    if not filename.endswith(".whl"):
+        return False
+    # Wheel filename: {name}-{ver}(-{build})?-{pyver}-{abi}-{plat}.whl
+    parts = filename[:-4].split("-")
+    if len(parts) < 5:
+        return False
+    tag = "-".join(parts[-3:])
+    return tag in _PURE_TAGS
+
+
+def _verify_sha256(data: bytes, expected: str, filename: str) -> None:
+    """Raise PyPIInstallError if the SHA-256 of *data* does not match."""
+    actual = hashlib.sha256(data).hexdigest()
+    if actual != expected:
+        raise PyPIInstallError(
+            _("SHA-256 mismatch for '%s': expected %s, got %s")
+            % (filename, expected, actual)
+        )
+
+
+def _wheel_metadata(whl_zip: zipfile.ZipFile) -> dict[str, str]:
+    """
+    Parse the METADATA file from a wheel zip and return a dict of headers.
+
+    Multi-value headers (e.g. Requires-Dist) are returned as
+    newline-joined strings; callers should split on ``\\n``.
+    """
+    metadata_path = next(
+        (n for n in whl_zip.namelist() if n.endswith("/METADATA")), None
+    )
+    if metadata_path is None:
+        return {}
+    raw = whl_zip.read(metadata_path).decode("utf-8", errors="replace")
+    parser = email.parser.HeaderParser()
+    msg = parser.parsestr(raw)
+    result: dict[str, str] = {}
+    for key in set(msg.keys()):
+        values = msg.get_all(key, [])
+        result[key.lower()] = "\n".join(values)
+    return result
+
+
+def _top_level_names(whl_zip: zipfile.ZipFile) -> list[str]:
+    """
+    Return the top-level importable package names listed in ``top_level.txt``.
+
+    Reads the ``*.dist-info/top_level.txt`` entry from a wheel zip if present.
+    Returns an empty list when the file is absent (common for modern wheels that
+    match their PyPI name exactly).
+    """
+    path = next((n for n in whl_zip.namelist() if n.endswith("/top_level.txt")), None)
+    if path is None:
+        return []
+    return [
+        line.strip()
+        for line in whl_zip.read(path).decode("utf-8", errors="replace").splitlines()
+        if line.strip()
+    ]
+
+
+# -------------------------------------------------------------------------
+#
+# PEP 508 environment marker evaluation
+#
+# -------------------------------------------------------------------------
+
+
+def _marker_env_vars() -> dict[str, str]:
+    """Return the PEP 508 marker environment for the current interpreter."""
+    return {
+        "os_name": os.name,
+        "sys_platform": sys.platform,
+        "platform_machine": platform.machine(),
+        "platform_python_implementation": platform.python_implementation(),
+        "platform_release": platform.release(),
+        "platform_system": platform.system(),
+        "platform_version": platform.version(),
+        "python_version": f"{sys.version_info.major}.{sys.version_info.minor}",
+        "python_full_version": (
+            f"{sys.version_info.major}.{sys.version_info.minor}"
+            f".{sys.version_info.micro}"
+        ),
+        "implementation_name": sys.implementation.name,
+        "implementation_version": (
+            f"{sys.version_info.major}.{sys.version_info.minor}"
+            f".{sys.version_info.micro}"
+        ),
+        "extra": "",
+    }
+
+
+def _tokenize_marker(s: str) -> list[str]:
+    """
+    Tokenize a PEP 508 marker string into a flat list of string tokens.
+
+    Produces quoted string literals (with quotes retained), two-character
+    operators (``>=``, ``<=``, ``==``, ``!=``, ``~=``), single-character
+    operators (``<``, ``>``), the merged two-word operator ``"not in"``,
+    parentheses, and identifier tokens (marker variable names and the
+    keywords ``and``, ``or``, ``not``, ``in``).
+    """
+    tokens: list[str] = []
+    i = 0
+    while i < len(s):
+        ch = s[i]
+        if ch.isspace():
+            i += 1
+            continue
+        if ch in "()":
+            tokens.append(ch)
+            i += 1
+            continue
+        if ch in ('"', "'"):
+            j = i + 1
+            while j < len(s) and s[j] != ch:
+                j += 1
+            tokens.append(s[i : j + 1])
+            i = j + 1
+            continue
+        if i + 1 < len(s) and s[i : i + 2] in (">=", "<=", "==", "!=", "~="):
+            tokens.append(s[i : i + 2])
+            i += 2
+            continue
+        if ch in "<>":
+            tokens.append(ch)
+            i += 1
+            continue
+        if ch.isalpha() or ch == "_":
+            j = i
+            while j < len(s) and (s[j].isalnum() or s[j] in "_-."):
+                j += 1
+            tokens.append(s[i:j])
+            i = j
+            continue
+        i += 1
+    # Merge a bare "not" immediately followed by "in" into the "not in" operator.
+    out: list[str] = []
+    k = 0
+    while k < len(tokens):
+        if tokens[k] == "not" and k + 1 < len(tokens) and tokens[k + 1] == "in":
+            out.append("not in")
+            k += 2
+        else:
+            out.append(tokens[k])
+            k += 1
+    return out
+
+
+def _marker_cmp(lhs: str, op: str, rhs: str, use_version: bool) -> bool:
+    """
+    Compare *lhs* and *rhs* using *op* under PEP 508 marker semantics.
+
+    When *use_version* is True the strings are parsed as dotted version
+    numbers (via ``_version_sort_key``) and compared as tuples of ints;
+    otherwise plain string comparison is used.
+    """
+    if use_version:
+        lv: tuple[int, ...] = _version_sort_key(lhs)
+        rv: tuple[int, ...] = _version_sort_key(rhs)
+        if op == "==":
+            return lv == rv
+        if op == "!=":
+            return lv != rv
+        if op == ">=":
+            return lv >= rv
+        if op == "<=":
+            return lv <= rv
+        if op == ">":
+            return lv > rv
+        if op == "<":
+            return lv < rv
+        if op == "~=":
+            if lv < rv:
+                return False
+            if len(rv) >= 2:
+                upper = rv[:-1] + (rv[-2] + 1,)
+                return lv < upper
+            return True
+        return False
+    if op == "==":
+        return lhs == rhs
+    if op == "!=":
+        return lhs != rhs
+    if op == ">=":
+        return lhs >= rhs
+    if op == "<=":
+        return lhs <= rhs
+    if op == ">":
+        return lhs > rhs
+    if op == "<":
+        return lhs < rhs
+    if op == "in":
+        return lhs in rhs
+    if op == "not in":
+        return lhs not in rhs
+    return False
+
+
+def _parse_marker_or(
+    tokens: list[str], pos: int, env: dict[str, str]
+) -> tuple[bool, int]:
+    """Parse and evaluate an OR expression from *tokens* starting at *pos*."""
+    left, pos = _parse_marker_and(tokens, pos, env)
+    while pos < len(tokens) and tokens[pos] == "or":
+        pos += 1
+        right, pos = _parse_marker_and(tokens, pos, env)
+        left = left or right
+    return left, pos
+
+
+def _parse_marker_and(
+    tokens: list[str], pos: int, env: dict[str, str]
+) -> tuple[bool, int]:
+    """Parse and evaluate an AND expression from *tokens* starting at *pos*."""
+    left, pos = _parse_marker_not(tokens, pos, env)
+    while pos < len(tokens) and tokens[pos] == "and":
+        pos += 1
+        right, pos = _parse_marker_not(tokens, pos, env)
+        left = left and right
+    return left, pos
+
+
+def _parse_marker_not(
+    tokens: list[str], pos: int, env: dict[str, str]
+) -> tuple[bool, int]:
+    """Parse and evaluate a NOT expression or atom from *tokens* at *pos*."""
+    if pos < len(tokens) and tokens[pos] == "not":
+        pos += 1
+        val, pos = _parse_marker_atom(tokens, pos, env)
+        return not val, pos
+    return _parse_marker_atom(tokens, pos, env)
+
+
+def _parse_marker_atom(
+    tokens: list[str], pos: int, env: dict[str, str]
+) -> tuple[bool, int]:
+    """
+    Parse and evaluate an atomic marker expression starting at *pos*.
+
+    An atom is either a parenthesised sub-expression or a comparison of
+    the form ``marker_var OP marker_var``.
+    """
+    if pos < len(tokens) and tokens[pos] == "(":
+        pos += 1
+        val, pos = _parse_marker_or(tokens, pos, env)
+        if pos < len(tokens) and tokens[pos] == ")":
+            pos += 1
+        return val, pos
+
+    lhs_tok = tokens[pos]
+    pos += 1
+    op = tokens[pos]
+    pos += 1
+    rhs_tok = tokens[pos]
+    pos += 1
+
+    def resolve(tok: str) -> str:
+        """Return the string value of a token — quoted literal or env variable."""
+        if tok and tok[0] in ('"', "'"):
+            return tok[1:-1]
+        return env.get(tok, "")
+
+    lhs_val = resolve(lhs_tok)
+    rhs_val = resolve(rhs_tok)
+
+    lhs_is_var = not (lhs_tok and lhs_tok[0] in ('"', "'"))
+    rhs_is_var = not (rhs_tok and rhs_tok[0] in ('"', "'"))
+    var_name = lhs_tok if lhs_is_var else (rhs_tok if rhs_is_var else "")
+    use_version = var_name in _VERSION_VARS
+
+    return _marker_cmp(lhs_val, op, rhs_val, use_version), pos
+
+
+def _eval_marker(marker_str: str, extras: frozenset[str] = frozenset()) -> bool:
+    """
+    Evaluate a PEP 508 environment marker against the current environment.
+
+    Returns True when the dep should be included.  *extras* is the set of
+    extras being requested on the parent package; a marker of the form
+    ``extra == "foo"`` is True only when ``"foo"`` is in *extras*.
+
+    Returns True on any parse error so unrecognised markers never silently
+    drop dependencies.
+    """
+    if not marker_str:
+        return True
+    env_base = _marker_env_vars()
+    # Evaluate once per requested extra; include the dep if any eval is True.
+    # When no extras are requested use a single iteration with extra="".
+    eval_set: frozenset[str] = extras if extras else frozenset({"__none__"})
+    for extra_val in eval_set:
+        env = dict(env_base)
+        env["extra"] = "" if extra_val == "__none__" else extra_val
+        try:
+            toks = _tokenize_marker(marker_str)
+            result, pos = _parse_marker_or(toks, 0, env)
+            if pos != len(toks):
+                # Tokens left over — marker was not fully parsed.
+                return True
+            if result:
+                return True
+        except Exception:
+            return True  # parse error → include dep to be safe
+    return False
+
+
+def _direct_dependencies(
+    wheel_meta: dict[str, str],
+    extras: frozenset[str] = frozenset(),
+) -> list[tuple[str, str, frozenset[str]]]:
+    """
+    Return ``(name, version_spec, dep_extras)`` for each applicable dependency.
+
+    Environment markers (``sys_platform``, ``python_version``, etc.) are
+    evaluated against the current interpreter.  *extras* is the set of
+    extras requested on the parent package; deps with ``extra == "foo"``
+    markers are included only when ``"foo"`` is in *extras*.
+
+    *dep_extras* carries any extras declared on the dependency itself
+    (e.g. ``requests[security]>=2.0`` yields
+    ``dep_extras=frozenset({"security"})``).  *version_spec* is the raw
+    PEP 440 constraint string (e.g. ``">=2.0,<3"``), or an empty string
+    when no constraint is declared.
+    """
+    raw = wheel_meta.get("requires-dist", "")
+    deps: list[tuple[str, str, frozenset[str]]] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        m = _REQ_RE.match(line)
+        if not m:
+            continue
+        name = m.group("name")
+        extras_str = m.group("extras") or ""
+        spec = (m.group("spec") or "").strip()
+        marker = (m.group("marker") or "").strip()
+        dep_extras = frozenset(e.strip() for e in extras_str.split(",") if e.strip())
+        if marker and not _eval_marker(marker, extras):
+            continue
+        if name:
+            deps.append((name, spec, dep_extras))
+    return deps
+
+
+def _gather_requirements(
+    package: str,
+    extras: frozenset[str],
+    specs: dict[str, list[str]],
+    seen: set[str],
+) -> None:
+    """
+    Recursively collect version constraints for *package* and its transitive deps.
+
+    Reads ``meta["info"]["requires_dist"]`` from the PyPI JSON API without
+    downloading any wheel.  *specs* is mutated in-place: for each dependency
+    that carries a version constraint, its canonical name is mapped to the
+    accumulated list of constraint strings from all paths through the dep graph.
+
+    Packages without any version constraint are not added to *specs*; the
+    install pass will use the latest compatible wheel for those.
+
+    :param package: Top-level package name to start from.
+    :param extras: Extras active on *package*; gates ``extra == "..."`` markers.
+    :param specs: Accumulated ``{canonical_name: [spec, ...]}`` mapping.
+    :param seen: Canonical names already visited (prevents infinite loops).
+    """
+    canonical = package.lower().replace("-", "_")
+    if canonical in seen:
+        return
+    seen.add(canonical)
+    # If already importable, skip: the install pass will also skip it, so its
+    # transitive constraints do not affect the resolution outcome.
+    try:
+        importlib.import_module(canonical)
+        return
+    except ImportError:
+        pass
+    try:
+        meta = _pypi_metadata(package)
+    except PyPIInstallError:
+        return  # unreachable now; the install pass will surface the error
+    for req_str in meta.get("info", {}).get("requires_dist") or []:
+        m = _REQ_RE.match(req_str)
+        if not m:
+            continue
+        name = m.group("name")
+        if not name:
+            continue
+        spec = (m.group("spec") or "").strip()
+        marker = (m.group("marker") or "").strip()
+        dep_extras = frozenset(
+            e.strip() for e in (m.group("extras") or "").split(",") if e.strip()
+        )
+        if marker and not _eval_marker(marker, extras):
+            continue
+        dep_canonical = name.lower().replace("-", "_")
+        if spec:
+            specs.setdefault(dep_canonical, []).append(spec)
+        _gather_requirements(name, dep_extras, specs, seen)
+
+
+def _find_satisfying_version(package: str, combined_spec: str) -> str | None:
+    """
+    Return the newest stable, non-yanked version of *package* satisfying
+    *combined_spec*.
+
+    Scans the ``releases`` dict in the PyPI JSON metadata newest-first,
+    skipping pre-release versions (``aN``, ``bN``, ``rcN``, ``.devN``) and
+    fully-yanked releases (all files for the version are yanked).  Returns
+    ``None`` when no version satisfies the constraint or when PyPI is
+    unreachable.
+
+    :param package: PyPI package name to look up.
+    :param combined_spec: Comma-joined PEP 440 constraints, e.g.
+        ``">=1.0,<2.0"``.  An empty string matches any version.
+    :returns: The newest satisfying version string, or ``None``.
+    """
+    try:
+        meta = _pypi_metadata(package)
+    except PyPIInstallError:
+        return None
+    releases = meta.get("releases", {})
+    for ver in sorted(releases, key=_version_sort_key, reverse=True):
+        if _is_prerelease(ver):
+            continue
+        files = releases[ver]
+        if files and all(_is_yanked(f) for f in files):
+            continue
+        if _satisfies_spec(ver, combined_spec):
+            return ver
+    return None
+
+
+def _satisfies_spec(installed_ver: str, spec: str) -> bool:
+    """Return True if *installed_ver* satisfies every constraint in *spec*.
+
+    Parses comma-separated PEP 440 operators (``>=``, ``<=``, ``==``,
+    ``!=``, ``~=``, ``>``, ``<``).  Wildcard ``==X.Y.*`` / ``!=X.Y.*``
+    forms are supported.  Version comparison uses ``_version_sort_key``;
+    pre-release suffixes sort as zero, which is not fully PEP 440 compliant
+    but sufficient for Gramps addon dependencies.
+    """
+    installed = _version_sort_key(installed_ver)
+    for raw in re.split(r",\s*", spec.strip()):
+        raw = raw.strip()
+        if not raw:
+            continue
+        m = re.match(r"^(~=|>=|<=|!=|==|>|<)\s*(.+)$", raw)
+        if not m:
+            continue
+        op, req_str = m.group(1), m.group(2).strip()
+        required = _version_sort_key(req_str.rstrip(".*"))
+        if op == ">=":
+            if installed < required:
+                return False
+        elif op == "<=":
+            if installed > required:
+                return False
+        elif op == ">":
+            if installed <= required:
+                return False
+        elif op == "<":
+            if installed >= required:
+                return False
+        elif op == "==":
+            if req_str.endswith(".*"):
+                n = len(required)
+                if installed[:n] != required:
+                    return False
+            elif installed != required:
+                return False
+        elif op == "!=":
+            if req_str.endswith(".*"):
+                n = len(required)
+                if installed[:n] == required:
+                    return False
+            elif installed == required:
+                return False
+        elif op == "~=":
+            # ~=X.Y  means  >=X.Y and <(X+1)
+            # ~=X.Y.Z means  >=X.Y.Z and <X.(Y+1)
+            if installed < required:
+                return False
+            parts = list(required)
+            if len(parts) >= 2:
+                upper = tuple(parts[:-2] + [parts[-2] + 1])
+                if installed >= upper:
+                    return False
+    return True
+
+
+def _version_satisfies(canonical: str, spec: str) -> bool:
+    """Return True if the installed version of *canonical* satisfies *spec*.
+
+    Uses ``importlib.metadata`` to look up the installed distribution version.
+    Tries both the canonical name (underscores) and the hyphenated form.
+    Returns True when no dist-info is found (package importable but
+    unregistered, e.g. a sys.path source install) to avoid spurious
+    reinstalls.
+    """
+    if not spec:
+        return True
+    for name in (canonical, canonical.replace("_", "-")):
+        try:
+            installed_ver = importlib.metadata.version(name)
+            return _satisfies_spec(installed_ver, spec)
+        except importlib.metadata.PackageNotFoundError:
+            continue
+    # No dist-info — assume the constraint is satisfied.
+    return True
+
+
+# -------------------------------------------------------------------------
+#
+# Name resolution
+#
+# -------------------------------------------------------------------------
+def resolve_pypi_name(import_name: str) -> str:
+    """Return the PyPI distribution name for *import_name*.
+
+    Addon ``requires_mod`` entries use Python import names (e.g. ``"PIL"``),
+    but ``install_package()`` and pip need the PyPI distribution name (e.g.
+    ``"Pillow"``).  This function translates known mismatches via
+    ``_IMPORT_TO_PYPI``; names not in the table are returned unchanged.
+
+    :param import_name: The Python import name as declared in ``requires_mod``.
+    :returns: The corresponding PyPI distribution name.
+    """
+    pypi_name = _IMPORT_TO_PYPI.get(import_name, import_name)
+    if pypi_name != import_name:
+        LOG.warning(
+            "requires_mod value %r is a Python import name, not a PyPI package "
+            "name.  Please update the addon to use %r instead.  "
+            "The correct name has been applied automatically this time.",
+            import_name,
+            pypi_name,
+        )
+    return pypi_name
+
+
+# -------------------------------------------------------------------------
+#
+# Environment probes
+#
+# -------------------------------------------------------------------------
+@functools.cache
+def _pip_available() -> bool:
+    """Return True if sys.executable can invoke pip as a module.
+
+    Runs ``sys.executable -m pip --version`` once and caches the result.
+    Returns False on Flatpak, stripped Docker images, and any environment
+    where pip has been removed from the Python installation.
+    """
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "--version"],
+            capture_output=True,
+            timeout=10,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+# -------------------------------------------------------------------------
+#
+# Public API
+#
+# -------------------------------------------------------------------------
+def install_package(
+    package: str, target: str, extras: frozenset[str] = frozenset()
+) -> list[str]:
+    """
+    Download and install *package* from PyPI into *target*.
+
+    Performs a three-pass install:
+
+    1. **Gather**: traverse the full dependency graph using PyPI JSON metadata
+       to collect all version constraints without downloading any wheels.
+    2. **Resolve**: for each constrained package, find the newest version that
+       satisfies all accumulated constraints simultaneously.  Raises
+       ``PyPIInstallError`` if no such version exists.
+    3. **Install**: download and extract wheels in dependency order, using the
+       resolved versions from pass 2.
+
+    Extras embedded in *package* (e.g. ``"requests[security]"``) are parsed
+    and merged with *extras*.  Returns a list of package names that were
+    installed.
+
+    :param package: PyPI package name, optionally with extras, e.g.
+        ``"requests[security]"``.
+    :param target: Filesystem path to install into (e.g. ``LIB_PATH``).
+    :param extras: Set of extras to activate on *package*.
+    :returns: List of package names that were installed.
+    :raises PyPIInstallError: if the package or a dependency cannot be
+        installed, or if no version satisfies the combined constraints.
+    """
+    # Parse extras embedded in the package name, e.g. "requests[security,crypto]".
+    em = re.match(r"^([^\[]+)\[([^\]]+)\]$", package.strip())
+    if em:
+        package = em.group(1).strip()
+        parsed = frozenset(e.strip() for e in em.group(2).split(",") if e.strip())
+        extras = extras | parsed
+
+    # Pass 1: gather all transitive version constraints from PyPI JSON metadata.
+    specs: dict[str, list[str]] = {}
+    _gather_requirements(package, extras, specs, set())
+
+    # Pass 2: resolve a satisfying version for each constrained package.
+    resolved: dict[str, str] = {}
+    for pkg_canonical, spec_list in specs.items():
+        combined = ",".join(spec_list)
+        version = _find_satisfying_version(pkg_canonical, combined)
+        if version is None:
+            raise PyPIInstallError(
+                _("No version of '%s' satisfies all constraints: %s")
+                % (pkg_canonical, combined)
+            )
+        resolved[pkg_canonical] = version
+
+    # Pass 3: install with pinned versions from the resolver.
+    installed: list[str] = []
+    _install_one(package, target, installed, set(), extras=extras, resolved=resolved)
+    return installed
+
+
+def _install_one(
+    package: str,
+    target: str,
+    installed: list[str],
+    seen: set[str],
+    version_spec: str = "",
+    extras: frozenset[str] = frozenset(),
+    resolved: dict[str, str] | None = None,
+) -> None:
+    """
+    Recursively install *package* and its applicable dependencies.
+
+    *seen* prevents infinite loops in the case of circular deps.
+    *version_spec* is a PEP 440 constraint string (e.g. ``">=2.0,<3"``)
+    used to decide whether an already-importable package satisfies the
+    requirement; an empty string means any version is accepted.
+    *extras* is the set of extras requested on *package*; deps with
+    matching ``extra ==`` markers are included.
+    *resolved* maps canonical package names to the pre-resolved version
+    string from the gather/resolve passes; when ``None`` the latest
+    compatible wheel is selected.
+    """
+    canonical = package.lower().replace("-", "_")
+    if canonical in seen:
+        return
+    seen.add(canonical)
+
+    resolved_ver: str | None = resolved.get(canonical) if resolved is not None else None
+
+    # Skip if already importable and the installed version satisfies the spec.
+    try:
+        importlib.import_module(canonical)
+        if _version_satisfies(canonical, version_spec):
+            LOG.debug(
+                "'%s' is already importable and satisfies %r, skipping.",
+                canonical,
+                version_spec or "any",
+            )
+            return
+        LOG.info(
+            "'%s' importable but does not satisfy %r; reinstalling.",
+            canonical,
+            version_spec,
+        )
+    except ImportError:
+        pass
+
+    LOG.info("Installing '%s' from PyPI into %s", package, target)
+    meta = _pypi_metadata(package)
+    file_info = _pick_wheel(meta, package, version=resolved_ver)
+
+    url = file_info["url"]
+    filename = file_info["filename"]
+    expected_sha256 = file_info.get("digests", {}).get("sha256", "")
+
+    LOG.debug("Downloading %s", url)
+    try:
+        data = _fetch_url(url)
+    except Exception as exc:
+        raise PyPIInstallError(
+            _("Failed to download '%s': %s") % (filename, exc) + _ssl_cert_hint(exc)
+        ) from exc
+
+    if expected_sha256:
+        _verify_sha256(data, expected_sha256, filename)
+
+    with zipfile.ZipFile(io.BytesIO(data)) as whl:
+        # Some packages have a PyPI name that differs from their importable
+        # name (e.g. "Pillow" imports as "PIL").  top_level.txt lists the
+        # actual importable names; if any are already present, skip extraction.
+        for top_name in _top_level_names(whl):
+            try:
+                importlib.import_module(top_name)
+                LOG.debug(
+                    "'%s' already importable as '%s', skipping.", package, top_name
+                )
+                return
+            except ImportError:
+                pass
+        wheel_meta = _wheel_metadata(whl)
+        whl.extractall(target)
+
+    installed.append(package)
+    LOG.info("Installed '%s'.", package)
+
+    # Install applicable direct dependencies (platform-conditional and extras-aware)
+    for dep_name, dep_spec, dep_extras in _direct_dependencies(wheel_meta, extras):
+        _install_one(dep_name, target, installed, seen, dep_spec, dep_extras, resolved)

--- a/gramps/gen/utils/requirements.py
+++ b/gramps/gen/utils/requirements.py
@@ -22,6 +22,7 @@
 # Python modules
 #
 # -------------------------------------------------------------------------
+from importlib import import_module
 from importlib.util import find_spec
 
 # -------------------------------------------------------------------------
@@ -47,17 +48,26 @@ class Requirements:
         self.gi_list = []
         self.exe_list = []
 
-    def check_mod(self, module):
+    def check_mod(self, module: str) -> bool:
         """
-        Check to see if a given module is available.
+        Check to see if a given module is available and importable.
+
+        Uses find_spec first (fast path), then actually imports the module to
+        catch compiled extensions whose native libraries are missing — a common
+        failure mode in bundled apps where the installer can place the .so/.pyd
+        file on sys.path but the dynamic linker cannot resolve its dependencies
+        at load time.
         """
         if module in self.mod_list:
             return True
-        if find_spec(module) is not None:
-            self.mod_list.append(module)
-            return True
-        else:
+        if find_spec(module) is None:
             return False
+        try:
+            import_module(module)
+        except ImportError:
+            return False
+        self.mod_list.append(module)
+        return True
 
     def check_gi(self, module_spec):
         """

--- a/gramps/gen/utils/test/pypi_e2e_test.py
+++ b/gramps/gen/utils/test/pypi_e2e_test.py
@@ -1,0 +1,272 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+End-to-end tests for gramps.gen.utils.pypi that hit the real PyPI network.
+
+These tests are skipped automatically when pypi.org is not reachable, so
+they are safe to run in CI but will be no-ops in offline environments.
+
+Run explicitly with:
+    python3 -m unittest gramps.gen.utils.test.pypi_e2e_test -v
+"""
+
+# -------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import hashlib
+import importlib
+import io
+import json
+import os
+import shutil
+import socket
+import sys
+import tempfile
+import unittest
+import zipfile
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from ..pypi import (
+    PyPIInstallError,
+    _fetch_url,
+    _is_pure_wheel,
+    _pick_wheel,
+    _pypi_metadata,
+    install_package,
+)
+
+
+def _network_available() -> bool:
+    """Return True if pypi.org is reachable on port 443."""
+    try:
+        socket.create_connection(("pypi.org", 443), timeout=5)
+        return True
+    except OSError:
+        return False
+
+
+NETWORK_AVAILABLE = _network_available()
+_skip_offline = unittest.skipUnless(
+    NETWORK_AVAILABLE, "requires network access to pypi.org"
+)
+
+# A small, stable, pure-Python package with no runtime dependencies.
+# iniconfig is used by pytest and changes very rarely.
+_NODEP_PACKAGE = "iniconfig"
+
+# A small pure-Python package that is unlikely to be pre-installed in
+# the test environment, used to exercise the actual download path.
+_DOWNLOAD_PACKAGE = "tomli"
+
+
+# -------------------------------------------------------------------------
+#
+# TestSSLAndMetadata
+#
+# -------------------------------------------------------------------------
+class TestSSLAndMetadata(unittest.TestCase):
+    """Verify that SSL and PyPI metadata fetching work without certifi."""
+
+    @_skip_offline
+    def test_ssl_reaches_pypi(self):
+        """ssl.create_default_context() fetches data from pypi.org successfully."""
+        data = _fetch_url(f"https://pypi.org/pypi/{_NODEP_PACKAGE}/json")
+        self.assertGreater(len(data), 100)
+
+    @_skip_offline
+    def test_ssl_response_is_valid_json(self):
+        """The PyPI metadata endpoint returns parseable JSON."""
+        data = _fetch_url(f"https://pypi.org/pypi/{_NODEP_PACKAGE}/json")
+        meta = json.loads(data)
+        self.assertIn("info", meta)
+        self.assertIn("urls", meta)
+
+    @_skip_offline
+    def test_pypi_metadata_returns_package_info(self):
+        """_pypi_metadata() returns the expected package name."""
+        meta = _pypi_metadata(_NODEP_PACKAGE)
+        self.assertEqual(meta["info"]["name"].lower(), _NODEP_PACKAGE)
+
+    @_skip_offline
+    def test_pypi_metadata_unknown_package_raises(self):
+        """_pypi_metadata() raises PyPIInstallError for a non-existent package."""
+        with self.assertRaises(PyPIInstallError):
+            _pypi_metadata("this-package-does-not-exist-xyzzy-42")
+
+
+# -------------------------------------------------------------------------
+#
+# TestPickWheelE2E
+#
+# -------------------------------------------------------------------------
+class TestPickWheelE2E(unittest.TestCase):
+    """Verify wheel selection against real PyPI metadata."""
+
+    @_skip_offline
+    def test_iniconfig_has_pure_wheel(self):
+        """iniconfig has a py3-none-any wheel on PyPI."""
+        meta = _pypi_metadata(_NODEP_PACKAGE)
+        wheel = _pick_wheel(meta, _NODEP_PACKAGE)
+        self.assertIn("py3-none-any", wheel["filename"])
+
+    @_skip_offline
+    def test_picked_wheel_has_sha256(self):
+        """The selected wheel entry carries a SHA-256 digest."""
+        meta = _pypi_metadata(_NODEP_PACKAGE)
+        wheel = _pick_wheel(meta, _NODEP_PACKAGE)
+        sha256 = wheel.get("digests", {}).get("sha256", "")
+        self.assertEqual(len(sha256), 64)
+
+    @_skip_offline
+    def test_numpy_has_no_pure_wheel(self):
+        """numpy only ships compiled wheels; no pure-Python wheel exists on PyPI.
+
+        We verify the absence of pure wheels directly from the metadata rather
+        than calling _pick_wheel, because on a compatible platform (e.g. Linux
+        x86_64 with glibc) _pick_wheel would successfully return a compiled
+        wheel instead of raising.
+        """
+        meta = _pypi_metadata("numpy")
+        all_files: list[dict] = list(meta.get("urls", []))
+        for files in meta.get("releases", {}).values():
+            all_files.extend(files)
+        pure_wheels = [f for f in all_files if _is_pure_wheel(f)]
+        self.assertEqual(pure_wheels, [], "Expected no pure-Python wheels for numpy")
+
+
+# -------------------------------------------------------------------------
+#
+# TestDownloadExtractE2E
+#
+# -------------------------------------------------------------------------
+class TestDownloadExtractE2E(unittest.TestCase):
+    """
+    End-to-end tests of the download → verify → extract pipeline.
+
+    These tests call the internal helpers directly, bypassing
+    install_package()'s importability guard.  That guard is correct
+    behaviour (skip packages already on sys.path) but irrelevant here:
+    we want to verify the network and extraction code work regardless
+    of what is already installed in the environment.
+
+    The wheel is fetched once in setUpClass and reused across tests to
+    avoid redundant network round-trips.
+    """
+
+    _wheel_data: bytes = b""
+    _wheel_info: dict = {}
+
+    @classmethod
+    def setUpClass(cls):
+        """Download the test wheel once for all tests in this class."""
+        if not NETWORK_AVAILABLE:
+            return
+        meta = _pypi_metadata(_DOWNLOAD_PACKAGE)
+        cls._wheel_info = _pick_wheel(meta, _DOWNLOAD_PACKAGE)
+        cls._wheel_data = _fetch_url(cls._wheel_info["url"])
+
+    def setUp(self):
+        self.target = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.target, ignore_errors=True)
+        for mod in list(sys.modules):
+            if mod == _DOWNLOAD_PACKAGE or mod.startswith(_DOWNLOAD_PACKAGE + "."):
+                del sys.modules[mod]
+        if self.target in sys.path:
+            sys.path.remove(self.target)
+
+    def _extract(self):
+        """Extract the pre-downloaded wheel into self.target."""
+        with zipfile.ZipFile(io.BytesIO(self._wheel_data)) as whl:
+            whl.extractall(self.target)
+
+    @_skip_offline
+    def test_sha256_matches_pypi_digest(self):
+        """The downloaded wheel's SHA-256 matches the digest published on PyPI."""
+        expected = self._wheel_info["digests"]["sha256"]
+        actual = hashlib.sha256(self._wheel_data).hexdigest()
+        self.assertEqual(actual, expected)
+
+    @_skip_offline
+    def test_wheel_extracts_package_files(self):
+        """Extracted wheel contains the package directory in target."""
+        self._extract()
+        entries = os.listdir(self.target)
+        self.assertTrue(
+            any(_DOWNLOAD_PACKAGE in e for e in entries),
+            f"Expected '{_DOWNLOAD_PACKAGE}' among {entries}",
+        )
+
+    @_skip_offline
+    def test_wheel_extracts_dist_info(self):
+        """Extracted wheel contains a .dist-info directory in target."""
+        self._extract()
+        dist_infos = [e for e in os.listdir(self.target) if ".dist-info" in e]
+        self.assertTrue(
+            dist_infos,
+            f"No .dist-info directory found among: {os.listdir(self.target)}",
+        )
+
+    @_skip_offline
+    def test_extracted_package_is_importable(self):
+        """Package extracted to target is importable once target is on sys.path."""
+        self._extract()
+        sys.path.insert(0, self.target)
+        # Force import from target even if the package is already on sys.path
+        sys.modules.pop(_DOWNLOAD_PACKAGE, None)
+        mod = importlib.import_module(_DOWNLOAD_PACKAGE)
+        self.assertIsNotNone(mod)
+
+
+# -------------------------------------------------------------------------
+#
+# TestInstallPackageBehaviourE2E
+#
+# -------------------------------------------------------------------------
+class TestInstallPackageBehaviourE2E(unittest.TestCase):
+    """Tests of install_package() orchestration behaviour against real PyPI."""
+
+    def setUp(self):
+        self.target = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.target, ignore_errors=True)
+        if self.target in sys.path:
+            sys.path.remove(self.target)
+
+    @_skip_offline
+    def test_already_importable_skipped(self):
+        """install_package() skips a package that is already importable."""
+        # "os" is always importable; nothing should be downloaded or extracted.
+        installed = install_package("os", self.target)
+        self.assertEqual(installed, [])
+        self.assertEqual(os.listdir(self.target), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gen/utils/test/pypi_test.py
+++ b/gramps/gen/utils/test/pypi_test.py
@@ -1,0 +1,2251 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Tests for gramps.gen.utils.pypi."""
+
+# -------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import hashlib
+import io
+import os
+import sys
+import tempfile
+import unittest
+import zipfile
+from unittest.mock import MagicMock, patch
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from ..pypi import (
+    PyPIInstallError,
+    _IMPORT_TO_PYPI,
+    _compatible_tags,
+    _direct_dependencies,
+    _eval_marker,
+    _find_satisfying_version,
+    _gather_requirements,
+    _glibc_version,
+    _is_compatible_wheel,
+    _is_prerelease,
+    _is_pure_wheel,
+    _is_yanked,
+    _manylinux_platform_tags,
+    _musl_version,
+    _pick_wheel,
+    _requires_python_ok,
+    _satisfies_spec,
+    _tokenize_marker,
+    _top_level_names,
+    _verify_sha256,
+    _version_satisfies,
+    _version_sort_key,
+    _wheel_metadata,
+    install_package,
+    resolve_pypi_name,
+)
+
+
+# -------------------------------------------------------------------------
+#
+# Helpers
+#
+# -------------------------------------------------------------------------
+def _make_wheel_zip(metadata_text: str = "", extra_files: dict | None = None) -> bytes:
+    """
+    Build a minimal in-memory wheel zip with the given METADATA content.
+
+    :param metadata_text: Content for the ``pkg-1.0.dist-info/METADATA`` entry.
+    :param extra_files: Additional ``{name: bytes}`` entries to add.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("pkg-1.0.dist-info/METADATA", metadata_text)
+        for name, data in (extra_files or {}).items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+def _sha256(data: bytes) -> str:
+    """Return the hex SHA-256 digest of *data*."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def _fake_pypi_meta(
+    filename: str, url: str = "https://example.com/pkg.whl", sha256: str = ""
+) -> dict:
+    """Build a minimal PyPI JSON metadata dict with a single file entry."""
+    return {
+        "urls": [
+            {
+                "filename": filename,
+                "url": url,
+                "packagetype": "bdist_wheel",
+                "digests": {"sha256": sha256},
+            }
+        ],
+        "releases": {},
+    }
+
+
+# -------------------------------------------------------------------------
+#
+# TestIsPureWheel
+#
+# -------------------------------------------------------------------------
+class TestIsPureWheel(unittest.TestCase):
+    def test_py3_none_any_is_pure(self):
+        """py3-none-any wheels are pure Python."""
+        info = {"filename": "mypkg-1.0-py3-none-any.whl"}
+        self.assertTrue(_is_pure_wheel(info))
+
+    def test_py2_py3_none_any_is_pure(self):
+        """py2.py3-none-any wheels are pure Python."""
+        info = {"filename": "mypkg-1.0-py2.py3-none-any.whl"}
+        self.assertTrue(_is_pure_wheel(info))
+
+    def test_platform_wheel_is_not_pure(self):
+        """Platform-specific wheels are not pure Python."""
+        info = {"filename": "mypkg-1.0-cp311-cp311-linux_x86_64.whl"}
+        self.assertFalse(_is_pure_wheel(info))
+
+    def test_abi3_wheel_is_not_pure(self):
+        """abi3 wheels are compiled and not pure Python."""
+        info = {"filename": "mypkg-1.0-cp38-abi3-manylinux1_x86_64.whl"}
+        self.assertFalse(_is_pure_wheel(info))
+
+    def test_tarball_is_not_pure(self):
+        """Source tarballs are not wheels."""
+        info = {"filename": "mypkg-1.0.tar.gz"}
+        self.assertFalse(_is_pure_wheel(info))
+
+    def test_too_few_parts_is_not_pure(self):
+        """Wheel filenames with fewer than 5 dash-separated parts are rejected."""
+        info = {"filename": "mypkg-1.0-py3.whl"}
+        self.assertFalse(_is_pure_wheel(info))
+
+    def test_empty_filename_is_not_pure(self):
+        """An empty filename is not a pure wheel."""
+        self.assertFalse(_is_pure_wheel({"filename": ""}))
+
+
+# -------------------------------------------------------------------------
+#
+# TestResolvePypiName
+#
+# -------------------------------------------------------------------------
+class TestResolvePypiName(unittest.TestCase):
+    def test_pil_maps_to_pillow(self):
+        """PIL (current addon-source import name) maps to Pillow and warns."""
+        with self.assertLogs("gramps.gen.utils.pypi", level="WARNING") as cm:
+            result = resolve_pypi_name("PIL")
+        self.assertEqual(result, "Pillow")
+        self.assertTrue(any("PIL" in msg and "Pillow" in msg for msg in cm.output))
+
+    def test_yaml_maps_to_pyyaml(self):
+        """yaml import name maps to PyYAML."""
+        self.assertEqual(resolve_pypi_name("yaml"), "PyYAML")
+
+    def test_cv2_maps_to_opencv(self):
+        """cv2 import name maps to opencv-python."""
+        self.assertEqual(resolve_pypi_name("cv2"), "opencv-python")
+
+    def test_bs4_maps_to_beautifulsoup4(self):
+        """bs4 import name maps to beautifulsoup4."""
+        self.assertEqual(resolve_pypi_name("bs4"), "beautifulsoup4")
+
+    def test_serial_maps_to_pyserial(self):
+        """serial import name maps to pyserial (not the unrelated 'serial' package)."""
+        self.assertEqual(resolve_pypi_name("serial"), "pyserial")
+
+    def test_sklearn_maps_to_scikit_learn(self):
+        """sklearn stub has no wheels; maps to scikit-learn."""
+        self.assertEqual(resolve_pypi_name("sklearn"), "scikit-learn")
+
+    def test_unknown_name_returned_unchanged_no_warning(self):
+        """A name not in the table is returned as-is and emits no warning."""
+        with self.assertNoLogs("gramps.gen.utils.pypi", level="WARNING"):
+            self.assertEqual(resolve_pypi_name("requests"), "requests")
+            self.assertEqual(resolve_pypi_name("pypdf"), "pypdf")
+            self.assertEqual(resolve_pypi_name("reportlab"), "reportlab")
+
+    def test_all_mapping_values_are_strings(self):
+        """Every entry in _IMPORT_TO_PYPI maps to a non-empty string."""
+        for import_name, pypi_name in _IMPORT_TO_PYPI.items():
+            self.assertIsInstance(pypi_name, str, import_name)
+            self.assertTrue(pypi_name, import_name)
+
+    def test_no_self_mappings(self):
+        """No entry maps a name to itself (that would be a pointless entry)."""
+        for import_name, pypi_name in _IMPORT_TO_PYPI.items():
+            self.assertNotEqual(
+                import_name.lower(),
+                pypi_name.lower(),
+                f"{import_name!r} maps to itself",
+            )
+
+
+# -------------------------------------------------------------------------
+#
+# TestCompatibleTags
+#
+# -------------------------------------------------------------------------
+class TestCompatibleTags(unittest.TestCase):
+    def setUp(self):
+        # Reset the module-level cache before each test.
+        import gramps.gen.utils.pypi as pypi_mod
+
+        pypi_mod._COMPAT_TAGS = None
+
+    def tearDown(self):
+        import gramps.gen.utils.pypi as pypi_mod
+
+        pypi_mod._COMPAT_TAGS = None
+
+    def test_returns_three_non_empty_sets(self):
+        """_compatible_tags returns three non-empty sets."""
+        py_tags, abi_tags, plat_tags = _compatible_tags()
+        self.assertIsInstance(py_tags, set)
+        self.assertIsInstance(abi_tags, set)
+        self.assertIsInstance(plat_tags, set)
+        self.assertTrue(py_tags)
+        self.assertTrue(abi_tags)
+        self.assertTrue(plat_tags)
+
+    def test_current_cpython_tag_in_py_tags(self):
+        """The exact CPython version tag is always present."""
+        import sys
+
+        expected = f"cp{sys.version_info.major}{sys.version_info.minor}"
+        py_tags, _, _ = _compatible_tags()
+        self.assertIn(expected, py_tags)
+
+    def test_py3_in_py_tags(self):
+        """Generic py3 tag is always present."""
+        py_tags, _, _ = _compatible_tags()
+        self.assertIn("py3", py_tags)
+
+    def test_abi3_and_none_in_abi_tags(self):
+        """abi3 and none are always in abi_tags."""
+        _, abi_tags, _ = _compatible_tags()
+        self.assertIn("abi3", abi_tags)
+        self.assertIn("none", abi_tags)
+
+    def test_windows_amd64(self):
+        """win_amd64 platform tag is generated for Windows AMD64."""
+        with patch("platform.system", return_value="Windows"):
+            with patch("platform.machine", return_value="AMD64"):
+                import gramps.gen.utils.pypi as pypi_mod
+
+                pypi_mod._COMPAT_TAGS = None
+                _, _, plat_tags = _compatible_tags()
+        self.assertIn("win_amd64", plat_tags)
+        self.assertNotIn("win32", plat_tags)
+
+    def test_windows_arm64(self):
+        """win_arm64 platform tag is generated for Windows ARM64."""
+        with patch("platform.system", return_value="Windows"):
+            with patch("platform.machine", return_value="ARM64"):
+                import gramps.gen.utils.pypi as pypi_mod
+
+                pypi_mod._COMPAT_TAGS = None
+                _, _, plat_tags = _compatible_tags()
+        self.assertIn("win_arm64", plat_tags)
+
+    def test_macos_arm64_includes_universal2(self):
+        """macOS arm64 platform tags include universal2 variants."""
+        with patch("platform.system", return_value="Darwin"):
+            with patch("platform.machine", return_value="arm64"):
+                with patch(
+                    "platform.mac_ver", return_value=("14.4.0", ("", "", ""), "")
+                ):
+                    import gramps.gen.utils.pypi as pypi_mod
+
+                    pypi_mod._COMPAT_TAGS = None
+                    _, _, plat_tags = _compatible_tags()
+        self.assertIn("macosx_14_4_arm64", plat_tags)
+        self.assertIn("macosx_11_0_arm64", plat_tags)
+        self.assertIn("macosx_14_4_universal2", plat_tags)
+        self.assertNotIn("macosx_14_5_arm64", plat_tags)
+
+    def test_macos_x86_64_includes_older_versions(self):
+        """macOS x86_64 tags span from 10.4 up to the current version."""
+        with patch("platform.system", return_value="Darwin"):
+            with patch("platform.machine", return_value="x86_64"):
+                with patch(
+                    "platform.mac_ver", return_value=("13.0.0", ("", "", ""), "")
+                ):
+                    import gramps.gen.utils.pypi as pypi_mod
+
+                    pypi_mod._COMPAT_TAGS = None
+                    _, _, plat_tags = _compatible_tags()
+        self.assertIn("macosx_10_9_x86_64", plat_tags)
+        self.assertIn("macosx_13_0_x86_64", plat_tags)
+        self.assertNotIn("macosx_13_1_x86_64", plat_tags)
+
+    def test_result_is_cached(self):
+        """Calling _compatible_tags twice returns the same objects."""
+        first = _compatible_tags()
+        second = _compatible_tags()
+        self.assertIs(first, second)
+
+    def test_macos_empty_version_does_not_crash(self):
+        """Empty mac_ver() string does not raise; falls back to pure wheels only."""
+        with patch("platform.system", return_value="Darwin"):
+            with patch("platform.machine", return_value="arm64"):
+                with patch("platform.mac_ver", return_value=("", ("", "", ""), "")):
+                    import gramps.gen.utils.pypi as pypi_mod
+
+                    pypi_mod._COMPAT_TAGS = None
+                    py_tags, abi_tags, plat_tags = _compatible_tags()
+        # Must not raise; "any" must still be present so pure wheels match.
+        self.assertIn("any", plat_tags)
+        # No macosx_* tags should be generated when version is unknown.
+        self.assertFalse(any(t.startswith("macosx_") for t in plat_tags))
+
+    def test_any_always_in_plat_tags(self):
+        """\"any\" is always in platform tags regardless of OS."""
+        for system, machine, extra in [
+            ("Windows", "AMD64", {}),
+            ("Linux", "x86_64", {}),
+            ("Darwin", "arm64", {"mac_ver": ("14.0.0", ("", "", ""), "")}),
+        ]:
+            with patch("platform.system", return_value=system):
+                with patch("platform.machine", return_value=machine):
+                    import gramps.gen.utils.pypi as pypi_mod
+
+                    pypi_mod._COMPAT_TAGS = None
+                    if "mac_ver" in extra:
+                        with patch("platform.mac_ver", return_value=extra["mac_ver"]):
+                            _, _, plat_tags = _compatible_tags()
+                    else:
+                        _, _, plat_tags = _compatible_tags()
+            self.assertIn("any", plat_tags, f"'any' missing for {system}/{machine}")
+
+
+# -------------------------------------------------------------------------
+#
+# TestIsCompatibleWheel
+#
+# -------------------------------------------------------------------------
+class TestIsCompatibleWheel(unittest.TestCase):
+    def setUp(self):
+        import gramps.gen.utils.pypi as pypi_mod
+
+        pypi_mod._COMPAT_TAGS = None
+
+    def tearDown(self):
+        import gramps.gen.utils.pypi as pypi_mod
+
+        pypi_mod._COMPAT_TAGS = None
+
+    def _patch_tags(self, py, abi, plat):
+        return patch(
+            "gramps.gen.utils.pypi._compatible_tags", return_value=(py, abi, plat)
+        )
+
+    def test_matching_compiled_wheel(self):
+        """A wheel whose tags all intersect the compat sets is compatible."""
+        with self._patch_tags({"cp312"}, {"cp312"}, {"win_amd64"}):
+            info = {"filename": "pkg-1.0-cp312-cp312-win_amd64.whl"}
+            self.assertTrue(_is_compatible_wheel(info))
+
+    def test_non_matching_platform(self):
+        """A wheel for a different platform is not compatible."""
+        with self._patch_tags({"cp312"}, {"cp312"}, {"win_amd64"}):
+            info = {"filename": "pkg-1.0-cp312-cp312-linux_x86_64.whl"}
+            self.assertFalse(_is_compatible_wheel(info))
+
+    def test_non_matching_python_version(self):
+        """A wheel for a different CPython minor version is not compatible."""
+        with self._patch_tags({"cp312"}, {"cp312"}, {"win_amd64"}):
+            info = {"filename": "pkg-1.0-cp311-cp311-win_amd64.whl"}
+            self.assertFalse(_is_compatible_wheel(info))
+
+    def test_abi3_wheel(self):
+        """A cp38-abi3 wheel is compatible when abi3 is in abi_tags."""
+        with self._patch_tags({"cp312", "cp38"}, {"abi3", "cp312"}, {"win_amd64"}):
+            info = {"filename": "pkg-1.0-cp38-abi3-win_amd64.whl"}
+            self.assertTrue(_is_compatible_wheel(info))
+
+    def test_multi_tag_platform_any_match(self):
+        """A dot-joined multi-tag platform field matches if any token matches."""
+        with self._patch_tags({"cp312"}, {"cp312"}, {"macosx_11_0_arm64"}):
+            # Filename has three dot-joined platform tags; arm64 one matches.
+            info = {
+                "filename": (
+                    "pkg-1.0-cp312-cp312"
+                    "-macosx_10_12_x86_64.macosx_11_0_arm64"
+                    ".macosx_10_12_universal2.whl"
+                )
+            }
+            self.assertTrue(_is_compatible_wheel(info))
+
+    def test_tarball_not_compatible(self):
+        """Source tarballs are never compatible wheels."""
+        with self._patch_tags({"cp312"}, {"cp312"}, {"win_amd64"}):
+            self.assertFalse(_is_compatible_wheel({"filename": "pkg-1.0.tar.gz"}))
+
+    def test_too_few_parts(self):
+        """Filenames with fewer than five dash-parts are rejected."""
+        with self._patch_tags({"cp312"}, {"cp312"}, {"win_amd64"}):
+            self.assertFalse(_is_compatible_wheel({"filename": "pkg-1.0-cp312.whl"}))
+
+    def test_empty_compat_sets_never_match(self):
+        """Empty compat sets mean nothing is compatible."""
+        with self._patch_tags(set(), set(), set()):
+            info = {"filename": "pkg-1.0-cp312-cp312-win_amd64.whl"}
+            self.assertFalse(_is_compatible_wheel(info))
+
+    def test_pure_any_wheel_is_compatible(self):
+        """py3-none-any wheels are compatible on every platform."""
+        # Use real tags — "any" should always be in plat_tags.
+        import gramps.gen.utils.pypi as pypi_mod
+
+        pypi_mod._COMPAT_TAGS = None
+        info = {"filename": "pkg-1.0-py3-none-any.whl"}
+        self.assertTrue(_is_compatible_wheel(info))
+
+    def test_py2py3_any_wheel_is_compatible(self):
+        """py2.py3-none-any wheels are compatible on every platform."""
+        import gramps.gen.utils.pypi as pypi_mod
+
+        pypi_mod._COMPAT_TAGS = None
+        info = {"filename": "pkg-1.0-py2.py3-none-any.whl"}
+        self.assertTrue(_is_compatible_wheel(info))
+
+
+# -------------------------------------------------------------------------
+#
+# TestVersionSortKey
+#
+# -------------------------------------------------------------------------
+class TestVersionSortKey(unittest.TestCase):
+    def test_simple_versions(self):
+        """Basic dotted versions sort numerically, not lexicographically."""
+        self.assertGreater(_version_sort_key("1.10"), _version_sort_key("1.9"))
+        self.assertGreater(_version_sort_key("2.0"), _version_sort_key("1.99"))
+
+    def test_three_part_version(self):
+        """Three-part versions are ordered correctly."""
+        self.assertGreater(_version_sort_key("1.0.1"), _version_sort_key("1.0.0"))
+
+    def test_equal_versions(self):
+        """Identical version strings produce identical keys."""
+        self.assertEqual(_version_sort_key("1.2.3"), _version_sort_key("1.2.3"))
+
+    def test_empty_string_does_not_crash(self):
+        """An empty version string returns an empty tuple without raising."""
+        self.assertEqual(_version_sort_key(""), ())
+
+    def test_non_numeric_segment_is_zero(self):
+        """Non-numeric segments are treated as zero."""
+        key = _version_sort_key("1.0.dev1")
+        self.assertEqual(key[0], 1)
+        self.assertEqual(key[1], 0)
+
+    def test_sorted_release_list(self):
+        """A list of version strings sorts newest-first when reversed."""
+        versions = ["0.9", "1.0", "1.10", "1.2", "2.0"]
+        result = sorted(versions, key=_version_sort_key, reverse=True)
+        self.assertEqual(result, ["2.0", "1.10", "1.2", "1.0", "0.9"])
+
+
+# -------------------------------------------------------------------------
+#
+# TestTopLevelNames
+#
+# -------------------------------------------------------------------------
+class TestTopLevelNames(unittest.TestCase):
+    def _make_wheel_with_toplevel(self, names: str) -> zipfile.ZipFile:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("pkg-1.0.dist-info/top_level.txt", names)
+        return zipfile.ZipFile(io.BytesIO(buf.getvalue()))
+
+    def _make_wheel_without_toplevel(self) -> zipfile.ZipFile:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("pkg-1.0.dist-info/METADATA", "Name: pkg\n")
+        return zipfile.ZipFile(io.BytesIO(buf.getvalue()))
+
+    def test_single_name(self):
+        """A single entry in top_level.txt is returned."""
+        with self._make_wheel_with_toplevel("PIL\n") as whl:
+            self.assertEqual(_top_level_names(whl), ["PIL"])
+
+    def test_multiple_names(self):
+        """Multiple entries are all returned."""
+        with self._make_wheel_with_toplevel("foo\nbar\nbaz\n") as whl:
+            self.assertEqual(_top_level_names(whl), ["foo", "bar", "baz"])
+
+    def test_blank_lines_ignored(self):
+        """Blank lines in top_level.txt are ignored."""
+        with self._make_wheel_with_toplevel("\nfoo\n\nbar\n") as whl:
+            self.assertEqual(_top_level_names(whl), ["foo", "bar"])
+
+    def test_absent_returns_empty_list(self):
+        """A wheel without top_level.txt returns an empty list."""
+        with self._make_wheel_without_toplevel() as whl:
+            self.assertEqual(_top_level_names(whl), [])
+
+
+# -------------------------------------------------------------------------
+#
+# TestVerifySha256
+#
+# -------------------------------------------------------------------------
+class TestVerifySha256(unittest.TestCase):
+    def test_correct_hash_passes(self):
+        """A correct SHA-256 digest does not raise."""
+        data = b"hello world"
+        _verify_sha256(data, _sha256(data), "test.whl")
+
+    def test_wrong_hash_raises(self):
+        """A mismatched SHA-256 digest raises PyPIInstallError."""
+        with self.assertRaises(PyPIInstallError):
+            _verify_sha256(b"hello world", "deadbeef" * 8, "test.whl")
+
+    def test_empty_data(self):
+        """SHA-256 of empty bytes is verified correctly."""
+        data = b""
+        _verify_sha256(data, _sha256(data), "empty.whl")
+
+
+# -------------------------------------------------------------------------
+#
+# TestWheelMetadata
+#
+# -------------------------------------------------------------------------
+class TestWheelMetadata(unittest.TestCase):
+    def _open(self, data: bytes) -> zipfile.ZipFile:
+        return zipfile.ZipFile(io.BytesIO(data))
+
+    def test_parses_name_and_version(self):
+        """Standard Name and Version headers are parsed."""
+        meta_text = "Name: mypkg\nVersion: 1.2.3\n"
+        with self._open(_make_wheel_zip(meta_text)) as whl:
+            meta = _wheel_metadata(whl)
+        self.assertEqual(meta.get("name"), "mypkg")
+        self.assertEqual(meta.get("version"), "1.2.3")
+
+    def test_parses_requires_dist(self):
+        """Multiple Requires-Dist headers are joined with newlines."""
+        meta_text = "Name: mypkg\nRequires-Dist: requests\nRequires-Dist: click\n"
+        with self._open(_make_wheel_zip(meta_text)) as whl:
+            meta = _wheel_metadata(whl)
+        deps = meta.get("requires-dist", "")
+        self.assertIn("requests", deps)
+        self.assertIn("click", deps)
+
+    def test_missing_metadata_returns_empty(self):
+        """A wheel with no METADATA file returns an empty dict."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("pkg-1.0.dist-info/WHEEL", "Wheel-Version: 1.0\n")
+        with zipfile.ZipFile(io.BytesIO(buf.getvalue())) as whl:
+            meta = _wheel_metadata(whl)
+        self.assertEqual(meta, {})
+
+
+# -------------------------------------------------------------------------
+#
+# TestEvalMarker
+#
+# -------------------------------------------------------------------------
+class TestEvalMarker(unittest.TestCase):
+    def test_empty_marker_returns_true(self):
+        """An empty marker string is always True."""
+        self.assertTrue(_eval_marker(""))
+
+    def test_sys_platform_match(self):
+        """sys_platform matching the current platform returns True."""
+        self.assertTrue(_eval_marker(f'sys_platform == "{sys.platform}"'))
+
+    def test_sys_platform_no_match(self):
+        """sys_platform for a different platform returns False."""
+        other = "win32" if sys.platform != "win32" else "linux"
+        self.assertFalse(_eval_marker(f'sys_platform == "{other}"'))
+
+    def test_sys_platform_not_equal(self):
+        """sys_platform != other_platform returns True."""
+        other = "win32" if sys.platform != "win32" else "linux"
+        self.assertTrue(_eval_marker(f'sys_platform != "{other}"'))
+        self.assertFalse(_eval_marker(f'sys_platform != "{sys.platform}"'))
+
+    def test_python_version_gte_low(self):
+        """python_version >= a very low version is True."""
+        self.assertTrue(_eval_marker('python_version >= "2.7"'))
+
+    def test_python_version_gte_future(self):
+        """python_version >= a far-future version is False."""
+        self.assertFalse(_eval_marker('python_version >= "99.0"'))
+
+    def test_python_version_uses_numeric_order(self):
+        """python_version comparison uses version order, not lexicographic order."""
+        # "3.10" > "3.9" numerically but "3.10" < "3.9" lexicographically.
+        if sys.version_info >= (3, 10):
+            self.assertTrue(_eval_marker('python_version >= "3.10"'))
+        else:
+            self.assertFalse(_eval_marker('python_version >= "3.10"'))
+
+    def test_extra_not_requested(self):
+        """extra == 'foo' is False when no extras are requested."""
+        self.assertFalse(_eval_marker('extra == "security"'))
+
+    def test_extra_requested(self):
+        """extra == 'foo' is True when that extra is in the requested set."""
+        self.assertTrue(_eval_marker('extra == "security"', frozenset({"security"})))
+
+    def test_extra_wrong_name(self):
+        """extra == 'foo' is False when a different extra is requested."""
+        self.assertFalse(_eval_marker('extra == "security"', frozenset({"crypto"})))
+
+    def test_and_both_true(self):
+        """'A and B' is True when both A and B are True."""
+        self.assertTrue(
+            _eval_marker(
+                f'sys_platform == "{sys.platform}" and python_version >= "2.7"'
+            )
+        )
+
+    def test_and_one_false(self):
+        """'A and B' is False when one side is False."""
+        self.assertFalse(
+            _eval_marker(
+                f'sys_platform == "{sys.platform}" and python_version >= "99.0"'
+            )
+        )
+
+    def test_or_one_true(self):
+        """'A or B' is True when at least one side is True."""
+        other = "win32" if sys.platform != "win32" else "linux"
+        self.assertTrue(
+            _eval_marker(f'sys_platform == "{other}" or python_version >= "2.7"')
+        )
+
+    def test_or_both_false(self):
+        """'A or B' is False when both sides are False."""
+        other = "win32" if sys.platform != "win32" else "linux"
+        self.assertFalse(
+            _eval_marker(f'sys_platform == "{other}" or python_version >= "99.0"')
+        )
+
+    def test_parenthesised_expression(self):
+        """Parenthesised sub-expressions are evaluated correctly."""
+        self.assertTrue(
+            _eval_marker(
+                f'(sys_platform == "{sys.platform}") and (python_version >= "2.7")'
+            )
+        )
+
+    def test_parse_error_returns_true(self):
+        """An unparseable marker returns True so no dep is silently dropped."""
+        self.assertTrue(_eval_marker("this is completely invalid !!!"))
+
+    def test_platform_system_match(self):
+        """platform_system matching the current system returns True."""
+        import platform
+
+        self.assertTrue(_eval_marker(f'platform_system == "{platform.system()}"'))
+
+    def test_implementation_name_cpython(self):
+        """implementation_name == 'cpython' is True on CPython."""
+        import platform
+
+        impl = platform.python_implementation().lower()
+        self.assertTrue(_eval_marker(f'implementation_name == "{impl}"'))
+
+
+# -------------------------------------------------------------------------
+#
+# TestTokenizeMarker
+#
+# -------------------------------------------------------------------------
+class TestTokenizeMarker(unittest.TestCase):
+    def test_simple_comparison(self):
+        """A simple equality expression tokenises correctly."""
+        tokens = _tokenize_marker('sys_platform == "win32"')
+        self.assertEqual(tokens, ["sys_platform", "==", '"win32"'])
+
+    def test_not_in_merged(self):
+        """'not' followed by 'in' is merged into the single token 'not in'."""
+        tokens = _tokenize_marker('sys_platform not in "win32 linux"')
+        self.assertEqual(tokens, ["sys_platform", "not in", '"win32 linux"'])
+
+    def test_boolean_not_not_merged(self):
+        """'not' before a parenthesised expression is kept as a separate token."""
+        tokens = _tokenize_marker('not (sys_platform == "win32")')
+        self.assertIn("not", tokens)
+        self.assertIn("(", tokens)
+
+    def test_and_or_keywords(self):
+        """'and' and 'or' appear as distinct tokens."""
+        tokens = _tokenize_marker('sys_platform == "win32" and python_version >= "3.8"')
+        self.assertIn("and", tokens)
+
+    def test_two_char_operators(self):
+        """Two-character operators are tokenised as a single token."""
+        for op in (">=", "<=", "==", "!=", "~="):
+            tokens = _tokenize_marker(f'python_version {op} "3.8"')
+            self.assertIn(op, tokens, f"operator {op!r} not found")
+
+    def test_single_quoted_string(self):
+        """Single-quoted string literals are included with their quotes."""
+        tokens = _tokenize_marker("sys_platform == 'win32'")
+        self.assertIn("'win32'", tokens)
+
+    def test_whitespace_ignored(self):
+        """Extra whitespace does not produce extra tokens."""
+        tokens = _tokenize_marker('  sys_platform   ==   "win32"  ')
+        self.assertEqual(tokens, ["sys_platform", "==", '"win32"'])
+
+
+# -------------------------------------------------------------------------
+#
+# TestDirectDependencies
+#
+# -------------------------------------------------------------------------
+class TestDirectDependencies(unittest.TestCase):
+    def test_simple_dependency(self):
+        """A bare package name is returned with an empty spec and no extras."""
+        meta = {"requires-dist": "requests"}
+        self.assertEqual(_direct_dependencies(meta), [("requests", "", frozenset())])
+
+    def test_version_constraint_preserved(self):
+        """Version specifiers are preserved alongside the dependency name."""
+        meta = {"requires-dist": "requests>=2.0"}
+        self.assertEqual(
+            _direct_dependencies(meta), [("requests", ">=2.0", frozenset())]
+        )
+
+    def test_compound_constraint_preserved(self):
+        """Multiple comma-joined constraints are kept intact."""
+        meta = {"requires-dist": "requests>=2.0,<3"}
+        self.assertEqual(
+            _direct_dependencies(meta), [("requests", ">=2.0,<3", frozenset())]
+        )
+
+    def test_non_matching_platform_marker_skipped(self):
+        """A dep whose platform marker does not match the current platform is skipped."""
+        other = "win32" if sys.platform != "win32" else "linux"
+        meta = {"requires-dist": f'pywin32>=1.0; sys_platform == "{other}"'}
+        self.assertEqual(_direct_dependencies(meta), [])
+
+    def test_matching_platform_marker_included(self):
+        """A dep whose platform marker matches the current platform is included."""
+        meta = {"requires-dist": f'foo; sys_platform == "{sys.platform}"'}
+        result = _direct_dependencies(meta)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0][0], "foo")
+
+    def test_extra_dependency_skipped_without_extras(self):
+        """Extra-conditional dependencies are skipped when no extras are requested."""
+        meta = {"requires-dist": 'cryptography; extra == "security"'}
+        self.assertEqual(_direct_dependencies(meta), [])
+
+    def test_extra_dependency_included_when_extra_requested(self):
+        """Extra-conditional deps are included when the matching extra is requested."""
+        meta = {"requires-dist": 'cryptography; extra == "security"'}
+        result = _direct_dependencies(meta, frozenset({"security"}))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0][0], "cryptography")
+
+    def test_dep_extras_parsed(self):
+        """Extras in square brackets are parsed into dep_extras."""
+        meta = {"requires-dist": "requests[security]>=2.0"}
+        result = _direct_dependencies(meta)
+        self.assertEqual(len(result), 1)
+        name, spec, dep_extras = result[0]
+        self.assertEqual(name, "requests")
+        self.assertEqual(spec, ">=2.0")
+        self.assertEqual(dep_extras, frozenset({"security"}))
+
+    def test_dep_multiple_extras_parsed(self):
+        """Multiple comma-separated extras in square brackets are all captured."""
+        meta = {"requires-dist": "requests[security,crypto]"}
+        result = _direct_dependencies(meta)
+        _, _, dep_extras = result[0]
+        self.assertEqual(dep_extras, frozenset({"security", "crypto"}))
+
+    def test_multiple_dependencies(self):
+        """Multiple deps on separate lines are all returned."""
+        meta = {"requires-dist": "requests\nclick\nrich"}
+        self.assertEqual(
+            _direct_dependencies(meta),
+            [
+                ("requests", "", frozenset()),
+                ("click", "", frozenset()),
+                ("rich", "", frozenset()),
+            ],
+        )
+
+    def test_mixed_conditional_and_plain(self):
+        """Only unconditional and matching entries are returned from a mixed list."""
+        other = "win32" if sys.platform != "win32" else "linux"
+        meta = {
+            "requires-dist": (
+                "requests\n" f'pywin32; sys_platform == "{other}"\n' "click\n"
+            )
+        }
+        self.assertEqual(
+            _direct_dependencies(meta),
+            [("requests", "", frozenset()), ("click", "", frozenset())],
+        )
+
+    def test_empty_metadata(self):
+        """Missing requires-dist key returns an empty list."""
+        self.assertEqual(_direct_dependencies({}), [])
+
+    def test_blank_lines_ignored(self):
+        """Blank lines in the requires-dist value are ignored."""
+        meta = {"requires-dist": "\nrequests\n\nclick\n"}
+        self.assertEqual(
+            _direct_dependencies(meta),
+            [("requests", "", frozenset()), ("click", "", frozenset())],
+        )
+
+    def test_compatible_release_specifier_preserved(self):
+        """The ~= specifier is preserved in the version spec field."""
+        meta = {"requires-dist": "mdurl~=0.3.2"}
+        self.assertEqual(
+            _direct_dependencies(meta), [("mdurl", "~=0.3.2", frozenset())]
+        )
+
+
+# -------------------------------------------------------------------------
+#
+# TestSatisfiesSpec
+#
+# -------------------------------------------------------------------------
+class TestSatisfiesSpec(unittest.TestCase):
+    def test_empty_spec_always_true(self):
+        """An empty spec string is always satisfied."""
+        self.assertTrue(_satisfies_spec("1.0", ""))
+
+    def test_gte_satisfied(self):
+        """Installed version >= required version passes >=."""
+        self.assertTrue(_satisfies_spec("2.0", ">=1.0"))
+        self.assertTrue(_satisfies_spec("1.0", ">=1.0"))
+
+    def test_gte_not_satisfied(self):
+        """Installed version below required fails >=."""
+        self.assertFalse(_satisfies_spec("0.9", ">=1.0"))
+
+    def test_lte_satisfied(self):
+        """Installed version <= required passes <=."""
+        self.assertTrue(_satisfies_spec("1.0", "<=2.0"))
+        self.assertTrue(_satisfies_spec("2.0", "<=2.0"))
+
+    def test_lte_not_satisfied(self):
+        """Installed version above required fails <=."""
+        self.assertFalse(_satisfies_spec("3.0", "<=2.0"))
+
+    def test_gt_satisfied(self):
+        """Strictly greater than passes >."""
+        self.assertTrue(_satisfies_spec("1.1", ">1.0"))
+
+    def test_gt_not_satisfied_equal(self):
+        """Equal to the bound does not satisfy >."""
+        self.assertFalse(_satisfies_spec("1.0", ">1.0"))
+
+    def test_lt_satisfied(self):
+        """Strictly less than passes <."""
+        self.assertTrue(_satisfies_spec("0.9", "<1.0"))
+
+    def test_lt_not_satisfied_equal(self):
+        """Equal to the bound does not satisfy <."""
+        self.assertFalse(_satisfies_spec("1.0", "<1.0"))
+
+    def test_eq_exact_match(self):
+        """Exact version equality passes ==."""
+        self.assertTrue(_satisfies_spec("1.2.3", "==1.2.3"))
+
+    def test_eq_no_match(self):
+        """Different version fails ==."""
+        self.assertFalse(_satisfies_spec("1.2.4", "==1.2.3"))
+
+    def test_eq_wildcard_match(self):
+        """Major.minor wildcard passes == when prefix matches."""
+        self.assertTrue(_satisfies_spec("1.2.5", "==1.2.*"))
+
+    def test_eq_wildcard_no_match(self):
+        """Major.minor wildcard fails when prefix differs."""
+        self.assertFalse(_satisfies_spec("1.3.0", "==1.2.*"))
+
+    def test_neq_no_match(self):
+        """Equal version fails !=."""
+        self.assertFalse(_satisfies_spec("1.2.3", "!=1.2.3"))
+
+    def test_neq_match(self):
+        """Different version passes !=."""
+        self.assertTrue(_satisfies_spec("1.2.4", "!=1.2.3"))
+
+    def test_neq_wildcard_match(self):
+        """Wildcard != excludes the whole minor series."""
+        self.assertFalse(_satisfies_spec("1.2.9", "!=1.2.*"))
+
+    def test_compatible_release_two_part(self):
+        """~=X.Y means >=X.Y and <(X+1)."""
+        self.assertTrue(_satisfies_spec("1.5", "~=1.4"))
+        self.assertFalse(_satisfies_spec("2.0", "~=1.4"))
+        self.assertFalse(_satisfies_spec("1.3", "~=1.4"))
+
+    def test_compatible_release_three_part(self):
+        """~=X.Y.Z means >=X.Y.Z and <X.(Y+1)."""
+        self.assertTrue(_satisfies_spec("1.4.1", "~=1.4.0"))
+        self.assertTrue(_satisfies_spec("1.4.9", "~=1.4.0"))
+        self.assertFalse(_satisfies_spec("1.5.0", "~=1.4.0"))
+        self.assertFalse(_satisfies_spec("1.3.9", "~=1.4.0"))
+
+    def test_compound_spec(self):
+        """Multiple comma-joined constraints are all checked."""
+        self.assertTrue(_satisfies_spec("2.5", ">=2.0,<3.0"))
+        self.assertFalse(_satisfies_spec("3.1", ">=2.0,<3.0"))
+        self.assertFalse(_satisfies_spec("1.9", ">=2.0,<3.0"))
+
+
+# -------------------------------------------------------------------------
+#
+# TestVersionSatisfies
+#
+# -------------------------------------------------------------------------
+class TestVersionSatisfies(unittest.TestCase):
+    def test_empty_spec_always_true(self):
+        """An empty spec is always satisfied without querying metadata."""
+        self.assertTrue(_version_satisfies("requests", ""))
+
+    def test_installed_version_satisfies(self):
+        """Returns True when dist-info reports a version satisfying the spec."""
+        with patch(
+            "gramps.gen.utils.pypi.importlib.metadata.version", return_value="2.31.0"
+        ):
+            self.assertTrue(_version_satisfies("requests", ">=2.0"))
+
+    def test_installed_version_does_not_satisfy(self):
+        """Returns False when dist-info reports a version failing the spec."""
+        with patch(
+            "gramps.gen.utils.pypi.importlib.metadata.version", return_value="1.5.0"
+        ):
+            self.assertFalse(_version_satisfies("requests", ">=2.0"))
+
+    def test_hyphenated_name_fallback(self):
+        """Tries the hyphenated form when the underscore form has no dist-info."""
+        import importlib.metadata as _md
+
+        def fake_version(name):
+            if name == "python-dateutil":
+                return "2.8.2"
+            raise _md.PackageNotFoundError(name)
+
+        with patch("gramps.gen.utils.pypi.importlib.metadata.version", fake_version):
+            self.assertTrue(_version_satisfies("python_dateutil", ">=2.0"))
+
+    def test_no_dist_info_returns_true(self):
+        """Returns True (assume OK) when no dist-info exists for the package."""
+        import importlib.metadata as _md
+
+        with patch(
+            "gramps.gen.utils.pypi.importlib.metadata.version",
+            side_effect=_md.PackageNotFoundError("x"),
+        ):
+            self.assertTrue(_version_satisfies("somepkg", ">=1.0"))
+
+
+# -------------------------------------------------------------------------
+#
+# TestPickWheel
+#
+# -------------------------------------------------------------------------
+class TestPickWheel(unittest.TestCase):
+    def test_picks_pure_wheel_from_urls(self):
+        """A pure-Python wheel in urls is returned."""
+        meta = _fake_pypi_meta("mypkg-1.0-py3-none-any.whl")
+        result = _pick_wheel(meta, "mypkg")
+        self.assertEqual(result["filename"], "mypkg-1.0-py3-none-any.whl")
+
+    def test_skips_compiled_wheel(self):
+        """A compiled wheel for a non-matching platform raises PyPIInstallError."""
+        # Use a tag that will never match the test runner's platform.
+        with patch(
+            "gramps.gen.utils.pypi._compatible_tags", return_value=(set(), set(), set())
+        ):
+            meta = _fake_pypi_meta("mypkg-1.0-cp311-cp311-linux_x86_64.whl")
+            with self.assertRaises(PyPIInstallError):
+                _pick_wheel(meta, "mypkg")
+
+    def test_falls_back_to_releases(self):
+        """Falls back to releases dict when urls has no pure wheel."""
+        meta = {
+            "urls": [],
+            "releases": {
+                "0.9": [
+                    {
+                        "filename": "mypkg-0.9-py3-none-any.whl",
+                        "url": "u",
+                        "digests": {},
+                    }
+                ]
+            },
+        }
+        result = _pick_wheel(meta, "mypkg")
+        self.assertEqual(result["filename"], "mypkg-0.9-py3-none-any.whl")
+
+    def test_no_wheel_at_all_raises(self):
+        """No pure wheel anywhere raises PyPIInstallError."""
+        meta = {"urls": [], "releases": {}}
+        with self.assertRaises(PyPIInstallError):
+            _pick_wheel(meta, "mypkg")
+
+    def test_releases_searched_newest_first(self):
+        """When falling back to releases, the newest version is preferred."""
+        meta = {
+            "urls": [],
+            "releases": {
+                "0.9": [
+                    {
+                        "filename": "mypkg-0.9-py3-none-any.whl",
+                        "url": "u09",
+                        "digests": {},
+                    }
+                ],
+                "1.10": [
+                    {
+                        "filename": "mypkg-1.10-py3-none-any.whl",
+                        "url": "u110",
+                        "digests": {},
+                    }
+                ],
+                "1.2": [
+                    {
+                        "filename": "mypkg-1.2-py3-none-any.whl",
+                        "url": "u12",
+                        "digests": {},
+                    }
+                ],
+            },
+        }
+        result = _pick_wheel(meta, "mypkg")
+        # 1.10 > 1.2 numerically, so it should be preferred over 1.2
+        self.assertEqual(result["filename"], "mypkg-1.10-py3-none-any.whl")
+
+
+# -------------------------------------------------------------------------
+#
+# TestInstallPackage
+#
+# -------------------------------------------------------------------------
+class TestInstallPackage(unittest.TestCase):
+    def setUp(self):
+        self.target = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.target, ignore_errors=True)
+        # Remove any test module from sys.modules to avoid cross-test pollution
+        for name in ("fakepkg", "fakepkg_dep", "fakepkg_toplevel", "fakepkg_alt"):
+            sys.modules.pop(name, None)
+
+    def _make_wheel_bytes(self, metadata_text: str = "") -> bytes:
+        return _make_wheel_zip(metadata_text, {"fakepkg/__init__.py": b""})
+
+    @patch("gramps.gen.utils.pypi._fetch_url")
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_installs_pure_package(self, mock_meta, mock_fetch):
+        """A pure-Python package with no deps is extracted to target."""
+        wheel_data = self._make_wheel_bytes("Name: fakepkg\nVersion: 1.0\n")
+        digest = _sha256(wheel_data)
+
+        mock_meta.return_value = _fake_pypi_meta(
+            "fakepkg-1.0-py3-none-any.whl",
+            "https://example.com/fakepkg.whl",
+            digest,
+        )
+        mock_fetch.return_value = wheel_data
+
+        installed = install_package("fakepkg", self.target)
+
+        self.assertIn("fakepkg", installed)
+        self.assertTrue(
+            os.path.exists(os.path.join(self.target, "fakepkg", "__init__.py"))
+        )
+
+    @patch("gramps.gen.utils.pypi._fetch_url")
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_skips_already_importable(self, mock_meta, mock_fetch):
+        """Packages already importable are skipped without a network call."""
+        installed = install_package("os", self.target)
+        mock_meta.assert_not_called()
+        mock_fetch.assert_not_called()
+        self.assertEqual(installed, [])
+
+    @patch("gramps.gen.utils.pypi._fetch_url")
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_sha256_mismatch_raises(self, mock_meta, mock_fetch):
+        """A SHA-256 mismatch raises PyPIInstallError."""
+        wheel_data = self._make_wheel_bytes()
+        mock_meta.return_value = _fake_pypi_meta(
+            "fakepkg-1.0-py3-none-any.whl",
+            "https://example.com/fakepkg.whl",
+            "deadbeef" * 8,
+        )
+        mock_fetch.return_value = wheel_data
+
+        with self.assertRaises(PyPIInstallError):
+            install_package("fakepkg", self.target)
+
+    @patch("gramps.gen.utils.pypi._fetch_url")
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_no_compatible_wheel_raises(self, mock_meta, mock_fetch):
+        """A package with no compatible wheels raises PyPIInstallError."""
+        mock_meta.return_value = _fake_pypi_meta(
+            "fakepkg-1.0-cp311-cp311-linux_x86_64.whl"
+        )
+        with patch(
+            "gramps.gen.utils.pypi._compatible_tags",
+            return_value=(set(), set(), set()),
+        ):
+            with self.assertRaises(PyPIInstallError):
+                install_package("fakepkg", self.target)
+        mock_fetch.assert_not_called()
+
+    @patch("gramps.gen.utils.pypi._fetch_url")
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_network_error_raises(self, mock_meta, mock_fetch):
+        """A network error on metadata fetch raises PyPIInstallError."""
+        mock_meta.side_effect = PyPIInstallError("network down")
+        with self.assertRaises(PyPIInstallError):
+            install_package("fakepkg", self.target)
+
+    @patch("gramps.gen.utils.pypi._fetch_url")
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_installs_direct_dependency(self, mock_meta, mock_fetch):
+        """A package's unconditional direct dependency is also installed."""
+        dep_wheel = _make_wheel_zip(
+            "Name: fakepkg_dep\nVersion: 1.0\n",
+            {"fakepkg_dep/__init__.py": b""},
+        )
+        dep_digest = _sha256(dep_wheel)
+
+        main_wheel = _make_wheel_zip(
+            "Name: fakepkg\nVersion: 1.0\nRequires-Dist: fakepkg_dep\n",
+            {"fakepkg/__init__.py": b""},
+        )
+        main_digest = _sha256(main_wheel)
+
+        def fake_meta(package):
+            if package == "fakepkg":
+                return _fake_pypi_meta(
+                    "fakepkg-1.0-py3-none-any.whl",
+                    "https://example.com/fakepkg.whl",
+                    main_digest,
+                )
+            if package == "fakepkg_dep":
+                return _fake_pypi_meta(
+                    "fakepkg_dep-1.0-py3-none-any.whl",
+                    "https://example.com/fakepkg_dep.whl",
+                    dep_digest,
+                )
+            raise PyPIInstallError(f"unexpected: {package}")
+
+        def fake_fetch(url):
+            if "fakepkg_dep" in url:
+                return dep_wheel
+            return main_wheel
+
+        mock_meta.side_effect = fake_meta
+        mock_fetch.side_effect = fake_fetch
+
+        installed = install_package("fakepkg", self.target)
+
+        self.assertIn("fakepkg", installed)
+        self.assertIn("fakepkg_dep", installed)
+
+    @patch("gramps.gen.utils.pypi._fetch_url")
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_circular_dependency_does_not_loop(self, mock_meta, mock_fetch):
+        """Circular Requires-Dist entries do not cause infinite recursion."""
+        wheel_data = _make_wheel_zip(
+            "Name: fakepkg\nVersion: 1.0\nRequires-Dist: fakepkg\n",
+            {"fakepkg/__init__.py": b""},
+        )
+        digest = _sha256(wheel_data)
+        mock_meta.return_value = _fake_pypi_meta(
+            "fakepkg-1.0-py3-none-any.whl",
+            "https://example.com/fakepkg.whl",
+            digest,
+        )
+        mock_fetch.return_value = wheel_data
+
+        installed = install_package("fakepkg", self.target)
+        self.assertIn("fakepkg", installed)
+        # Only installed once despite the self-referential dep
+        self.assertEqual(installed.count("fakepkg"), 1)
+
+    @patch("gramps.gen.utils.pypi._fetch_url")
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_conditional_dependency_not_installed(self, mock_meta, mock_fetch):
+        """A dep whose platform marker does not match the current platform is not installed."""
+        other = "win32" if sys.platform != "win32" else "linux"
+        wheel_data = _make_wheel_zip(
+            "Name: fakepkg\nVersion: 1.0\n"
+            f'Requires-Dist: pywin32; sys_platform == "{other}"\n',
+            {"fakepkg/__init__.py": b""},
+        )
+        digest = _sha256(wheel_data)
+        mock_meta.return_value = _fake_pypi_meta(
+            "fakepkg-1.0-py3-none-any.whl",
+            "https://example.com/fakepkg.whl",
+            digest,
+        )
+        mock_fetch.return_value = wheel_data
+
+        installed = install_package("fakepkg", self.target)
+        self.assertIn("fakepkg", installed)
+        self.assertNotIn("pywin32", installed)
+        # pywin32 metadata should never have been fetched
+        for call in mock_meta.call_args_list:
+            self.assertNotEqual(call.args[0], "pywin32")
+
+    @patch("gramps.gen.utils.pypi._fetch_url")
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_extras_dep_installed_when_extra_requested(self, mock_meta, mock_fetch):
+        """An extra-conditional dep is installed when that extra is requested."""
+        dep_wheel = _make_wheel_zip(
+            "Name: fakepkg_dep\nVersion: 1.0\n",
+            {"fakepkg_dep/__init__.py": b""},
+        )
+        dep_digest = _sha256(dep_wheel)
+
+        main_wheel = _make_wheel_zip(
+            "Name: fakepkg\nVersion: 1.0\n"
+            'Requires-Dist: fakepkg_dep; extra == "security"\n',
+            {"fakepkg/__init__.py": b""},
+        )
+        main_digest = _sha256(main_wheel)
+
+        def fake_meta(package):
+            if package == "fakepkg":
+                return _fake_pypi_meta(
+                    "fakepkg-1.0-py3-none-any.whl",
+                    "https://example.com/fakepkg.whl",
+                    main_digest,
+                )
+            if package == "fakepkg_dep":
+                return _fake_pypi_meta(
+                    "fakepkg_dep-1.0-py3-none-any.whl",
+                    "https://example.com/fakepkg_dep.whl",
+                    dep_digest,
+                )
+            raise PyPIInstallError(f"unexpected package: {package}")
+
+        def fake_fetch(url):
+            return dep_wheel if "fakepkg_dep" in url else main_wheel
+
+        mock_meta.side_effect = fake_meta
+        mock_fetch.side_effect = fake_fetch
+
+        installed = install_package("fakepkg", self.target, frozenset({"security"}))
+        self.assertIn("fakepkg", installed)
+        self.assertIn("fakepkg_dep", installed)
+
+    @patch("gramps.gen.utils.pypi._fetch_url")
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_extras_dep_not_installed_without_extra(self, mock_meta, mock_fetch):
+        """An extra-conditional dep is NOT installed when the extra is not requested."""
+        main_wheel = _make_wheel_zip(
+            "Name: fakepkg\nVersion: 1.0\n"
+            'Requires-Dist: fakepkg_dep; extra == "security"\n',
+            {"fakepkg/__init__.py": b""},
+        )
+        main_digest = _sha256(main_wheel)
+        mock_meta.return_value = _fake_pypi_meta(
+            "fakepkg-1.0-py3-none-any.whl",
+            "https://example.com/fakepkg.whl",
+            main_digest,
+        )
+        mock_fetch.return_value = main_wheel
+
+        installed = install_package("fakepkg", self.target)
+        self.assertIn("fakepkg", installed)
+        self.assertNotIn("fakepkg_dep", installed)
+        for call in mock_meta.call_args_list:
+            self.assertNotEqual(call.args[0], "fakepkg_dep")
+
+    @patch("gramps.gen.utils.pypi._fetch_url")
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_extras_parsed_from_package_name(self, mock_meta, mock_fetch):
+        """Extras embedded in the package name activate the matching extra deps."""
+        dep_wheel = _make_wheel_zip(
+            "Name: fakepkg_dep\nVersion: 1.0\n",
+            {"fakepkg_dep/__init__.py": b""},
+        )
+        dep_digest = _sha256(dep_wheel)
+
+        main_wheel = _make_wheel_zip(
+            "Name: fakepkg\nVersion: 1.0\n"
+            'Requires-Dist: fakepkg_dep; extra == "security"\n',
+            {"fakepkg/__init__.py": b""},
+        )
+        main_digest = _sha256(main_wheel)
+
+        def fake_meta(package):
+            if package == "fakepkg":
+                return _fake_pypi_meta(
+                    "fakepkg-1.0-py3-none-any.whl",
+                    "https://example.com/fakepkg.whl",
+                    main_digest,
+                )
+            if package == "fakepkg_dep":
+                return _fake_pypi_meta(
+                    "fakepkg_dep-1.0-py3-none-any.whl",
+                    "https://example.com/fakepkg_dep.whl",
+                    dep_digest,
+                )
+            raise PyPIInstallError(f"unexpected package: {package}")
+
+        def fake_fetch(url):
+            return dep_wheel if "fakepkg_dep" in url else main_wheel
+
+        mock_meta.side_effect = fake_meta
+        mock_fetch.side_effect = fake_fetch
+
+        # "fakepkg[security]" parses the "security" extra from the name.
+        installed = install_package("fakepkg[security]", self.target)
+        self.assertIn("fakepkg", installed)
+        self.assertIn("fakepkg_dep", installed)
+
+    @patch("gramps.gen.utils.pypi._fetch_url")
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_skips_when_top_level_name_importable(self, mock_meta, mock_fetch):
+        """A package whose top_level.txt name is importable is skipped even when
+        the canonical PyPI name is not directly importable (e.g. Pillow → PIL)."""
+        wheel_data = _make_wheel_zip(
+            "Name: fakepkg_toplevel\nVersion: 1.0\n",
+            {
+                "fakepkg_toplevel-1.0.dist-info/top_level.txt": b"fakepkg_alt\n",
+                "fakepkg_alt/__init__.py": b"",
+            },
+        )
+        digest = _sha256(wheel_data)
+        mock_meta.return_value = _fake_pypi_meta(
+            "fakepkg_toplevel-1.0-py3-none-any.whl",
+            "https://example.com/fakepkg_toplevel.whl",
+            digest,
+        )
+        mock_fetch.return_value = wheel_data
+
+        # Simulate "fakepkg_alt" already installed under its real import name.
+        sys.modules["fakepkg_alt"] = MagicMock()
+
+        installed = install_package("fakepkg_toplevel", self.target)
+
+        # Package was not re-extracted.
+        self.assertEqual(installed, [])
+        # The wheel was downloaded (needed to read top_level.txt).
+        mock_fetch.assert_called_once()
+        # Nothing was written to the target directory.
+        self.assertEqual(os.listdir(self.target), [])
+
+    @patch("gramps.gen.utils.pypi._fetch_url")
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_installs_when_top_level_name_not_importable(self, mock_meta, mock_fetch):
+        """A package is installed when its top_level.txt name is not yet importable."""
+        wheel_data = _make_wheel_zip(
+            "Name: fakepkg_toplevel\nVersion: 1.0\n",
+            {
+                "fakepkg_toplevel-1.0.dist-info/top_level.txt": b"fakepkg_alt\n",
+                "fakepkg_alt/__init__.py": b"",
+            },
+        )
+        digest = _sha256(wheel_data)
+        mock_meta.return_value = _fake_pypi_meta(
+            "fakepkg_toplevel-1.0-py3-none-any.whl",
+            "https://example.com/fakepkg_toplevel.whl",
+            digest,
+        )
+        mock_fetch.return_value = wheel_data
+
+        installed = install_package("fakepkg_toplevel", self.target)
+
+        self.assertIn("fakepkg_toplevel", installed)
+        self.assertTrue(
+            os.path.exists(os.path.join(self.target, "fakepkg_alt", "__init__.py"))
+        )
+
+    @patch("gramps.gen.utils.pypi._fetch_url")
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_version_conflict_resolved(self, mock_meta, mock_fetch):
+        """Conflicting version constraints on a shared dep are resolved correctly.
+
+        pkg_a requires deplib>=1.0,<2.0 and pkg_b requires deplib>=1.5.
+        The resolver should pick deplib 1.9 (newest satisfying >=1.5,<2.0).
+        pkg_b is a direct dep of pkg_a (declared in pkg_a's wheel METADATA).
+        """
+        # Build wheels for each package
+        deplib_wheel = _make_wheel_zip(
+            "Name: deplib\nVersion: 1.9\n",
+            {"deplib/__init__.py": b""},
+        )
+        deplib_digest = _sha256(deplib_wheel)
+
+        pkg_b_wheel = _make_wheel_zip(
+            "Name: fakepkg_b\nVersion: 1.0\n",
+            {"fakepkg_b/__init__.py": b""},
+        )
+        pkg_b_digest = _sha256(pkg_b_wheel)
+
+        pkg_a_wheel = _make_wheel_zip(
+            "Name: fakepkg_a\nVersion: 1.0\n"
+            "Requires-Dist: fakepkg_b\n"
+            "Requires-Dist: deplib>=1.0,<2.0\n",
+            {"fakepkg_a/__init__.py": b""},
+        )
+        pkg_a_digest = _sha256(pkg_a_wheel)
+
+        # PyPI JSON for each package (info.requires_dist drives the gather pass)
+        deplib_releases = {
+            "2.0": [
+                {
+                    "filename": "deplib-2.0-py3-none-any.whl",
+                    "url": "u/2.0",
+                    "digests": {},
+                }
+            ],
+            "1.9": [
+                {
+                    "filename": "deplib-1.9-py3-none-any.whl",
+                    "url": "https://example.com/deplib-1.9.whl",
+                    "digests": {"sha256": deplib_digest},
+                }
+            ],
+            "1.5": [
+                {
+                    "filename": "deplib-1.5-py3-none-any.whl",
+                    "url": "u/1.5",
+                    "digests": {},
+                }
+            ],
+        }
+
+        def fake_meta(package):
+            if package == "fakepkg_a":
+                return {
+                    "info": {
+                        "requires_dist": [
+                            "fakepkg_b",
+                            "deplib>=1.0,<2.0",
+                        ]
+                    },
+                    "urls": [
+                        {
+                            "filename": "fakepkg_a-1.0-py3-none-any.whl",
+                            "url": "https://example.com/fakepkg_a.whl",
+                            "digests": {"sha256": pkg_a_digest},
+                        }
+                    ],
+                    "releases": {},
+                }
+            if package == "fakepkg_b":
+                return {
+                    "info": {"requires_dist": ["deplib>=1.5"]},
+                    "urls": [
+                        {
+                            "filename": "fakepkg_b-1.0-py3-none-any.whl",
+                            "url": "https://example.com/fakepkg_b.whl",
+                            "digests": {"sha256": pkg_b_digest},
+                        }
+                    ],
+                    "releases": {},
+                }
+            if package == "deplib":
+                return {
+                    "info": {"requires_dist": []},
+                    "urls": [],
+                    "releases": deplib_releases,
+                }
+            raise PyPIInstallError(f"unexpected: {package}")
+
+        def fake_fetch(url):
+            if "fakepkg_b" in url:
+                return pkg_b_wheel
+            if "fakepkg_a" in url:
+                return pkg_a_wheel
+            if "deplib-1.9" in url:
+                return deplib_wheel
+            raise Exception(f"unexpected fetch: {url}")
+
+        mock_meta.side_effect = fake_meta
+        mock_fetch.side_effect = fake_fetch
+
+        installed = install_package("fakepkg_a", self.target)
+
+        self.assertIn("fakepkg_a", installed)
+        self.assertIn("deplib", installed)
+        # Verify the resolved 1.9 wheel was extracted (not the 2.0 that violates
+        # the <2.0 constraint, nor the 1.5 when a newer 1.9 satisfies both).
+        fetched_urls = [call.args[0] for call in mock_fetch.call_args_list]
+        self.assertTrue(
+            any("deplib-1.9" in u for u in fetched_urls),
+            f"Expected deplib-1.9 to be fetched; got {fetched_urls}",
+        )
+
+    @patch("gramps.gen.utils.pypi._fetch_url")
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_unsatisfiable_conflict_raises(self, mock_meta, mock_fetch):
+        """When no version satisfies the combined constraints, PyPIInstallError is raised."""
+
+        def fake_meta(package):
+            if package == "fakepkg":
+                return {
+                    "info": {"requires_dist": ["deplib>=2.0"]},
+                    "urls": [
+                        {
+                            "filename": "fakepkg-1.0-py3-none-any.whl",
+                            "url": "u",
+                            "digests": {},
+                        }
+                    ],
+                    "releases": {},
+                }
+            if package == "deplib":
+                return {
+                    "info": {"requires_dist": []},
+                    "releases": {
+                        "1.9": [
+                            {
+                                "filename": "deplib-1.9-py3-none-any.whl",
+                                "url": "u/1.9",
+                                "digests": {},
+                            }
+                        ]
+                    },
+                    "urls": [],
+                }
+            raise PyPIInstallError(f"unexpected: {package}")
+
+        mock_meta.side_effect = fake_meta
+
+        # fakepkg requires deplib>=2.0 but only 1.9 is available → conflict
+        with self.assertRaises(PyPIInstallError) as ctx:
+            install_package("fakepkg", self.target)
+
+        self.assertIn("deplib", str(ctx.exception))
+
+
+# -------------------------------------------------------------------------
+#
+# TestIsPrerelease
+#
+# -------------------------------------------------------------------------
+class TestIsPrerelease(unittest.TestCase):
+    def test_stable_version_is_not_prerelease(self):
+        """Plain version numbers are not pre-releases."""
+        for ver in ("1.0", "2.3.4", "1.10.0", "1.0.post1", "1.0.post2"):
+            self.assertFalse(_is_prerelease(ver), ver)
+
+    def test_alpha_is_prerelease(self):
+        """aN suffix marks a pre-release."""
+        for ver in ("1.0a1", "2.0a12", "1.0.0a3"):
+            self.assertTrue(_is_prerelease(ver), ver)
+
+    def test_beta_is_prerelease(self):
+        """bN suffix marks a pre-release."""
+        for ver in ("1.0b1", "2.0b2"):
+            self.assertTrue(_is_prerelease(ver), ver)
+
+    def test_rc_is_prerelease(self):
+        """rcN suffix marks a release candidate."""
+        for ver in ("1.0rc1", "2.1.0rc3"):
+            self.assertTrue(_is_prerelease(ver), ver)
+
+    def test_dev_is_prerelease(self):
+        """.devN suffix marks a development release."""
+        for ver in ("1.0.dev0", "2.0.dev1"):
+            self.assertTrue(_is_prerelease(ver), ver)
+
+    def test_post_release_is_not_prerelease(self):
+        """.postN is a post-release, not a pre-release."""
+        self.assertFalse(_is_prerelease("1.0.post1"))
+        self.assertFalse(_is_prerelease("2.3.post0"))
+
+
+# -------------------------------------------------------------------------
+#
+# TestIsYanked
+#
+# -------------------------------------------------------------------------
+class TestIsYanked(unittest.TestCase):
+    def test_yanked_true(self):
+        """File entry with yanked=True is yanked."""
+        self.assertTrue(_is_yanked({"yanked": True}))
+
+    def test_yanked_false(self):
+        """File entry with yanked=False is not yanked."""
+        self.assertFalse(_is_yanked({"yanked": False}))
+
+    def test_yanked_absent(self):
+        """File entry without a yanked field is not yanked."""
+        self.assertFalse(_is_yanked({}))
+
+    def test_yanked_reason_string_is_truthy(self):
+        """Some PyPI responses set yanked to a non-empty reason string."""
+        self.assertTrue(_is_yanked({"yanked": "security issue"}))
+
+
+# -------------------------------------------------------------------------
+#
+# TestRequiresPythonOk
+#
+# -------------------------------------------------------------------------
+class TestRequiresPythonOk(unittest.TestCase):
+    def test_no_field_always_ok(self):
+        """A missing requires_python field is always satisfied."""
+        self.assertTrue(_requires_python_ok({}))
+
+    def test_empty_string_always_ok(self):
+        """An empty requires_python string is always satisfied."""
+        self.assertTrue(_requires_python_ok({"requires_python": ""}))
+
+    def test_satisfied_lower_bound(self):
+        """requires_python >= a very low version is satisfied."""
+        self.assertTrue(_requires_python_ok({"requires_python": ">=2.7"}))
+
+    def test_unsatisfied_future_version(self):
+        """requires_python >= 99.0 is not satisfied."""
+        self.assertFalse(_requires_python_ok({"requires_python": ">=99.0"}))
+
+    def test_exact_current_version(self):
+        """requires_python == current major.minor is satisfied."""
+        current = f"{sys.version_info.major}.{sys.version_info.minor}"
+        self.assertTrue(_requires_python_ok({"requires_python": f"=={current}.*"}))
+
+    def test_none_field_always_ok(self):
+        """requires_python=None (as returned by some PyPI entries) is always ok."""
+        self.assertTrue(_requires_python_ok({"requires_python": None}))
+
+
+# -------------------------------------------------------------------------
+#
+# TestGatherRequirements
+#
+# -------------------------------------------------------------------------
+class TestGatherRequirements(unittest.TestCase):
+    def _meta(self, requires_dist: list[str]) -> dict:
+        """Build a minimal PyPI JSON dict with the given requires_dist list."""
+        return {
+            "info": {"requires_dist": requires_dist},
+            "urls": [],
+            "releases": {},
+        }
+
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_versioned_dep_added_to_specs(self, mock_meta):
+        """A dep with a version constraint is added to specs."""
+
+        def fake_meta(package):
+            if package == "mypkg":
+                return self._meta(["requests>=2.0"])
+            return self._meta([])
+
+        mock_meta.side_effect = fake_meta
+        specs: dict[str, list[str]] = {}
+        _gather_requirements("mypkg", frozenset(), specs, set())
+        self.assertIn("requests", specs)
+        self.assertEqual(specs["requests"], [">=2.0"])
+
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_unversioned_dep_not_added(self, mock_meta):
+        """A dep with no version constraint is NOT added to specs."""
+
+        def fake_meta(package):
+            if package == "mypkg":
+                return self._meta(["requests"])
+            return self._meta([])
+
+        mock_meta.side_effect = fake_meta
+        specs: dict[str, list[str]] = {}
+        _gather_requirements("mypkg", frozenset(), specs, set())
+        self.assertNotIn("requests", specs)
+
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_multiple_constraints_accumulated(self, mock_meta):
+        """Constraints from multiple packages on the same dep accumulate."""
+
+        def fake_meta(package):
+            if package == "pkg_a":
+                return self._meta(["requests>=1.0,<3.0"])
+            if package == "pkg_b":
+                return self._meta(["requests>=2.0"])
+            return self._meta([])
+
+        mock_meta.side_effect = fake_meta
+        specs: dict[str, list[str]] = {}
+        # Gather from pkg_a (which dep-pulls pkg_b that also constrains requests)
+        # We drive this manually by calling gather on both roots.
+        _gather_requirements("pkg_a", frozenset(), specs, set())
+        _gather_requirements("pkg_b", frozenset(), specs, set())
+        self.assertIn("requests", specs)
+        # Both constraints should be present (order may vary)
+        combined = ",".join(specs["requests"])
+        self.assertIn(">=1.0,<3.0", combined)
+        self.assertIn(">=2.0", combined)
+
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_circular_dependency_does_not_loop(self, mock_meta):
+        """Circular deps do not cause infinite recursion."""
+
+        def fake_meta(package):
+            if package == "pkg_a":
+                return self._meta(["pkg_b>=1.0"])
+            if package == "pkg_b":
+                return self._meta(["pkg_a>=1.0"])  # circular
+            return self._meta([])
+
+        mock_meta.side_effect = fake_meta
+        specs: dict[str, list[str]] = {}
+        _gather_requirements("pkg_a", frozenset(), specs, set())
+        # Should complete without RecursionError; both constraints gathered
+        self.assertIn("pkg_b", specs)
+        self.assertIn("pkg_a", specs)
+
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_marker_filtered_dep_not_gathered(self, mock_meta):
+        """A dep whose platform marker does not match is not gathered."""
+        other = "win32" if sys.platform != "win32" else "linux"
+
+        def fake_meta(package):
+            if package == "mypkg":
+                return self._meta([f'pywin32>=1.0; sys_platform == "{other}"'])
+            return self._meta([])
+
+        mock_meta.side_effect = fake_meta
+        specs: dict[str, list[str]] = {}
+        _gather_requirements("mypkg", frozenset(), specs, set())
+        self.assertNotIn("pywin32", specs)
+
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_pypi_error_handled_gracefully(self, mock_meta):
+        """PyPIInstallError during gather does not propagate."""
+        mock_meta.side_effect = PyPIInstallError("network down")
+        specs: dict[str, list[str]] = {}
+        # Should not raise; install pass will surface the real error
+        _gather_requirements("mypkg", frozenset(), specs, set())
+        self.assertEqual(specs, {})
+
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_null_requires_dist_handled(self, mock_meta):
+        """info.requires_dist == None does not raise."""
+        mock_meta.return_value = {"info": {"requires_dist": None}, "releases": {}}
+        specs: dict[str, list[str]] = {}
+        _gather_requirements("mypkg", frozenset(), specs, set())
+        self.assertEqual(specs, {})
+
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_missing_info_key_handled(self, mock_meta):
+        """Missing info key does not raise."""
+        mock_meta.return_value = {"releases": {}}
+        specs: dict[str, list[str]] = {}
+        _gather_requirements("mypkg", frozenset(), specs, set())
+        self.assertEqual(specs, {})
+
+
+# -------------------------------------------------------------------------
+#
+# TestFindSatisfyingVersion
+#
+# -------------------------------------------------------------------------
+class TestFindSatisfyingVersion(unittest.TestCase):
+    def _meta_with_releases(self, versions: list[str]) -> dict:
+        """Build a minimal PyPI JSON dict with the given release versions."""
+        releases = {
+            v: [{"filename": f"pkg-{v}-py3-none-any.whl", "url": f"u/{v}"}]
+            for v in versions
+        }
+        return {"info": {}, "urls": [], "releases": releases}
+
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_returns_newest_for_empty_spec(self, mock_meta):
+        """An empty spec returns the newest available version."""
+        mock_meta.return_value = self._meta_with_releases(["1.0", "1.10", "1.2"])
+        result = _find_satisfying_version("pkg", "")
+        self.assertEqual(result, "1.10")
+
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_returns_newest_satisfying_gte(self, mock_meta):
+        """>=1.5 returns the newest version that is at least 1.5."""
+        mock_meta.return_value = self._meta_with_releases(["1.0", "1.5", "2.0", "3.0"])
+        result = _find_satisfying_version("pkg", ">=1.5")
+        self.assertEqual(result, "3.0")
+
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_returns_newest_satisfying_range(self, mock_meta):
+        """>=1.0,<2.0 returns the newest 1.x version."""
+        mock_meta.return_value = self._meta_with_releases(
+            ["0.9", "1.5", "1.9", "2.0", "3.0"]
+        )
+        result = _find_satisfying_version("pkg", ">=1.0,<2.0")
+        self.assertEqual(result, "1.9")
+
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_returns_none_when_no_version_satisfies(self, mock_meta):
+        """Returns None when no release satisfies the combined spec."""
+        mock_meta.return_value = self._meta_with_releases(["1.0", "1.5"])
+        result = _find_satisfying_version("pkg", ">=2.0")
+        self.assertIsNone(result)
+
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_returns_none_on_pypi_error(self, mock_meta):
+        """Returns None when _pypi_metadata raises PyPIInstallError."""
+        mock_meta.side_effect = PyPIInstallError("unreachable")
+        result = _find_satisfying_version("pkg", ">=1.0")
+        self.assertIsNone(result)
+
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_returns_none_on_empty_releases(self, mock_meta):
+        """Returns None when the releases dict is empty."""
+        mock_meta.return_value = {"info": {}, "releases": {}}
+        result = _find_satisfying_version("pkg", "")
+        self.assertIsNone(result)
+
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_skips_prerelease_versions(self, mock_meta):
+        """Pre-release versions are skipped; the newest stable is returned."""
+        mock_meta.return_value = {
+            "info": {},
+            "releases": {
+                "2.0a1": [{"filename": "pkg-2.0a1-py3-none-any.whl", "yanked": False}],
+                "1.9": [{"filename": "pkg-1.9-py3-none-any.whl", "yanked": False}],
+                "1.8": [{"filename": "pkg-1.8-py3-none-any.whl", "yanked": False}],
+            },
+        }
+        result = _find_satisfying_version("pkg", "")
+        self.assertEqual(result, "1.9")
+
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_skips_yanked_versions(self, mock_meta):
+        """Fully-yanked releases are skipped."""
+        mock_meta.return_value = {
+            "info": {},
+            "releases": {
+                "2.0": [{"filename": "pkg-2.0-py3-none-any.whl", "yanked": True}],
+                "1.9": [{"filename": "pkg-1.9-py3-none-any.whl", "yanked": False}],
+            },
+        }
+        result = _find_satisfying_version("pkg", "")
+        self.assertEqual(result, "1.9")
+
+    @patch("gramps.gen.utils.pypi._pypi_metadata")
+    def test_post_release_not_skipped(self, mock_meta):
+        """Post-releases (.postN) are not treated as pre-releases."""
+        mock_meta.return_value = {
+            "info": {},
+            "releases": {
+                "1.0.post1": [
+                    {"filename": "pkg-1.0.post1-py3-none-any.whl", "yanked": False}
+                ],
+                "1.0": [{"filename": "pkg-1.0-py3-none-any.whl", "yanked": False}],
+            },
+        }
+        result = _find_satisfying_version("pkg", "")
+        self.assertEqual(result, "1.0.post1")
+
+
+# -------------------------------------------------------------------------
+#
+# TestPickWheelVersion
+#
+# -------------------------------------------------------------------------
+class TestPickWheelVersion(unittest.TestCase):
+    def _meta_with_version(self, version: str, filename: str) -> dict:
+        """Build a minimal PyPI JSON dict with a single release."""
+        return {
+            "urls": [],
+            "releases": {
+                version: [
+                    {
+                        "filename": filename,
+                        "url": f"https://example.com/{filename}",
+                        "digests": {},
+                    }
+                ]
+            },
+        }
+
+    def test_pinned_version_selects_release_files(self):
+        """When version is given, files from that release are used."""
+        meta = self._meta_with_version("1.5", "pkg-1.5-py3-none-any.whl")
+        result = _pick_wheel(meta, "pkg", version="1.5")
+        self.assertEqual(result["filename"], "pkg-1.5-py3-none-any.whl")
+
+    def test_pinned_version_not_found_raises(self):
+        """A pinned version with no compatible wheel raises PyPIInstallError."""
+        meta = self._meta_with_version("1.5", "pkg-1.5-py3-none-any.whl")
+        with self.assertRaises(PyPIInstallError):
+            _pick_wheel(meta, "pkg", version="9.9")
+
+    def test_pinned_version_no_compatible_wheel_raises(self):
+        """A pinned version present in releases but incompatible raises."""
+        with patch(
+            "gramps.gen.utils.pypi._compatible_tags",
+            return_value=(set(), set(), set()),
+        ):
+            meta = self._meta_with_version(
+                "1.5", "pkg-1.5-cp311-cp311-linux_x86_64.whl"
+            )
+            with self.assertRaises(PyPIInstallError):
+                _pick_wheel(meta, "pkg", version="1.5")
+
+    def test_yanked_wheel_in_urls_skipped(self):
+        """A yanked file in meta['urls'] is not returned."""
+        meta = {
+            "urls": [
+                {
+                    "filename": "pkg-1.0-py3-none-any.whl",
+                    "url": "u",
+                    "digests": {},
+                    "yanked": True,
+                }
+            ],
+            "releases": {},
+        }
+        with self.assertRaises(PyPIInstallError):
+            _pick_wheel(meta, "pkg")
+
+    def test_requires_python_mismatch_skipped(self):
+        """A wheel whose requires_python the interpreter doesn't satisfy is skipped."""
+        meta = {
+            "urls": [
+                {
+                    "filename": "pkg-1.0-py3-none-any.whl",
+                    "url": "u",
+                    "digests": {},
+                    "requires_python": ">=99.0",
+                    "yanked": False,
+                }
+            ],
+            "releases": {},
+        }
+        with self.assertRaises(PyPIInstallError):
+            _pick_wheel(meta, "pkg")
+
+    def test_requires_python_satisfied_returned(self):
+        """A wheel whose requires_python is satisfied is returned normally."""
+        meta = {
+            "urls": [
+                {
+                    "filename": "pkg-1.0-py3-none-any.whl",
+                    "url": "u",
+                    "digests": {},
+                    "requires_python": ">=2.7",
+                    "yanked": False,
+                }
+            ],
+            "releases": {},
+        }
+        result = _pick_wheel(meta, "pkg")
+        self.assertEqual(result["filename"], "pkg-1.0-py3-none-any.whl")
+
+
+# -------------------------------------------------------------------------
+#
+# TestGlibcVersion
+#
+# -------------------------------------------------------------------------
+class TestGlibcVersion(unittest.TestCase):
+    def setUp(self):
+        _glibc_version.cache_clear()
+
+    def tearDown(self):
+        _glibc_version.cache_clear()
+
+    def test_ctypes_path_returns_tuple(self):
+        """_glibc_version returns (major, minor) when gnu_get_libc_version is found."""
+        import gramps.gen.utils.pypi as pypi_mod
+        from unittest.mock import MagicMock
+
+        mock_ns = MagicMock()
+        mock_fn = MagicMock(return_value=b"2.31")
+        mock_ns.gnu_get_libc_version = mock_fn
+        with patch("gramps.gen.utils.pypi.ctypes") as mock_ctypes:
+            mock_ctypes.CDLL.return_value = mock_ns
+            mock_ctypes.c_char_p = str  # restype assignment must not raise
+            _glibc_version.cache_clear()
+            result = _glibc_version()
+        self.assertEqual(result, (2, 31))
+
+    def test_fallback_to_platform_libc_ver(self):
+        """Falls back to platform.libc_ver when ctypes path raises."""
+        import gramps.gen.utils.pypi as pypi_mod
+
+        with patch("gramps.gen.utils.pypi.ctypes") as mock_ctypes:
+            mock_ctypes.CDLL.side_effect = OSError("no ctypes")
+            with patch("platform.libc_ver", return_value=("glibc", "2.17")):
+                _glibc_version.cache_clear()
+                result = _glibc_version()
+        self.assertEqual(result, (2, 17))
+
+    def test_returns_none_on_non_glibc(self):
+        """Returns None when both ctypes and platform.libc_ver report non-glibc."""
+        with patch("gramps.gen.utils.pypi.ctypes") as mock_ctypes:
+            mock_ctypes.CDLL.side_effect = OSError("no ctypes")
+            with patch("platform.libc_ver", return_value=("musl", "1.2")):
+                _glibc_version.cache_clear()
+                result = _glibc_version()
+        self.assertIsNone(result)
+
+    def test_result_is_cached(self):
+        """Calling _glibc_version twice returns the same object."""
+        first = _glibc_version()
+        second = _glibc_version()
+        self.assertEqual(first, second)
+
+
+# -------------------------------------------------------------------------
+#
+# TestMuslVersion
+#
+# -------------------------------------------------------------------------
+class TestMuslVersion(unittest.TestCase):
+    def setUp(self):
+        _musl_version.cache_clear()
+
+    def tearDown(self):
+        _musl_version.cache_clear()
+
+    def test_returns_version_when_linker_present(self):
+        """Returns (major, minor) when the musl linker exists and prints its version."""
+        with patch("platform.machine", return_value="x86_64"):
+            with patch("os.path.exists", return_value=True):
+                with patch("subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(
+                        stdout="musl libc (x86_64)\nVersion 1.2.3\n",
+                        stderr="",
+                    )
+                    _musl_version.cache_clear()
+                    result = _musl_version()
+        self.assertEqual(result, (1, 2))
+
+    def test_returns_none_when_linker_absent(self):
+        """Returns None when the musl dynamic linker file does not exist."""
+        with patch("platform.machine", return_value="x86_64"):
+            with patch("os.path.exists", return_value=False):
+                _musl_version.cache_clear()
+                result = _musl_version()
+        self.assertIsNone(result)
+
+    def test_returns_none_when_subprocess_raises(self):
+        """Returns None when running the musl linker raises an exception."""
+        with patch("platform.machine", return_value="x86_64"):
+            with patch("os.path.exists", return_value=True):
+                with patch("subprocess.run", side_effect=OSError("exec failed")):
+                    _musl_version.cache_clear()
+                    result = _musl_version()
+        self.assertIsNone(result)
+
+    def test_arm_variant_normalised(self):
+        """armv7l and other armv* are mapped to 'arm' for the linker path."""
+        seen_paths = []
+
+        def fake_exists(path):
+            seen_paths.append(path)
+            return False
+
+        with patch("platform.machine", return_value="armv7l"):
+            with patch("os.path.exists", side_effect=fake_exists):
+                _musl_version.cache_clear()
+                _musl_version()
+        self.assertTrue(any("ld-musl-arm.so.1" in p for p in seen_paths))
+
+
+# -------------------------------------------------------------------------
+#
+# TestManylinuxPlatformTags
+#
+# -------------------------------------------------------------------------
+class TestManylinuxPlatformTags(unittest.TestCase):
+    def test_pep600_tags_generated(self):
+        """PEP 600 manylinux_2_Y tags are generated for Y from 5 to glibc_minor."""
+        tags = _manylinux_platform_tags("x86_64", 2, 31)
+        self.assertIn("manylinux_2_5_x86_64", tags)
+        self.assertIn("manylinux_2_17_x86_64", tags)
+        self.assertIn("manylinux_2_31_x86_64", tags)
+        self.assertNotIn("manylinux_2_32_x86_64", tags)
+        self.assertNotIn("manylinux_2_4_x86_64", tags)
+
+    def test_legacy_aliases_x86_64(self):
+        """manylinux1, manylinux2010, and manylinux2014 are added for x86_64."""
+        tags = _manylinux_platform_tags("x86_64", 2, 31)
+        self.assertIn("manylinux1_x86_64", tags)
+        self.assertIn("manylinux2010_x86_64", tags)
+        self.assertIn("manylinux2014_x86_64", tags)
+
+    def test_legacy_aliases_aarch64(self):
+        """Only manylinux2014 alias is generated for aarch64."""
+        tags = _manylinux_platform_tags("aarch64", 2, 28)
+        self.assertNotIn("manylinux1_aarch64", tags)
+        self.assertNotIn("manylinux2010_aarch64", tags)
+        self.assertIn("manylinux2014_aarch64", tags)
+
+    def test_no_manylinux1_below_2_5(self):
+        """manylinux1 is not generated when glibc_minor < 5."""
+        tags = _manylinux_platform_tags("x86_64", 2, 4)
+        self.assertNotIn("manylinux1_x86_64", tags)
+
+    def test_no_manylinux2010_below_2_12(self):
+        """manylinux2010 is not generated when glibc_minor < 12."""
+        tags = _manylinux_platform_tags("x86_64", 2, 11)
+        self.assertNotIn("manylinux2010_x86_64", tags)
+        self.assertIn("manylinux1_x86_64", tags)
+
+    def test_no_manylinux2014_below_2_17(self):
+        """manylinux2014 is not generated when glibc_minor < 17."""
+        tags = _manylinux_platform_tags("x86_64", 2, 16)
+        self.assertNotIn("manylinux2014_x86_64", tags)
+        self.assertIn("manylinux2010_x86_64", tags)
+
+    def test_non_x86_arch_gets_no_manylinux1(self):
+        """ppc64le does not get manylinux1 or manylinux2010 aliases."""
+        tags = _manylinux_platform_tags("ppc64le", 2, 31)
+        self.assertNotIn("manylinux1_ppc64le", tags)
+        self.assertNotIn("manylinux2010_ppc64le", tags)
+        self.assertIn("manylinux2014_ppc64le", tags)
+
+    def test_unknown_arch_gets_no_legacy_aliases(self):
+        """An unrecognised arch gets PEP 600 tags but no legacy aliases."""
+        tags = _manylinux_platform_tags("riscv64", 2, 35)
+        self.assertIn("manylinux_2_17_riscv64", tags)
+        self.assertNotIn("manylinux1_riscv64", tags)
+        self.assertNotIn("manylinux2010_riscv64", tags)
+        self.assertNotIn("manylinux2014_riscv64", tags)
+
+    def test_glibc_major_not_2_returns_empty(self):
+        """Non-2.x glibc returns an empty tag set."""
+        tags = _manylinux_platform_tags("x86_64", 3, 0)
+        self.assertEqual(tags, set())
+
+
+# -------------------------------------------------------------------------
+#
+# Extended TestCompatibleTags — Linux manylinux/musllinux
+#
+# -------------------------------------------------------------------------
+class TestCompatibleTagsLinux(unittest.TestCase):
+    def setUp(self):
+        import gramps.gen.utils.pypi as pypi_mod
+
+        pypi_mod._COMPAT_TAGS = None
+
+    def tearDown(self):
+        import gramps.gen.utils.pypi as pypi_mod
+
+        pypi_mod._COMPAT_TAGS = None
+
+    def _linux_tags(
+        self,
+        machine: str = "x86_64",
+        glibc: tuple[int, int] | None = (2, 31),
+        musl: tuple[int, int] | None = None,
+    ) -> set[str]:
+        """Return plat_tags for a patched Linux environment."""
+        import gramps.gen.utils.pypi as pypi_mod
+
+        pypi_mod._COMPAT_TAGS = None
+        with patch("platform.system", return_value="Linux"):
+            with patch("platform.machine", return_value=machine):
+                with patch("gramps.gen.utils.pypi._glibc_version", return_value=glibc):
+                    with patch(
+                        "gramps.gen.utils.pypi._musl_version", return_value=musl
+                    ):
+                        _, _, plat_tags = _compatible_tags()
+        return plat_tags
+
+    def test_manylinux_tags_present_on_glibc_system(self):
+        """manylinux tags are generated when glibc is detectable."""
+        tags = self._linux_tags(machine="x86_64", glibc=(2, 31))
+        self.assertIn("manylinux_2_17_x86_64", tags)
+        self.assertIn("manylinux_2_31_x86_64", tags)
+        self.assertIn("manylinux1_x86_64", tags)
+        self.assertIn("manylinux2014_x86_64", tags)
+
+    def test_bare_linux_tag_always_present(self):
+        """linux_{arch} is always included regardless of libc."""
+        tags = self._linux_tags(machine="x86_64", glibc=(2, 31))
+        self.assertIn("linux_x86_64", tags)
+
+    def test_no_manylinux_when_glibc_undetected(self):
+        """No manylinux tags when glibc detection returns None."""
+        tags = self._linux_tags(machine="x86_64", glibc=None)
+        self.assertFalse(any(t.startswith("manylinux") for t in tags))
+        self.assertIn("linux_x86_64", tags)
+
+    def test_musllinux_tags_present_on_musl_system(self):
+        """musllinux tags are generated when musl is detectable."""
+        tags = self._linux_tags(machine="x86_64", glibc=None, musl=(1, 2))
+        self.assertIn("musllinux_1_1_x86_64", tags)
+        self.assertIn("musllinux_1_2_x86_64", tags)
+        self.assertNotIn("musllinux_1_3_x86_64", tags)
+
+    def test_musllinux_and_manylinux_mutually_exclusive_in_practice(self):
+        """On a pure musl system glibc returns None and no manylinux tags appear."""
+        tags = self._linux_tags(machine="x86_64", glibc=None, musl=(1, 2))
+        self.assertFalse(any(t.startswith("manylinux") for t in tags))
+
+    def test_aarch64_manylinux2014_present(self):
+        """aarch64 gets manylinux2014 and PEP 600 tags but not manylinux1."""
+        tags = self._linux_tags(machine="aarch64", glibc=(2, 28))
+        self.assertIn("manylinux2014_aarch64", tags)
+        self.assertIn("manylinux_2_17_aarch64", tags)
+        self.assertNotIn("manylinux1_aarch64", tags)
+
+    def test_any_always_present_on_linux(self):
+        """\"any\" is always in plat_tags on Linux."""
+        tags = self._linux_tags()
+        self.assertIn("any", tags)
+
+    def test_manylinux_wheel_compatible_on_glibc_system(self):
+        """_is_compatible_wheel matches a manylinux2014 wheel on a glibc system."""
+        import gramps.gen.utils.pypi as pypi_mod
+
+        pypi_mod._COMPAT_TAGS = None
+        with patch("platform.system", return_value="Linux"):
+            with patch("platform.machine", return_value="x86_64"):
+                with patch(
+                    "gramps.gen.utils.pypi._glibc_version", return_value=(2, 31)
+                ):
+                    with patch(
+                        "gramps.gen.utils.pypi._musl_version", return_value=None
+                    ):
+                        # Use py3-none tags so the test is Python-version-agnostic;
+                        # "py3" and "none" are always in the compat sets.
+                        info = {
+                            "filename": "pkg-1.0-py3-none-manylinux_2_17_x86_64.whl"
+                        }
+                        self.assertTrue(_is_compatible_wheel(info))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gui/plug/_windows.py
+++ b/gramps/gui/plug/_windows.py
@@ -28,9 +28,9 @@
 import traceback
 import os
 from html import escape
+import subprocess
 import threading
 import sys
-import subprocess
 import importlib
 
 # -------------------------------------------------------------------------
@@ -93,6 +93,13 @@ from gramps.gen.plug.utils import get_all_addons, available_updates
 from ..display import display_help, display_url
 from gramps.gui.widgets import BasicLabel, SimpleButton
 from gramps.gen.utils.requirements import Requirements
+from gramps.gen.utils.pypi import (
+    PyPIInstallError,
+    _pip_available,
+    install_package,
+    is_frozen,
+    resolve_pypi_name,
+)
 from gramps.gen.const import USER_PLUGINS, LIB_PATH
 from gramps.gen.constfunc import win
 from gramps.version import major_version
@@ -272,7 +279,7 @@ class AddonRow(Gtk.ListBoxRow):
             b2.connect("clicked", self.__on_wiki_clicked, addon["h"])
             bb.pack_start(b2, False, False, 0)
 
-        if not req.check_addon(addon):
+        if not req.check_addon(addon) or addon.get("rm"):
             b3 = Gtk.Button(label=_("Requires"))
             b3.connect("clicked", self.__on_requires_clicked, addon)
             bb.pack_start(b3, False, False, 0)
@@ -285,31 +292,51 @@ class AddonRow(Gtk.ListBoxRow):
         vbox.pack_start(bb, False, False, 0)
         vbox.show_all()
 
+    def _install_python_deps(self, button: Gtk.Button, addon: dict) -> bool:
+        """Install Python module dependencies declared by *addon*.
+
+        Returns True on success.  On failure, disables *button*, shows an
+        error dialog, and returns False.
+        """
+        for package in self.req.install(addon):
+            # Translate import names (e.g. "PIL") to PyPI names ("Pillow").
+            pypi_name = resolve_pypi_name(package)
+            try:
+                if is_frozen() or not _pip_available():
+                    # Frozen bundles (cx_Freeze/AIO, macOS .app) and pip-less
+                    # environments (Flatpak, stripped Docker): use the stdlib
+                    # wheel installer, which now supports manylinux/musllinux.
+                    install_package(pypi_name, LIB_PATH)
+                else:
+                    # Source / snap installs where pip is available.
+                    subprocess.check_output(
+                        [
+                            sys.executable,
+                            "-m",
+                            "pip",
+                            "install",
+                            "--target",
+                            LIB_PATH,
+                            pypi_name,
+                        ],
+                        stderr=subprocess.STDOUT,
+                    )
+            except (PyPIInstallError, subprocess.CalledProcessError) as err:
+                button.set_sensitive(False)
+                InfoDialog(
+                    _("Module installation failed"),
+                    str(err),
+                    parent=self.window,
+                )
+                return False
+        return True
+
     def __on_install_clicked(self, button, addon):
         """
         Install the addon and possibly some required python modules.
         """
-        # Install required modules
-        for package in self.req.install(addon):
-            try:
-                subprocess.check_output(
-                    [
-                        "pip.exe" if win() else "pip",
-                        "install",
-                        "--target",
-                        LIB_PATH,
-                        package,
-                    ],
-                    stderr=subprocess.STDOUT,
-                )
-            except subprocess.CalledProcessError as err:
-                button.set_sensitive(False)
-                InfoDialog(
-                    _("Module installation failed"),
-                    err.output.decode("utf-8"),
-                    parent=self.window,
-                )
-                return
+        if not self._install_python_deps(button, addon):
+            return
 
         # Invalidate the caches to ensure that the new modules will be found.
         importlib.invalidate_caches()
@@ -322,17 +349,31 @@ class AddonRow(Gtk.ListBoxRow):
             )
             return
 
+        # Install addon dependencies declared via depends_on ("do" field).
+        # Install their Python module requirements first.
+        pmgr = GuiPluginManager.get_instance()
+        for dep_id in addon.get("do", []):
+            if pmgr.get_plugin(dep_id) is None:
+                dep = self.manager.find_addon(dep_id)
+                if dep is not None:
+                    if not self._install_python_deps(button, dep):
+                        return
+                    importlib.invalidate_caches()
+                    dep_path = dep["_u"] + "/download/" + dep["z"]
+                    if load_addon_file(dep_path):
+                        self.manager.install_addon(dep_id)
+
         # Install addon
         path = addon["_u"] + "/download/" + addon["z"]
-        load_addon_file(path)
+        if not load_addon_file(path):
+            InfoDialog(
+                _("Addon installation failed"),
+                _("Gramps was unable to install '%s'.") % addon["n"],
+                parent=self.window,
+            )
+            return
         self.manager.install_addon(addon["i"])
-
-        # Refresh this row
-        pmgr = GuiPluginManager.get_instance()
-        plugin = pmgr.get_plugin(addon["i"])
-        if plugin:
-            self.addon["_v"] = plugin.version
-        self.__build_gui(self.vbox, self.addon, self.req)
+        self.manager.refresh()
 
     def __on_wiki_clicked(self, button, url):
         """
@@ -607,9 +648,19 @@ class AddonManager(ManagedWindow):
         """
         Populate the list box.
         """
+        self._addon_list = addon_list
         for addon in addon_list:
             self.lb.add(AddonRow(self, addon, self.req, self.window))
         self.__placeholder(_("No matching addons found."))
+
+    def find_addon(self, addon_id):
+        """
+        Return the addon dict for the given plugin ID, or None if not found.
+        """
+        for addon in getattr(self, "_addon_list", []):
+            if addon["i"] == addon_id:
+                return addon
+        return None
 
     def __clear_filters(self, combo):
         """

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -408,6 +408,7 @@ gramps/gen/utils/image.py
 gramps/gen/utils/keyword.py
 gramps/gen/utils/lds.py
 gramps/gen/utils/place.py
+gramps/gen/utils/pypi.py
 gramps/gen/utils/requirements.py
 gramps/gen/utils/string.py
 gramps/gen/utils/symbols.py

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -332,6 +332,8 @@ gramps/gen/utils/test/grampslocale_test.py
 gramps/gen/utils/test/keyword_test.py
 gramps/gen/utils/test/maclocale_test.py
 gramps/gen/utils/test/place_test.py
+gramps/gen/utils/test/pypi_e2e_test.py
+gramps/gen/utils/test/pypi_test.py
 gramps/gen/utils/test/requirements_test.py
 #
 # gui - GUI code


### PR DESCRIPTION
## Problem

Addon plugins can declare Python module dependencies via `requires_mod`. When a user installs such an addon, Gramps is supposed to install the missing modules into `LIB_PATH` (`~/.gramps/gramps6x/plugins/lib/`). This did not work on Windows AIO or Mac `.app` bundles:

- **Windows AIO**: `pip.exe` is a cx_Freeze binary running in its own Python context, separate from Gramps's interpreter.
- **Mac bundle**: `sys.executable` is the Gramps C launcher, not a Python interpreter, so subprocess calls raise `PermissionError`. pip is present in the bundle but its SSL layer calls `certifi.where()`, which returns a path to `cacert.pem` — a data file that was never bundled — causing `FileNotFoundError` before any `--cert` flag is read.

A second independent bug: `Requirements.check_mod()` used `find_spec()` to test whether a module was available. `find_spec()` only checks whether a module file exists on `sys.path` — it does not attempt to load it. A compiled extension (`.so` / `.pyd`) whose native library dependencies are missing passes `find_spec()` but raises `ImportError` when actually imported. This caused the addon manager to report a broken module as satisfied and then fail silently.

Two additional Addon Manager bugs are also fixed in this PR:

- **Shared-tgz install conflict**: Multiple addons sharing the same `.addon.tgz` (e.g. SQLite Import + Export, PDFForms) each appear as separate installable entries. Installing the second entry re-extracted the tgz into an already-existing directory, causing an `OSError` on Mac. The return value of `load_addon_file` was never checked so the failure was silent.

- **Sibling plugins not marked installed**: After installing one entry from a shared tgz, the other entries from the same tgz stayed showing an "Install" button (only the clicked row was refreshed). Clicking Install again triggered the conflict above.

See also: #2303

## Fix

### Installer — `gramps/gen/utils/pypi.py` (new) and `gramps/gui/plug/_windows.py`

The install path is now split based on whether Gramps is running inside a frozen bundle (`sys.frozen`):

**Frozen bundles (Windows AIO, Mac .app):** A new stdlib-only module `gramps/gen/utils/pypi.py` downloads and installs wheels from PyPI directly, with no subprocess or external binary required:

- **`install_package(package, target)`** — public API, drop-in replacement for the old pip call
- Fetches wheel metadata from the PyPI JSON API
- Verifies SHA-256 of the downloaded wheel before extracting
- Extracts using `zipfile` (wheels are zips)
- Recursively installs direct dependencies (`Requires-Dist` entries), and checks version constraints — if a dep is already importable but its installed version does not satisfy the declared spec (e.g. `>=2.0`) it is reinstalled
- **Network requests time out after 30 s** — a slow or unreachable PyPI will raise an error rather than hanging the UI indefinitely
- **SSL uses `ssl.create_default_context()`** — system trust store on all platforms, no certifi or `cacert.pem` required
- **Supports both pure-Python and compiled wheels.** Pure wheels (`py3-none-any`) are preferred; if none is available, the installer selects a compiled wheel matching the current Python version and platform (Windows: `win_amd64` / `win_arm64` / `win32`; macOS: `macosx_X_Y_{arm64,x86_64,universal2}` spanning all versions back to 10.4).

**Source / snap installs with pip:** `_pip_available()` probes whether `sys.executable -m pip --version` succeeds (result cached). When pip is available, it is used via `sys.executable -m pip install --target`; pip handles all wheel formats natively.

**Flatpak / pip-less environments:** Flathub and other sandboxed runtimes strip `pip` from the Python installation. `_pip_available()` returns `False` and the stdlib installer is used instead — exactly as for frozen bundles.

The stdlib installer now supports compiled Linux wheels as well: `_compatible_tags()` detects glibc (via `ctypes.gnu_get_libc_version()`, falling back to `platform.libc_ver()`) and musl (by probing `/lib/ld-musl-{arch}.so.1`) and generates the full manylinux / musllinux tag set — PEP 600 perennial tags plus the three legacy aliases (manylinux1, manylinux2010, manylinux2014) where the architecture qualifies. The bare `linux_{arch}` tag is still included as a fallback.

**Platform-conditional `Requires-Dist` entries evaluated, not skipped:** Previously every dependency line containing a `;` marker was unconditionally dropped. Now a full PEP 508 marker evaluator is used: `sys_platform`, `python_version`, `platform_system`, `implementation_name`, `extra`, and all other standard marker variables are supported; comparisons of version variables (`python_version`, `python_full_version`, `implementation_version`) use tuple ordering rather than lexicographic string ordering; `and`, `or`, `not`, parentheses, and the `in` / `not in` operators are all handled. Markers that fail to parse are treated as `True` (dep included) to avoid silently dropping dependencies. Examples: `pywin32; sys_platform == "win32"` is installed on Windows and skipped on Linux; `importlib-metadata>=3.6; python_version < "3.10"` is skipped on Python 3.10+.

**Extras on transitive deps propagated:** A dependency declared as e.g. `requests[security]>=2.0` previously had its extras silently dropped, and the version spec was parsed incorrectly as `"[security]>=2.0"`. Now `_direct_dependencies()` uses a compiled PEP 508 regex to correctly separate name, bracket-extras, version spec, and marker. Dep-extras are forwarded to recursive `_install_one()` calls so that `extra == "foo"` markers within the transitive dependency are evaluated correctly. `install_package()` also accepts a top-level `extras` parameter and parses extras embedded in the package name (e.g. `install_package("requests[security]", target)` activates the `security` extra automatically).

**Version-conflict resolution (tier 1):** `install_package` now performs a three-pass install instead of a single DFS:

1. **Gather** (`_gather_requirements`): traverses the full dependency graph using `meta["info"]["requires_dist"]` from the PyPI JSON API — no wheels are downloaded in this pass. Collects all version constraints from every path through the graph into a `dict[str, list[str]]`. Already-importable packages are skipped (they will also be skipped in the install pass).

2. **Resolve** (`_find_satisfying_version`): for each package that has at least one version constraint, scans `meta["releases"]` newest-first and returns the newest **stable** release satisfying the combined constraint string. Pre-releases (`aN`, `bN`, `rcN`, `.devN`) and fully-yanked releases (all files carry `"yanked": true`) are skipped. Raises `PyPIInstallError` immediately when no version satisfies the intersection (e.g. one dep requires `>=2.0` while another requires `<1.5`).

3. **Install**: unchanged DFS pass, but `_pick_wheel` now accepts an optional `version=` parameter so the install pass uses the exact version chosen in the resolve pass rather than always picking the latest.

`_pypi_metadata` is now decorated with `@functools.cache` so that the gather and install passes share the same PyPI response without a second network round-trip.

Known limitation: constraint gathering reads the *latest* release's dep list; if an older version is resolved, its actual transitive dependencies may differ slightly (addressed in a future tier).

**Wheel quality filters:** `_pick_wheel` now skips files that should not be installed on the running interpreter:

- **Yanked files** (`"yanked": true` in the PyPI API response) are excluded from all search paths — latest release, older releases, and pinned-version installs. A release is used only if at least one of its files is not yanked.
- **`Requires-Python` constraint** (`requires_python` field on each file entry) is validated against the running interpreter's `major.minor` version before a wheel is selected. A wheel declaring `Requires-Python: >=3.12` will not be chosen on Python 3.9.

Both filters apply in `_pick_wheel` regardless of whether the call comes from the unversioned (latest) path or the pinned-version path.

**Import name → PyPI name mapping:** Addon `requires_mod` entries use Python import names (e.g. `"PIL"`, `"yaml"`, `"bs4"`) which often differ from PyPI distribution names (`"Pillow"`, `"PyYAML"`, `"beautifulsoup4"`). `resolve_pypi_name()` translates known mismatches via a built-in `_IMPORT_TO_PYPI` table before any install attempt. When a mapped name is encountered a `LOG.warning` is emitted so addon authors know to update `requires_mod` to use the correct PyPI name directly.

### check_mod — `gramps/gen/utils/requirements.py`

After `find_spec()` confirms a module file exists, attempt `import_module()`. If that raises `ImportError` (e.g. a compiled extension with a missing native library), return `False` so the addon manager correctly treats the module as unavailable. (Ported from #2303.)

### Addon Manager install fixes — `gramps/gui/plug/_windows.py`

- **Check `load_addon_file` return value**: if extraction fails (e.g. OSError on Mac when re-extracting into an existing directory), show an error dialog and abort instead of proceeding into a broken state.

- **Call `manager.refresh()` after install** instead of only rebuilding the clicked row. This marks all sibling plugins sharing the same tgz as installed and prevents the spurious second-install attempt.

- **Auto-install `depends_on` addons**: before installing an addon, check its `"do"` catalog field (populated from `depends_on` in the gpr.py by the build system) and automatically install any declared dependencies that are not yet registered.  Python module requirements (`requires_mod`) declared by those dependency addons are now installed as well, via the new shared `_install_python_deps()` helper.

## Bundle detection (`_is_frozen`)

`_is_frozen()` determines which install path to take. Most bundlers set `sys.frozen`, but some do not — notably older Briefcase versions on macOS and Nuitka/PyOxidizer on Windows. The function now uses three checks:

| Bundler | Platform | `sys.frozen` set? | Detected by |
|---|---|---|---|
| cx_Freeze | Win/Mac/Linux | ✓ `True` | `sys.frozen` check |
| PyInstaller | Win/Mac/Linux | ✓ `True` | `sys.frozen` check |
| py2app | macOS | ✓ `'macosx_app'` | `sys.frozen` check (truthy) |
| py2exe | Windows | ✓ `True`/`'dll'` | `sys.frozen` check |
| Briefcase (new) | Win/Mac | ✓ `True` | `sys.frozen` check |
| Briefcase (old) / unknown | macOS | ✗ | `.app` path check |
| Nuitka | Windows | ✗ | `basename != python*.exe` check |
| PyOxidizer | Windows | ✗ | `basename != python*.exe` check |

The `.app` path check catches bundles where `sys.executable` ends with `.app` or contains `.app/` (e.g. a user running from `/Users/john/Desktop/Gramps.app`). The Windows basename check catches bundles where `sys.executable` is a named app binary (`Gramps.exe`) rather than a Python interpreter (`python.exe`, `python3.12.exe`, etc.).

## Tests

**Unit tests** (`gramps/gen/utils/test/pypi_test.py`) — 200 tests, no network required, all logic mocked:
- `_is_pure_wheel`: 7 cases covering both pure tags, platform wheels, abi3, tarballs, malformed filenames
- `_compatible_tags`: 9 existing cases (Windows AMD64/ARM64, macOS arm64, macOS x86_64, cache behaviour, always-present tags) + 8 new Linux cases (manylinux tag generation, musllinux tag generation, bare linux fallback, aarch64/ppc64le arch coverage)
- `_glibc_version`: ctypes path, `platform.libc_ver()` fallback, returns None on non-glibc, caching
- `_musl_version`: linker found + version parsed, linker absent, subprocess error, ARM arch normalisation
- `_manylinux_platform_tags`: PEP 600 tag range, all three legacy aliases, arch restrictions, glibc != 2 guard
- `_is_compatible_wheel`: 8 cases — matching compiled wheel, platform mismatch, Python version mismatch, abi3 wheel, dot-joined multi-tag platform field, tarball, too-few parts, empty compat sets
- `_is_prerelease`: 6 cases — alpha (`1.0a1`), beta (`1.0b1`), release candidate (`2.0rc1`), dev release (`1.0.dev0`), stable release (`1.0.0`), post-release (`1.0.post1`) correctly classified as stable
- `_is_yanked`: 4 cases — boolean `True`, truthy reason string, boolean `False`, absent key
- `_requires_python_ok`: 6 cases — no constraint (always True), satisfied `>=` constraint, unsatisfied `>=` constraint, satisfied range, unsatisfied upper bound, malformed spec treated as satisfied
- `_verify_sha256`: correct hash, mismatch, empty bytes
- `_wheel_metadata`: name/version parsing, multi-value `Requires-Dist`, missing METADATA
- `_tokenize_marker`: 7 cases — two-char operators, `not in` merging, single-quoted strings, whitespace
- `_eval_marker`: 17 cases — `sys_platform` equality, `python_version` numeric ordering (catches `"3.10" > "3.9"` lexicographic trap), `extra ==` with/without matching extras, `and`/`or`/`not`, parentheses, parse-error safety
- `_direct_dependencies`: returns `(name, spec, dep_extras)` triples — bare names, preserved version constraints, platform markers evaluated for current/non-current platform, extras markers with/without requested extras, dep-extras parsed (single and multiple), compound constraints
- `_gather_requirements`: 8 cases — versioned dep added to specs, unversioned dep not added, multiple constraints accumulated across packages, circular dep guard, platform-filtered dep not gathered, PyPIInstallError handled gracefully, null/missing `requires_dist`
- `_find_satisfying_version`: 10 cases — newest for empty spec, newest satisfying `>=`, range `>=X,<Y`, no version satisfies, PyPI unreachable, empty releases, pre-release skipped in favour of older stable release, fully-yanked release skipped, partially-yanked release used (non-yanked file present), pre-release selected when it is the only version satisfying the constraint
- `_pick_wheel`: selects pure from `urls`, compiled wheel fallback, falls back to `releases`, raises when nothing found; pinned-version variants: selects from release files, raises when pinned release has no compatible wheel; yanked file skipped, `Requires-Python`-incompatible wheel skipped
- `_satisfies_spec`: all seven PEP 440 operators, wildcard `==X.Y.*` / `!=X.Y.*`, compatible-release `~=` (two-part and three-part), compound specs
- `_version_satisfies`: satisfied, not satisfied, hyphenated-name fallback, missing dist-info returns True
- `resolve_pypi_name`: all mapped names, LOG.warning emitted for mapped names, no warning for pass-through names
- `install_package`: full happy path, skips importable modules, SHA-256 mismatch, no compatible wheel, network error, direct dep install, circular dep guard, platform-conditional dep skipped, extra dep installed/skipped based on requested extras, extras parsed from package name, version conflict resolved to correct release, unsatisfiable conflict raises PyPIInstallError

**End-to-end tests** (`gramps/gen/utils/test/pypi_e2e_test.py`) — 12 tests, hit real PyPI, auto-skipped when offline:
- SSL connectivity and JSON parsing without certifi
- Wheel selection on real `iniconfig` and `numpy` metadata
- Full download, SHA-256 verification, and extraction of a real wheel
- Package importable after adding extract target to `sys.path`
- `install_package()` skips already-importable packages without touching the filesystem

## Test plan

- [ ] Run unit tests: `python3 -m unittest gramps.gen.utils.test.pypi_test -v`
- [ ] Run e2e tests: `python3 -m unittest gramps.gen.utils.test.pypi_e2e_test -v`
- [ ] Install an addon with a pure-Python `requires_mod` dependency from source (pip path)
- [ ] Install an addon whose dependency already has an older version installed — verify the newer version satisfying the spec is installed
- [ ] Install an addon with conflicting transitive version constraints — verify the resolver picks a version satisfying all constraints, or shows a clear error if none exists
- [ ] Install an addon with a pure-Python `requires_mod` dependency on Flatpak / pip-less Linux
- [ ] Install an addon with a pure-Python `requires_mod` dependency on Mac `.app` bundle
- [ ] Install an addon with a pure-Python `requires_mod` dependency on Windows AIO
- [ ] Install an addon with a compiled `requires_mod` dependency on Mac `.app` bundle
- [ ] Install an addon with a compiled `requires_mod` dependency on Windows AIO
- [ ] Install an addon whose `requires_mod` entry uses a Python import name (e.g. `PIL`) — verify it installs correctly and a warning is logged
- [ ] Install an addon that has `requires_mod` with a platform-conditional dep (e.g. `pywin32; sys_platform == "win32"`) — verify it is installed on Windows but skipped on Linux/macOS
- [ ] Install an addon with `depends_on` that pulls in a package with extras (e.g. `requests[security]`) — verify the security extras' deps are also installed
- [ ] Install one addon from a shared-tgz pair — verify both show as installed after refresh
- [ ] Install an addon with `depends_on` — verify the dependency is auto-installed first

🤖 Generated with [Claude Code](https://claude.com/claude-code)