### PR TITLE
Skip bsddb import tests when neither berkeleydb nor bsddb3 is installed

### DIFF
--- a/gramps/plugins/test/imports_test.py
+++ b/gramps/plugins/test/imports_test.py
@@ -26,6 +26,7 @@
 # **********************************************
 
 import unittest
+from unittest import SkipTest
 import os
 import sys
 import re
@@ -255,6 +256,29 @@ def db_load(zipfn, self):
             else:
                 dbid = "bsddb"
 
+            # Skip when the bsddb backend cannot be loaded. bsddb is
+            # deprecated upstream — Gramps stopped requiring it at
+            # runtime when SQLite became the default in 5.0 — but the
+            # import path is preserved for users with legacy databases.
+            # The bsddb plugin needs either berkeleydb (the maintained
+            # successor) or bsddb3 (deprecated since Python 3.6,
+            # unavailable on Windows). Without one of them present,
+            # make_database raises a generic "can't load database
+            # backend" which the surrounding except-handler converts
+            # into an assertion failure — skip cleanly instead.
+            if dbid == "bsddb":
+                try:
+                    import berkeleydb  # noqa: F401
+                except ImportError:
+                    try:
+                        import bsddb3  # noqa: F401
+                    except ImportError:
+                        self.skipTest(
+                            "neither berkeleydb nor bsddb3 is "
+                            "installed — skipping legacy bsddb "
+                            "import path"
+                        )
+
             db = make_database(dbid)
             db.disable_signals()
 
@@ -270,6 +294,11 @@ def db_load(zipfn, self):
                 continue
         return db
     # Get here is there is an exception the while loop does not handle
+    except SkipTest:
+        # Re-raise so the test framework records a skip; the catch-all
+        # below would otherwise convert it into a spurious assertion
+        # failure (SkipTest is a subclass of Exception).
+        raise
     except (
         DbVersionError,
         DbPythonError,


### PR DESCRIPTION
## Root cause
`db_load` in `gramps/plugins/test/imports_test.py` calls `make_database("bsddb")`, which raises a generic `Exception: can't load database backend: 'bsddb'` when neither `berkeleydb` (the maintained successor) nor `bsddb3` (deprecated since Python 3.6, unavailable on Windows) is installed. The catch-all `except Exception` in `db_load` swallows that and reports it as `AssertionError: Cannot open database …`, so the legacy BSDDB import tests fail on every SQLite-default install instead of skipping cleanly.

## Fix
Probe `berkeleydb` then `bsddb3` before invoking `make_database` for the `bsddb` backend; if neither is importable, call `self.skipTest(...)`. Add `except SkipTest: raise` ahead of the catch-all so the skip isn't reconverted into an assertion failure. Behaviour is unchanged on systems with either backend installed.

## Verified against
- gramps-project/gramps@6235c3ba3a:gramps/plugins/db/bsddb/bsddb.py:32-35 — the plugin already tries \`berkeleydb\` first and falls back to \`bsddb3\`, so the probe order in the test mirrors what the plugin loader does.

## Test
The change is to the test file itself. Verified locally on a Linux Python 3.12 install with neither package installed:
- **Before**: \`FAILED (failures=5, skipped=56)\` — the five \`test_imp_{3_4_5,4_1_3,4_2_8,5_0_1bsd,5_1_2bsd}_zip\` tests fail with \`AssertionError: Cannot open database … can't load database backend: 'bsddb'\`.
- **After**: \`OK (skipped=61)\` over 32499 tests; the same five now report \`skip: neither berkeleydb nor bsddb3 is installed — skipping legacy bsddb import path\`.

Note: 6.1 has a related Windows-only skip (`29a0bedaa0 Skip bsddb tests on Windows`) that this PR generalises; a forward-merge from \`maintenance/gramps60\` will need to drop that hunk in favour of this one.