### PR TITLE
Graph plugins: preserve date modifier in years-only mode (bug 4658)

### DIFF
--- a/gramps/plugins/graph/gvfamilylines.py
+++ b/gramps/plugins/graph/gvfamilylines.py
@@ -98,6 +98,31 @@ _CORNERS = [
     {"name": _("Both"), "value": "fm"},
 ]
 
+
+# ------------------------------------------------------------------------
+#
+# Helper functions
+#
+# ------------------------------------------------------------------------
+def _year_only_date(date: Date) -> Date:
+    """
+    Return a copy of *date* truncated to its year, preserving the
+    modifier (before/after/about) and quality (estimated/calculated).
+
+    Unlike ``Date(date.get_year())`` -- which builds a fresh date with
+    ``MOD_NONE``/``QUAL_NONE`` and drops the second stop of compound
+    dates -- this preserves the original modifier and quality, and
+    for ranges/spans preserves the second-stop year as well. That is
+    what bug 4658 asks for: "before 1923" must stay "before 1923",
+    not collapse to "1923".
+    """
+    if date.is_compound():
+        result = date.copy_ymd(date.get_year(), 0, 0, remove_stop_date=False)
+        result.set2_yr_mon_day(date.get_stop_year(), 0, 0)
+        return result
+    return date.copy_ymd(date.get_year(), 0, 0)
+
+
 # ------------------------------------------------------------------------
 #
 # A quick overview of the classes we'll be using:
@@ -896,7 +921,7 @@ class FamilyLinesReport(Report):
             if bth_event and self._incdates:
                 date = bth_event.get_date_object()
                 if self._just_years and date.get_year_valid():
-                    birth_str = self.get_date(Date(date.get_year()))  # localized year
+                    birth_str = self.get_date(_year_only_date(date))
                 else:
                     birth_str = self.get_date(date)
 
@@ -911,7 +936,7 @@ class FamilyLinesReport(Report):
             if dth_event and self._incdates:
                 date = dth_event.get_date_object()
                 if self._just_years and date.get_year_valid():
-                    death_str = self.get_date(Date(date.get_year()))  # localized year
+                    death_str = self.get_date(_year_only_date(date))
                 else:
                     death_str = self.get_date(date)
 
@@ -1042,9 +1067,7 @@ class FamilyLinesReport(Report):
                         if self._incdates:
                             date = event.get_date_object()
                             if self._just_years and date.get_year_valid():
-                                wedding_date = self.get_date(  # localized year
-                                    Date(date.get_year())
-                                )
+                                wedding_date = self.get_date(_year_only_date(date))
                             else:
                                 wedding_date = self.get_date(date)
                         # get the wedding location

--- a/gramps/plugins/graph/gvrelgraph.py
+++ b/gramps/plugins/graph/gvrelgraph.py
@@ -94,6 +94,30 @@ _ARROWS = [
 
 # ------------------------------------------------------------------------
 #
+# Helper functions
+#
+# ------------------------------------------------------------------------
+def _year_only_date(date: Date) -> Date:
+    """
+    Return a copy of *date* truncated to its year, preserving the
+    modifier (before/after/about) and quality (estimated/calculated).
+
+    Unlike ``Date(date.get_year())`` -- which builds a fresh date with
+    ``MOD_NONE``/``QUAL_NONE`` and drops the second stop of compound
+    dates -- this preserves the original modifier and quality, and
+    for ranges/spans preserves the second-stop year as well. That is
+    what bug 4658 asks for: "before 1923" must stay "before 1923",
+    not collapse to "1923".
+    """
+    if date.is_compound():
+        result = date.copy_ymd(date.get_year(), 0, 0, remove_stop_date=False)
+        result.set2_yr_mon_day(date.get_stop_year(), 0, 0)
+        return result
+    return date.copy_ymd(date.get_year(), 0, 0)
+
+
+# ------------------------------------------------------------------------
+#
 # RelGraphReport class
 #
 # ------------------------------------------------------------------------
@@ -827,9 +851,7 @@ class RelGraphReport(Report):
             if event_date:
                 if self.event_choice in [4, 5]:
                     if event_date.get_year_valid():
-                        return self.get_date(
-                            Date(event_date.get_year())
-                        )  # localized year
+                        return self.get_date(_year_only_date(event_date))
                     else:
                         return ""
                 elif self.event_choice in [1, 2, 3, 7]:

--- a/gramps/plugins/graph/test/year_only_date_test.py
+++ b/gramps/plugins/graph/test/year_only_date_test.py
@@ -1,0 +1,179 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Unit test for the ``_year_only_date`` helper used by the Family Lines
+Graph and Relationship Graph reports.
+
+Bug 0004658: when the "Limit dates to years only" report option is on,
+modifier (before/after/about), quality (estimated/calculated) and the
+second-stop of compound dates must be preserved; the old code built a
+fresh ``Date(date.get_year())`` and dropped all of those.
+"""
+
+import unittest
+
+from gramps.gen.lib import Date
+from gramps.plugins.graph.gvfamilylines import _year_only_date as fl_year_only
+from gramps.plugins.graph.gvrelgraph import _year_only_date as rg_year_only
+
+
+def _make_simple(modifier, quality=Date.QUAL_NONE, day=15, month=6, year=1923):
+    """Build a non-compound Date with the given modifier and quality."""
+    date = Date()
+    date.set(
+        quality,
+        modifier,
+        Date.CAL_GREGORIAN,
+        (day, month, year, False),
+        "",
+    )
+    return date
+
+
+def _make_compound(modifier, year1=1923, year2=1925):
+    """Build a compound (range/span) Date with two distinct year stops."""
+    date = Date()
+    date.set(
+        Date.QUAL_NONE,
+        modifier,
+        Date.CAL_GREGORIAN,
+        (15, 6, year1, False, 20, 9, year2, False),
+        "",
+    )
+    return date
+
+
+class YearOnlyDateTest(unittest.TestCase):
+    """Bug 4658: years-only mode must preserve modifier/quality/stop year."""
+
+    # ------------------------------------------------------------------
+    # Modifier preservation -- the symptom the bug names.
+    # ------------------------------------------------------------------
+
+    def test_before_preserves_modifier(self):
+        """Reporter's case: 'before 1923' must stay 'before 1923'."""
+        src = _make_simple(Date.MOD_BEFORE)
+        for fn in (fl_year_only, rg_year_only):
+            res = fn(src)
+            self.assertEqual(res.get_modifier(), Date.MOD_BEFORE)
+            self.assertEqual(res.get_year(), 1923)
+
+    def test_after_preserves_modifier(self):
+        src = _make_simple(Date.MOD_AFTER)
+        for fn in (fl_year_only, rg_year_only):
+            res = fn(src)
+            self.assertEqual(res.get_modifier(), Date.MOD_AFTER)
+            self.assertEqual(res.get_year(), 1923)
+
+    def test_about_preserves_modifier(self):
+        src = _make_simple(Date.MOD_ABOUT)
+        for fn in (fl_year_only, rg_year_only):
+            res = fn(src)
+            self.assertEqual(res.get_modifier(), Date.MOD_ABOUT)
+            self.assertEqual(res.get_year(), 1923)
+
+    # ------------------------------------------------------------------
+    # Quality preservation -- estimated/calculated must survive too.
+    # ------------------------------------------------------------------
+
+    def test_estimated_quality_preserved(self):
+        src = _make_simple(Date.MOD_NONE, quality=Date.QUAL_ESTIMATED)
+        for fn in (fl_year_only, rg_year_only):
+            self.assertEqual(fn(src).get_quality(), Date.QUAL_ESTIMATED)
+
+    def test_calculated_quality_preserved(self):
+        src = _make_simple(Date.MOD_NONE, quality=Date.QUAL_CALCULATED)
+        for fn in (fl_year_only, rg_year_only):
+            self.assertEqual(fn(src).get_quality(), Date.QUAL_CALCULATED)
+
+    # ------------------------------------------------------------------
+    # Year-only truncation -- month and day must be zeroed.
+    # ------------------------------------------------------------------
+
+    def test_month_day_zeroed(self):
+        src = _make_simple(Date.MOD_NONE, day=15, month=6, year=1923)
+        for fn in (fl_year_only, rg_year_only):
+            res = fn(src)
+            self.assertEqual(res.get_year(), 1923)
+            self.assertEqual(res.get_month(), 0)
+            self.assertEqual(res.get_day(), 0)
+
+    # ------------------------------------------------------------------
+    # Compound dates -- the old code threw away the second stop entirely.
+    # ------------------------------------------------------------------
+
+    def test_range_keeps_both_years(self):
+        src = _make_compound(Date.MOD_RANGE, 1923, 1925)
+        for fn in (fl_year_only, rg_year_only):
+            res = fn(src)
+            self.assertEqual(res.get_modifier(), Date.MOD_RANGE)
+            self.assertEqual(res.get_year(), 1923)
+            self.assertEqual(res.get_stop_year(), 1925)
+
+    def test_span_keeps_both_years(self):
+        src = _make_compound(Date.MOD_SPAN, 1923, 1925)
+        for fn in (fl_year_only, rg_year_only):
+            res = fn(src)
+            self.assertEqual(res.get_modifier(), Date.MOD_SPAN)
+            self.assertEqual(res.get_year(), 1923)
+            self.assertEqual(res.get_stop_year(), 1925)
+
+    # ------------------------------------------------------------------
+    # Regression guard: behaviour for the unmodified common case must
+    # match the previous output (year-only, no modifier).
+    # ------------------------------------------------------------------
+
+    def test_plain_date_collapses_to_year(self):
+        src = _make_simple(Date.MOD_NONE, day=15, month=6, year=1923)
+        for fn in (fl_year_only, rg_year_only):
+            res = fn(src)
+            self.assertEqual(res.get_modifier(), Date.MOD_NONE)
+            self.assertEqual(res.get_quality(), Date.QUAL_NONE)
+            self.assertEqual(res.get_year(), 1923)
+            self.assertEqual(res.get_month(), 0)
+            self.assertEqual(res.get_day(), 0)
+
+    # ------------------------------------------------------------------
+    # The helper is intentionally duplicated in both plugins (no shared
+    # private module in gramps/plugins/graph/). Guard against the copies
+    # drifting.
+    # ------------------------------------------------------------------
+
+    def test_helpers_agree(self):
+        cases = [
+            _make_simple(Date.MOD_NONE),
+            _make_simple(Date.MOD_BEFORE),
+            _make_simple(Date.MOD_AFTER),
+            _make_simple(Date.MOD_ABOUT),
+            _make_simple(Date.MOD_NONE, quality=Date.QUAL_ESTIMATED),
+            _make_simple(Date.MOD_NONE, quality=Date.QUAL_CALCULATED),
+            _make_compound(Date.MOD_RANGE, 1900, 1910),
+            _make_compound(Date.MOD_SPAN, 1900, 1910),
+        ]
+        for src in cases:
+            self.assertEqual(
+                fl_year_only(src).serialize(),
+                rg_year_only(src).serialize(),
+                msg=f"helpers disagree for {src.serialize()}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -556,6 +556,11 @@ gramps/plugins/gramplet/metadataviewer.py
 #
 gramps/plugins/graph/__init__.py
 #
+# plugins/graph/test directory
+#
+gramps/plugins/graph/test/__init__.py
+gramps/plugins/graph/test/year_only_date_test.py
+#
 # plugins/importer directory
 #
 gramps/plugins/importer/__init__.py


### PR DESCRIPTION
Fixes https://gramps-project.org/bugs/view.php?id=4658 (MantisBT bug 0004658).

## Root cause

When the "Limit dates to years only" report option is on, both Family Lines Graph and Relationship Graph rendered modified or compound dates as a bare year — `before 1923` became `1923`, `between 1923 and 1925` became `1923`, `estimated about 1923-06-15` became `1923`. The defect is `Date(date.get_year())`, which invokes the `Date` constructor's int-source branch and builds a fresh date with `MOD_NONE`/`QUAL_NONE` and a single year, discarding the modifier (before/after/about), the quality (estimated/calculated), and the second stop of compound dates.

## Fix

Introduce a private `_year_only_date` helper in each plugin that copies the original date via `Date.copy_ymd` (the existing `Date` API for "copy with new y/m/d", which preserves modifier and quality) and zeroes month and day; for compound dates it additionally truncates the second stop to year-only via `set2_yr_mon_day`. Replace all four `Date(date.get_year())` call sites:

- `gramps/plugins/graph/gvfamilylines.py` — birth, death, wedding label strings.
- `gramps/plugins/graph/gvrelgraph.py` — `get_date_string` for any event when `event_choice` is in {4, 5}.

The helper is intentionally **duplicated per plugin** rather than placed in a new shared module under `gramps/plugins/graph/` — there is no precedent for `_*.py` helpers in plugin directories today, and a one-line difference between the two copies would silently regress one of the plugins. A `test_helpers_agree` test guards against the copies drifting.

The sister Relationship Graph plugin is included in this PR because gburto01 flagged in [the bug's 2011-02-27 note](https://gramps-project.org/bugs/view.php?id=4658#c0017855) that the buggy idiom was originally written in Relationship Graph and ported across to Family Lines Graph for harmonisation. Fixing only the named plugin would leave the same defect alive in the sibling.

## Verified against

- gramps-project/gramps@6235c3ba3abe25940ca7beb2eed261d18d6641b4:gramps/gen/lib/date.py:665-709 — `Date.__init__` int-source branch sets `modifier = MOD_NONE`, `quality = QUAL_NONE`, single-stop only. Confirms the root cause.
- gramps-project/gramps@6235c3ba3abe25940ca7beb2eed261d18d6641b4:gramps/gen/lib/date.py:1507-1515 — `Date.copy_ymd` is the existing API for "copy with new year/month/day" and preserves modifier/quality via the `Date(self)` copy.
- gramps-project/gramps@6235c3ba3abe25940ca7beb2eed261d18d6641b4:gramps/gen/lib/date.py:1428-1436 — `set2_yr_mon_day` is the API for setting the second stop of a compound date.
- gburto01's [comment on 2011-02-27](https://gramps-project.org/bugs/view.php?id=4658#c0017855) confirming the Relationship → Family Lines port.

## Test

Regression test at `gramps/plugins/graph/test/year_only_date_test.py` — 10 cases:

- Modifier preservation: `MOD_BEFORE`, `MOD_AFTER`, `MOD_ABOUT`.
- Quality preservation: `QUAL_ESTIMATED`, `QUAL_CALCULATED`.
- Month/day truncation (year preserved).
- Compound `MOD_RANGE` / `MOD_SPAN` second-stop preserved.
- Plain unmodified date regression guard (behaviour unchanged for the common case).
- Both plugin helpers agree byte-for-byte via `Date.serialize` across all of the above.

Run:

```
GDK_BACKEND=- GRAMPS_RESOURCES=build/share LANGUAGE= LANG=en_US.utf-8 \
  python3 -m unittest gramps.plugins.graph.test.year_only_date_test
```

End-to-end check with `gramps.gen.datehandler.displayer`:

```
before 1923                          -> before 1923                  (was: 1923)
between 1923-06-15 and 1925-09-20    -> between 1923 and 1925        (was: 1923)
estimated about 1923-06-15           -> estimated about 1923         (was: 1923)
```
