### PR TITLE
Fix fan chart crash at startup with age-gradient background

### DIFF
--- a/gramps/gui/widgets/fanchart.py
+++ b/gramps/gui/widgets/fanchart.py
@@ -1513,8 +1513,12 @@ class FanChartWidget(FanChartBaseWidget):
         elif self.form == FORM_QUADRANT:
             self.rootangle_rad = [math.radians(180), math.radians(270)]
         for i in range(self.generations):
-            # person, parents?, children?
-            self.data[i] = [(None,) * 4] * 2**i
+            # person, parents?, children?, userdata
+            # Each slot gets its own empty userdata list so that
+            # prepare_background_box can safely call userdata.append()
+            # even when _fill_data_structures short-circuits (e.g. on
+            # startup before rootpersonh is set). See bug 0013395.
+            self.data[i] = [(None, None, None, []) for _ in range(2**i)]
             self.angle[i] = []
             angle = self.rootangle_rad[0]
             portion = 1 / (2**i) * (self.rootangle_rad[1] - self.rootangle_rad[0])

--- a/gramps/gui/widgets/fanchart2way.py
+++ b/gramps/gui/widgets/fanchart2way.py
@@ -224,8 +224,12 @@ class FanChart2WayWidget(FanChartWidget, FanChartDescWidget):
         self.angle = {}
         self.data = {}
         for i in range(self.generations_asc):
-            # name, person, parents?, children?
-            self.data[i] = [(None,) * 4] * 2**i
+            # person, parents?, children?, userdata
+            # Each slot gets its own empty userdata list so that
+            # prepare_background_box can safely call userdata.append()
+            # even when _fill_data_structures short-circuits (e.g. on
+            # startup before rootpersonh is set). See bug 0013395.
+            self.data[i] = [(None, None, None, []) for _ in range(2**i)]
             self.angle[i] = []
             angle = self.rootangle_rad_asc[0]
             portion = (

--- a/gramps/gui/widgets/test/fanchart_test.py
+++ b/gramps/gui/widgets/test/fanchart_test.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps developers
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Regression tests for fan chart widget data-structure initialisation.
+
+Bug 0013395 reported that Gramps crashed at startup with::
+
+    AttributeError: 'NoneType' object has no attribute 'append'
+
+in ``fanchart.py:set_userdata_age`` when:
+
+* the Fan Chart was the last view displayed,
+* "Remember last view displayed" was enabled,
+* the Background was "Age (0-100) based gradient".
+
+Root cause: :meth:`FanChartWidget.set_generations` initialised every
+``self.data[i]`` slot to a shared ``(None,) * 4`` tuple, leaving the
+4th element (``userdata``) as ``None``.  When
+:meth:`_fill_data_structures` short-circuited (no ``rootpersonh`` yet),
+``prepare_background_box`` later iterated over the unfilled slots and
+called ``userdata.append(...)`` on ``None``.
+
+These tests verify the invariant: after ``set_generations`` every data
+slot's ``userdata`` is a list, regardless of whether
+``_fill_data_structures`` has populated the slot.
+"""
+
+import unittest
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk  # noqa: F401  pylint: disable=unused-import
+
+from ..fanchart import FORM_CIRCLE, FanChartWidget
+from ..fanchart2way import FanChart2WayWidget
+
+
+class TestFanChartWidgetSetGenerations(unittest.TestCase):
+    """Ancestor fan chart (``FanChartWidget``)."""
+
+    def setUp(self):
+        # Bypass __init__ so the test does not require a Gtk display.
+        # set_generations is pure-Python data structure initialisation.
+        self.widget = FanChartWidget.__new__(FanChartWidget)
+        self.widget.generations = 3
+        self.widget.form = FORM_CIRCLE
+        self.widget.childring = False
+
+    def test_userdata_is_list_in_every_data_slot(self):
+        """Every data[i][j][3] must be a list, never None (bug 0013395)."""
+        self.widget.set_generations()
+        for gen, slots in self.widget.data.items():
+            for index, slot in enumerate(slots):
+                self.assertIsInstance(
+                    slot[3],
+                    list,
+                    f"data[{gen}][{index}][3] expected list, "
+                    f"got {type(slot[3]).__name__}",
+                )
+
+    def test_each_data_slot_has_its_own_userdata_list(self):
+        """Slots must not share a single list reference."""
+        self.widget.set_generations()
+        # Mutate one userdata and check no other slot was affected.
+        sentinel = object()
+        self.widget.data[2][0][3].append(sentinel)
+        for gen, slots in self.widget.data.items():
+            for index, slot in enumerate(slots):
+                if (gen, index) == (2, 0):
+                    continue
+                self.assertNotIn(
+                    sentinel,
+                    slot[3],
+                    f"data[{gen}][{index}][3] shares its list "
+                    "reference with data[2][0][3]",
+                )
+
+
+class TestFanChart2WayWidgetSetGenerations(unittest.TestCase):
+    """Two-way fan chart ascendance side (``FanChart2WayWidget``)."""
+
+    def setUp(self):
+        self.widget = FanChart2WayWidget.__new__(FanChart2WayWidget)
+        self.widget.generations_asc = 3
+        self.widget.generations_desc = 3
+
+    def test_ascendance_userdata_is_list_in_every_data_slot(self):
+        """Every ascendance data[i][j][3] must be a list (bug 0013395)."""
+        self.widget.set_generations()
+        for gen, slots in self.widget.data.items():
+            for index, slot in enumerate(slots):
+                self.assertIsInstance(
+                    slot[3],
+                    list,
+                    f"data[{gen}][{index}][3] expected list, "
+                    f"got {type(slot[3]).__name__}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -490,6 +490,11 @@ gramps/gui/widgets/undoableentry.py
 gramps/gui/widgets/undoablestyledbuffer.py
 gramps/gui/widgets/validatedcomboentry.py
 #
+# gramps/gui/widgets/test directory
+#
+gramps/gui/widgets/test/__init__.py
+gramps/gui/widgets/test/fanchart_test.py
+#
 # plugins
 #
 gramps/plugins/__init__.py


### PR DESCRIPTION
## Root cause
`FanChartWidget.set_generations` and `FanChart2WayWidget.set_generations` initialised `self.data[i]` with a shared `(None,) * 4` tuple per slot, leaving the `userdata` element as `None`. When `_fill_data_structures` short-circuits (no `rootpersonh` yet, e.g. on startup with "Remember last view displayed" enabled, or after a tree rename), the slots are never replaced, and the `BACKGROUND_GRAD_AGE` / `BACKGROUND_GRAD_PERIOD` paths in `prepare_background_box` then crash with `AttributeError: 'NoneType' object has no attribute 'append'`.

## Fix
Replace the buggy initialiser with a list comprehension that gives each slot its own empty `userdata` list, in both fan-chart variants. The invariant — every `data[i][j][3]` is a list, never `None` — now holds regardless of whether `_fill_data_structures` runs to completion. The list-comprehension form also avoids the latent shared-reference bug the `[(...,) * 4] * 2**i` pattern would have caused if any code path relied on per-slot mutation.

## Verified against
- gramps-project/gramps@6235c3ba3abe25940ca7beb2eed261d18d6641b4:gramps/gui/widgets/fanchart.py:1517 (ancestor variant — buggy line)
- gramps-project/gramps@6235c3ba3abe25940ca7beb2eed261d18d6641b4:gramps/gui/widgets/fanchart2way.py:228 (2-way variant — same buggy pattern)
- gramps-project/gramps@6235c3ba3abe25940ca7beb2eed261d18d6641b4:gramps/gui/widgets/fanchartdesc.py:204 (descendant variant — already safe; uses `[]` literal)

## Test
New `gramps/gui/widgets/test/fanchart_test.py` with three cases:
1. `TestFanChartWidgetSetGenerations.test_userdata_is_list_in_every_data_slot` — asserts the invariant on the ancestor chart.
2. `TestFanChartWidgetSetGenerations.test_each_data_slot_has_its_own_userdata_list` — guards against the shared-reference latent bug.
3. `TestFanChart2WayWidgetSetGenerations.test_ascendance_userdata_is_list_in_every_data_slot` — same invariant on the 2-way chart's ascendance side.

Tests use `FanChartWidget.__new__(cls)` to bypass `Gtk.DrawingArea.__init__` so they run headlessly under `python3 -m unittest gramps.gui.widgets.test.fanchart_test`.

Verification matrix:
| State | Result |
|---|---|
| Pre-fix (stash the source changes) | 2 assertion failures + 1 error reproducing the exact production stack: `AttributeError: 'NoneType' object has no attribute 'append'` |
| Post-fix | 3/3 pass |

## Related Mantis reports
Same NoneType.append fingerprint via different triggers — this fix should resolve them too, but I've left them for separate verification rather than auto-closing here:
- Issue #12932 — "When 'remember last view displayed' is enabled" (same path)
- Issue #13591 — "Cannot launch Gramps anymore"
- Issue #14076 — closed; same fingerprint via tree rename