### PR TITLE
Fix list view crash on column-sort click after closing the database

### DIFF
--- a/gramps/gui/views/treemodels/test/treebasemodel_test.py
+++ b/gramps/gui/views/treemodels/test/treebasemodel_test.py
@@ -1,0 +1,70 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps developers
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Regression test for :meth:`TreeBaseModel.reverse_order`.
+
+Bug 0013214 reported that clicking a column header in the People view
+after closing the family tree raised::
+
+    KeyError: None
+
+in ``treebasemodel.py:reverse_order``.  When the database closes the
+framework clears the model's ``tree`` dict, so the root entry
+``tree[None]`` disappears.  The unconditional ``self.tree[None]``
+lookup in :meth:`reverse_order` then crashed.
+
+This test exercises the same shape: drive ``reverse_order`` on a model
+whose ``tree`` is empty.  Pre-fix the call raised ``KeyError``;
+post-fix it returns silently.
+"""
+
+import unittest
+
+from ..treebasemodel import TreeBaseModel
+
+
+class TreeBaseModelReverseOrderTest(unittest.TestCase):
+    """Bug 0013214 regression."""
+
+    def test_reverse_order_with_empty_tree_does_not_raise(self):
+        """Empty self.tree must short-circuit, not KeyError."""
+        # Bypass __init__: TreeBaseModel.__init__ talks to a database,
+        # which we do not have headless. We only need to drive the
+        # one method, with the minimal state it touches.
+        model = TreeBaseModel.__new__(TreeBaseModel)
+        model.tree = {}
+        # clear_path_cache() calls self.lru_path.clear().
+        model.lru_path = {}
+        # __reverse is a name-mangled private attr on TreeBaseModel.
+        model._TreeBaseModel__reverse = False
+
+        # Pre-fix this raised KeyError(None). Post-fix it returns
+        # silently and toggles the internal reverse flag.
+        model.reverse_order()
+
+        # Sanity-check the only observable side-effect on the empty
+        # path: the reverse flag was still toggled, since the user's
+        # intent (next time data is loaded, sort the other way) is
+        # captured even when the current model has nothing to flip.
+        self.assertTrue(model._TreeBaseModel__reverse)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gui/views/treemodels/treebasemodel.py
+++ b/gramps/gui/views/treemodels/treebasemodel.py
@@ -732,7 +732,13 @@ class TreeBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
         """
         self.clear_path_cache()
         self.__reverse = not self.__reverse
-        top_node = self.tree[None]
+        # When the database is closed the model's tree is cleared,
+        # so the root entry self.tree[None] no longer exists. A
+        # subsequent column-click would then raise KeyError; nothing
+        # to reverse here, so short-circuit. See bug 13214.
+        top_node = self.tree.get(None)
+        if top_node is None:
+            return
         self._reverse_level(top_node)
 
     def _reverse_level(self, node):

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -465,6 +465,7 @@ gramps/gui/views/treemodels/sourcemodel.py
 # gui.views.treemodels.test package
 #
 gramps/gui/views/treemodels/test/node_test.py
+gramps/gui/views/treemodels/test/treebasemodel_test.py
 #
 # gui/widgets - the GUI widgets package
 #


### PR DESCRIPTION
## Root cause
When the database is closed the framework switches the active model to an empty state by clearing `self.tree`, so the root entry `self.tree[None]` no longer exists. `TreeBaseModel.reverse_order` did the lookup unconditionally, so the next column-header click in any list view backed by a `TreeBaseModel` raised `KeyError: None`.

## Fix
Short-circuit `reverse_order` when the tree has no root entry: there is nothing to reverse in a cleared state, and the user's expected behaviour is "no action because no tree is open". The internal `__reverse` flag is still toggled, so the user's sort-direction intent is captured next time data is loaded.

## Verified against
- gramps-project/gramps@6235c3ba3abe25940ca7beb2eed261d18d6641b4:gramps/gui/views/treemodels/treebasemodel.py:727 (buggy unconditional `self.tree[None]` lookup)
- gramps-project/gramps@6235c3ba3abe25940ca7beb2eed261d18d6641b4:gramps/gui/views/listview.py:759 (column_clicked entry point; reaches the model via `self.model.reverse_order()`)

## Test
New `gramps/gui/views/treemodels/test/treebasemodel_test.py` exercises `reverse_order` on a `__new__`-constructed `TreeBaseModel` with empty `self.tree`.

Verification matrix:
| State | Result |
|---|---|
| Pre-fix | `KeyError: None` at `treebasemodel.py:735` — same line and same exception as the reported crash |
| Post-fix | passes |

## Related Mantis reports
Same `KeyError: None` fingerprint, left for separate verification rather than auto-closing:
- Issue #13610
- Issue #13967 (closed; marked as duplicate of #13214 in Mantis)
- Issue #12448
- Issue #2092 — umbrella "Problems when no database is open"