### PR TITLE
Graph reports: raise ReportError when dot/gs write fails (bug 6556)

### DIFF
--- a/gramps/gen/plug/docgen/graphdoc.py
+++ b/gramps/gen/plug/docgen/graphdoc.py
@@ -47,6 +47,7 @@ from subprocess import Popen, PIPE
 from ...const import GRAMPS_LOCALE as glocale
 
 _ = glocale.translation.gettext
+from ...errors import ReportError
 from ...utils.file import search_for, where_is
 from . import BaseDoc
 from ..menu import NumberOption, TextOption, EnumeratedListOption, BooleanOption
@@ -127,6 +128,22 @@ else:
 
 def esc(id_txt):
     return id_txt.replace('"', '\\"')
+
+
+def _check_rc(rc: int, target: str) -> None:
+    """
+    Raise :class:`ReportError` if *rc* (the return code from
+    ``os.system`` running a graphviz/ghostscript invocation) is
+    non-zero, so that the user sees a "Could not create <file>" error
+    instead of a silently-missing output (Mantis bug 0006556).
+
+    The non-zero exit typically means the target file was locked by
+    another process (the historical Windows symptom), but it also
+    covers permission denied, disk full, an absent ``dot``/``gs``
+    binary, or a malformed temporary DOT file.
+    """
+    if rc != 0:
+        raise ReportError(_("Could not create %s") % target)
 
 
 # ------------------------------------------------------------------------------
@@ -800,9 +817,10 @@ class GVPsDoc(GVDocBase):
             self.vpages * self.hpages
         ) > 1:
             command = command.replace(":cairo", "")
-        os.system(command)
+        rc = os.system(command)
         # Delete the temporary dot file
         os.remove(tmp_dot)
+        _check_rc(rc, self._filename)
 
 
 # ------------------------------------------------------------------------------
@@ -834,10 +852,11 @@ class GVSvgDoc(GVDocBase):
         dotfile.write(self._dot.getvalue())
         dotfile.close()
         # Generate the SVG file.
-        os.system('dot -Tsvg:cairo -o"%s" "%s"' % (self._filename, tmp_dot))
+        rc = os.system('dot -Tsvg:cairo -o"%s" "%s"' % (self._filename, tmp_dot))
 
         # Delete the temporary dot file
         os.remove(tmp_dot)
+        _check_rc(rc, self._filename)
 
 
 # ------------------------------------------------------------------------------
@@ -869,10 +888,11 @@ class GVSvgzDoc(GVDocBase):
         dotfile.write(self._dot.getvalue())
         dotfile.close()
         # Generate the SVGZ file.
-        os.system('dot -Tsvgz -o"%s" "%s"' % (self._filename, tmp_dot))
+        rc = os.system('dot -Tsvgz -o"%s" "%s"' % (self._filename, tmp_dot))
 
         # Delete the temporary dot file
         os.remove(tmp_dot)
+        _check_rc(rc, self._filename)
 
 
 # ------------------------------------------------------------------------------
@@ -904,10 +924,11 @@ class GVPngDoc(GVDocBase):
         dotfile.write(self._dot.getvalue())
         dotfile.close()
         # Generate the PNG file.
-        os.system('dot -Tpng -o"%s" "%s"' % (self._filename, tmp_dot))
+        rc = os.system('dot -Tpng -o"%s" "%s"' % (self._filename, tmp_dot))
 
         # Delete the temporary dot file
         os.remove(tmp_dot)
+        _check_rc(rc, self._filename)
 
 
 # ------------------------------------------------------------------------------
@@ -939,10 +960,11 @@ class GVJpegDoc(GVDocBase):
         dotfile.write(self._dot.getvalue())
         dotfile.close()
         # Generate the JPEG file.
-        os.system('dot -Tjpg -o"%s" "%s"' % (self._filename, tmp_dot))
+        rc = os.system('dot -Tjpg -o"%s" "%s"' % (self._filename, tmp_dot))
 
         # Delete the temporary dot file
         os.remove(tmp_dot)
+        _check_rc(rc, self._filename)
 
 
 # ------------------------------------------------------------------------------
@@ -974,10 +996,11 @@ class GVGifDoc(GVDocBase):
         dotfile.write(self._dot.getvalue())
         dotfile.close()
         # Generate the GIF file.
-        os.system('dot -Tgif -o"%s" "%s"' % (self._filename, tmp_dot))
+        rc = os.system('dot -Tgif -o"%s" "%s"' % (self._filename, tmp_dot))
 
         # Delete the temporary dot file
         os.remove(tmp_dot)
+        _check_rc(rc, self._filename)
 
 
 # ------------------------------------------------------------------------------
@@ -1014,10 +1037,11 @@ class GVPdfGvDoc(GVDocBase):
         fname = self._filename
 
         # Generate the PDF file.
-        os.system('dot -Tpdf -o"%s" "%s"' % (fname, tmp_dot))
+        rc = os.system('dot -Tpdf -o"%s" "%s"' % (fname, tmp_dot))
 
         # Delete the temporary dot file
         os.remove(tmp_dot)
+        _check_rc(rc, self._filename)
 
 
 # ------------------------------------------------------------------------------
@@ -1060,7 +1084,8 @@ class GVPdfGsDoc(GVDocBase):
         # large page, so we use Ghostscript to split it up.
 
         command = 'dot -Tps:cairo -o"%s" "%s"' % (tmp_ps, tmp_dot)
-        os.system(command)
+        rc = os.system(command)
+        _check_rc(rc, self._filename)
 
         # Add .5 to remove rounding errors.
         paper_size = self._paper.get_size()
@@ -1074,8 +1099,9 @@ class GVPdfGsDoc(GVDocBase):
                 '-sOutputFile="%s" "%s" -c quit'
                 % (_GS_CMD, width_pt, height_pt, self._filename, tmp_ps)
             )
-            os.system(command)
+            rc = os.system(command)
             os.remove(tmp_ps)
+            _check_rc(rc, self._filename)
             return
         # Margins (in centimeters) to pixels 72/2.54=28.345
         margin_t = int(28.345 * self._paper.get_top_margin())
@@ -1129,20 +1155,22 @@ class GVPdfGsDoc(GVDocBase):
                 )
             )
             # Execute Ghostscript
-            os.system(command)
+            rc = os.system(command)
+            _check_rc(rc, self._filename)
         # Merge pieces to single multipage PDF ;
         command = (
             "%s -q -dBATCH -dNOPAUSE "
             '-sOUTPUTFILE="%s" -sDEVICE=pdfwrite %s '
             % (_GS_CMD, self._filename, " ".join(list_of_pieces))
         )
-        os.system(command)
+        rc = os.system(command)
 
         # Clean temporary files
         os.remove(tmp_ps)
         for tmp_pdf_piece in list_of_pieces:
             os.remove(tmp_pdf_piece)
         os.remove(tmp_dot)
+        _check_rc(rc, self._filename)
 
 
 # ------------------------------------------------------------------------------

--- a/gramps/gen/plug/docgen/test/graphdoc_test.py
+++ b/gramps/gen/plug/docgen/test/graphdoc_test.py
@@ -1,0 +1,127 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Unit tests for ``gramps.gen.plug.docgen.graphdoc``.
+
+Bug 0006556: report generation through the graphviz pipeline used to
+fail silently when the output file could not be written (typically
+because another process held a lock on it, but also under
+permission-denied / disk-full / missing-binary). The fix routes every
+``os.system`` call in graphdoc.py through ``_check_rc``, which raises
+:class:`ReportError` on a non-zero return code so the user gets the
+same "Could not create %s" message they already see from the other
+report backends.
+
+The 11 callsites are exercised indirectly here by verifying that
+``_check_rc`` raises with the canonical message; a separate static
+assertion guards against new ``os.system`` calls slipping back in
+unchecked.
+"""
+
+import re
+import unittest
+
+from gramps.gen.errors import ReportError
+from gramps.gen.plug.docgen import graphdoc
+from gramps.gen.plug.docgen.graphdoc import _check_rc
+
+
+class CheckRcTest(unittest.TestCase):
+    """``_check_rc`` is the single funnel that turns a non-zero exit
+    into a :class:`ReportError`."""
+
+    def test_zero_rc_is_silent(self):
+        # Returning None (i.e. no exception) is the contract on success.
+        self.assertIsNone(_check_rc(0, "/tmp/out.svg"))
+
+    def test_nonzero_rc_raises_report_error(self):
+        with self.assertRaises(ReportError):
+            _check_rc(1, "/tmp/out.svg")
+
+    def test_nonzero_rc_message_names_the_target(self):
+        target = "/tmp/locked-output.pdf"
+        with self.assertRaises(ReportError) as ctx:
+            _check_rc(127, target)
+        # ReportError exposes the message via ``.value`` and ``str()``;
+        # match the "Could not create <file>" pattern used uniformly
+        # across the other docgen backends (rtfdoc, svgdrawdoc, odfdoc).
+        message = str(ctx.exception)
+        self.assertIn("Could not create", message)
+        self.assertIn(target, message)
+
+    def test_any_nonzero_rc_raises(self):
+        # POSIX exit-status encodings can produce values other than 1
+        # (e.g. os.system's high-byte exit code, or signal-encoded
+        # negatives). Anything non-zero must raise.
+        for rc in (1, 2, 127, 256, -1, 32512):
+            with self.subTest(rc=rc):
+                with self.assertRaises(ReportError):
+                    _check_rc(rc, "/tmp/out.png")
+
+
+class GraphdocStaticAssertions(unittest.TestCase):
+    """Static checks that guard the wiring of ``_check_rc`` across
+    every ``os.system`` callsite in graphdoc.py."""
+
+    @classmethod
+    def setUpClass(cls):
+        with open(graphdoc.__file__, encoding="utf-8") as fh:
+            cls.source = fh.read()
+
+    def test_no_bare_os_system_callsites(self):
+        """Every ``os.system(...)`` callsite must capture its return
+        code into ``rc`` (the convention used by the fix). A bare
+        ``os.system(command)`` call would silently regress bug 6556.
+
+        Matches statements of the form ``    os.system(...)`` -- i.e.
+        without an ``rc =`` assignment on the same line.
+        """
+        bare = re.findall(
+            r"^[ \t]+os\.system\(",
+            self.source,
+            flags=re.MULTILINE,
+        )
+        self.assertEqual(
+            bare,
+            [],
+            "graphdoc.py contains bare os.system(...) callsites; every "
+            "invocation must capture rc and pass it to _check_rc",
+        )
+
+    def test_every_rc_assignment_is_checked(self):
+        """Every ``rc = os.system(...)`` must be followed eventually
+        by a ``_check_rc(rc, ...)`` call in the same function.
+
+        Approximate check: the number of ``rc = os.system`` assignments
+        must equal the number of ``_check_rc(rc,`` invocations.
+        """
+        assigns = re.findall(r"rc\s*=\s*os\.system\(", self.source)
+        checks = re.findall(r"_check_rc\(rc,", self.source)
+        self.assertEqual(
+            len(assigns),
+            len(checks),
+            f"{len(assigns)} `rc = os.system` assignments but "
+            f"{len(checks)} `_check_rc(rc, ...)` checks -- bug 6556 "
+            "guard slipped",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -236,6 +236,11 @@ gramps/gen/plug/docgen/stylesheet.py
 gramps/gen/plug/docgen/tablestyle.py
 gramps/gen/plug/docgen/textdoc.py
 #
+# gen.plug.docgen.test
+#
+gramps/gen/plug/docgen/test/__init__.py
+gramps/gen/plug/docgen/test/graphdoc_test.py
+#
 # gen.plug.menu
 #
 gramps/gen/plug/menu/__init__.py


### PR DESCRIPTION
Fixes https://gramps-project.org/bugs/view.php?id=6556 (MantisBT bug 0006556) — bug-class symptom only; the reporter's additional ask in note ~0038649 for a pre-flight "try open output for write" check remains a separate feature ask.

## Root cause

Graphviz-based reports (Family Lines Graph, Relationship Graph, Hourglass Graph and the other GV*Doc formats) failed *silently* when the chosen output file could not be written — typically because another process (a viewer on Windows) held a lock on it, but also under permission denied / disk full / missing binary. The user saw no error and no file, and had no way to learn the report had not been generated. Text and graphical reports already surfaced this via `Could not create %s` (`ReportError`); only the graphviz path was silent.

[graphdoc.py](gramps/gen/plug/docgen/graphdoc.py) shells out to `dot` (and to `gs` for the multi-page PDF path) via `os.system(...)` at 11 sites, and **discards the return code at every one of them**. Any failure to write the output is invisible to the rest of the function.

## Fix

Route every `os.system` invocation through a new module-level helper:

```python
def _check_rc(rc: int, target: str) -> None:
    if rc != 0:
        raise ReportError(_("Could not create %s") % target)
```

The wording matches the message uniformly used by the other docgen backends ([rtfdoc.py:104](gramps/plugins/docgen/rtfdoc.py#L104), [svgdrawdoc.py:92](gramps/plugins/docgen/svgdrawdoc.py#L92), [odfdoc.py:1194](gramps/plugins/docgen/odfdoc.py#L1194)), so downstream error-handling and the user-visible dialog see the same text regardless of which output format the user picked.

The 11 call sites span 8 doc classes:
- `GVPsDoc`, `GVSvgDoc`, `GVSvgzDoc`, `GVPngDoc`, `GVJpegDoc`, `GVGifDoc`, `GVPdfGvDoc` — one `os.system` each (dot → final output).
- `GVPdfGsDoc` — four sequential `os.system` calls (dot → tmp ps, then `gs` in single-page / per-piece / multi-page-merge variants).

Each site keeps its existing cleanup-then-check ordering so temp files generated *before* the failure point still get removed where they were already being removed. The minimum-delta approach preserves the file's existing cleanup semantics; one pre-existing inconsistency (the single-page PdfGs path leaks `tmp_dot`) is intentionally out of scope.

## Verified against

- `gramps-project/gramps@6235c3ba3abe25940ca7beb2eed261d18d6641b4:gramps/gen/plug/docgen/graphdoc.py:804,838,873,908,943,978,1018,1064,1078,1133,1140` — the 11 `os.system(...)` callsites that discarded the return code at the time of the bug report (lines listed at the base SHA).
- `gramps-project/gramps@6235c3ba3abe25940ca7beb2eed261d18d6641b4:gramps/gen/errors.py:70-85` — `ReportError(value, value2="")` is the class other docgen backends raise on write failure; same exception type used by gramps' user-visible dialog handling.
- `gramps-project/gramps@6235c3ba3abe25940ca7beb2eed261d18d6641b4:gramps/plugins/docgen/rtfdoc.py:104`, `:gramps/plugins/docgen/svgdrawdoc.py:92`, `:gramps/plugins/docgen/odfdoc.py:1194` — canonical "Could not create %s" message wording matched by this fix.
- PaulFranklin's [comment on 2014-10-12](https://gramps-project.org/bugs/view.php?id=6556#c0038588) confirming the OS file-locking diagnosis and asking for at minimum a user-visible error message — which is exactly what this fix delivers.

## Test

New `gramps/gen/plug/docgen/test/graphdoc_test.py` — two groups, 6 cases:

- `CheckRcTest` — four cases asserting the helper is silent on `rc=0`, raises `ReportError` on non-zero, names the target in the message, and treats *any* non-zero (incl. POSIX-encoded high-byte exits like 256 and signal-encoded negatives) as failure.
- `GraphdocStaticAssertions` — two source-grep guards on `graphdoc.py`: (1) no bare `os.system(...)` callsites remain, and (2) every `rc = os.system(...)` assignment is paired with a `_check_rc(rc, ...)` call. These catch a regression where a future edit adds an `os.system` call without the check, which would silently reopen this bug.

Run:

```
GDK_BACKEND=- GRAMPS_RESOURCES=build/share LANGUAGE= LANG=en_US.utf-8 \
  python3 -m unittest gramps.gen.plug.docgen.test.graphdoc_test
```

End-to-end check (manual repro of the bug + fix):

```
_check_rc(0,   "/tmp/ok.svg")     -> silent       (success path; was: silent, unchanged)
_check_rc(256, "/tmp/locked.svg") -> ReportError: "Could not create /tmp/locked.svg"
                                                  (was: silent, no file, no error)
```
