### PR TITLE
Don't use slots on GObject-derived classes.

### DIFF
--- a/gramps/gui/glade.py
+++ b/gramps/gui/glade.py
@@ -59,7 +59,14 @@ class Glade(Gtk.Builder):
     Glade class: Manage glade files as Gtk.Builder objects
     """
 
-    __slots__ = ["__toplevel", "__filename", "__dirname"]
+    def __setattr__(self, name, value):
+        if not hasattr(self, name) and name not in [
+            "__toplevel",
+            "__filename",
+            "__dirname",
+        ]:
+            raise AttributeError(f"Ad-hoc attribute {name} is not permitted.")
+        super().__setattr__(self, name, value)
 
     def __init__(self, filename=None, dirname=None, toplevel=None, also_load=[]):
         """


### PR DESCRIPTION
It conflicts with the PyGobject memory management, causing crashes especially with PyGobject 3.55.0 and later, see [PyGobject Issue 734](https://gitlab.gnome.org/GNOME/pygobject/-/issues/734). PyGobject 3.55.3 and later [deletes `__slots__` namespaces with a warning](https://gitlab.gnome.org/GNOME/pygobject/-/merge_requests/508). 

This PR removes the `__slots__` declaration from `class Glade`. To preserve the `__slots__` behavior of preventing ad-hoc member variable creation it adds a `__setattr__` override that raises an `AttributeException` if a new name isn't one of the coded in values. 

Fixes [#14153](https://gramps-project.org/bugs/view.php?id=14153).