### PR TITLE
docs(man): document LANGUAGE environment variable (bug 10443)

### DIFF
--- a/data/man/en.rst
+++ b/data/man/en.rst
@@ -252,6 +252,15 @@ The program checks whether these environment variables are set:
     Describe which language to use.
     E.g., for the Polish language this variable has to be set to `pl_PL.UTF-8`.
 
+``LANGUAGE``
+    A colon-separated list of language codes (e.g. `ru` or `pt_BR:pt`)
+    in preference order. When set, this overrides ``LANG`` for translated
+    messages — Gramps splits it on `:` and walks the list looking for a
+    matching message catalog. Use it together with ``LANG`` when ``LANG``
+    alone does not pick up a translation, e.g.::
+
+        LANG=ru_RU.UTF-8 LANGUAGE=ru gramps
+
 ``GRAMPSHOME``
     Force Gramps to use the specified directory to keep program
     settings and databases in.


### PR DESCRIPTION
Fixes (man-page portion of) https://gramps-project.org/bugs/view.php?id=10443 (MantisBT bug 0010443). The reporter also asked for three wiki pages to be updated; those are out of scope for a source-tree PR but the same misleading-doc gap exists in the source-tracked man page.

## Root cause

The man page's `ENVIRONMENT VARIABLES` section listed only `LANG`. Users who set `LANG=xx_YY.UTF-8` and hit a system where that alone doesn't pick up the translation — the common gettext fallback-chain hazard the reporter ran into with Russian — had no way to learn from the documentation that they also needed to set `LANGUAGE`. The reporter found this empirically after digging through `gramps -v` output and asked that the docs be updated to save other users the same time.

## Fix

Add a `LANGUAGE` entry to [data/man/en.rst](data/man/en.rst) immediately after `LANG` in `ENVIRONMENT VARIABLES`. The new entry explains:

- It's a colon-separated list of language codes (e.g. `ru` or `pt_BR:pt`) in preference order.
- It overrides `LANG` for translated messages.
- The canonical "set both" idiom the reporter found works:

```
LANG=ru_RU.UTF-8 LANGUAGE=ru gramps
```

Backtick style matches the surrounding file (double for variable names referenced inline, single for value literals).

## Verified against

- gramps-project/gramps@6235c3ba3abe25940ca7beb2eed261d18d6641b4:gramps/gen/utils/grampslocale.py:250-256 — `_init_from_environment` reads `LANGUAGE`, splits on `:`, overrides the `LANG`-derived locale. Comment at line 250 reads "`$LANGUAGE overrides $LANG, $LC_MESSAGES`" — authoritative source for the prose I added.
- gramps-project/gramps@6235c3ba3abe25940ca7beb2eed261d18d6641b4:gramps/cli/argparser.py:140 — the `gramps --help` text already shows the `LANGUAGE=de_DE; LANG=de_DE.UTF-8 gramps …` idiom for navwebpage report generation. The man page was the only piece of in-tree documentation missing it.

## Out of scope

- **`data/man/gramps.1.in` regeneration.** That file is generated from `en.rst` via `sphinx-build -b man`. Maintainers regenerate in batches: last regen was [`8159aca9b4`](https://github.com/gramps-project/gramps/commit/8159aca9b4) "Generate gramps.1.in file" in Feb 2022, and `en.rst` has seen 4 unpaired commits since (most recently [`bcb956214c`](https://github.com/gramps-project/gramps/commit/bcb956214c) "Fix references to gramps-xml file format in man pages" Jan 2024). I followed that pattern — `en.rst` only, leaving the next batched regeneration to a maintainer.
- **Localized man pages** under `data/man/{cs,fr,nl,pl,pt_BR,sv}/`. Those follow the Weblate translation workflow once the English source is updated.
- **The three wiki pages** the reporter actually flagged (`Howto:Change_the_language_of_reports#How_to_install_a_locale` and the `Gramps_5.0_Wiki_Manual_-_Command_Line#Environment_variables` / `Gramps_5.0_Wiki_Manual_-_Settings#Language` pages). Wiki edits live outside the source tree; that's a separate community task that Sam888 already noted in 2018-02-18 (~0053900).

## Test

Documentation-only change, no functional code path. No unit test applies. Manual verification: the prose accurately describes the behavior implemented at `grampslocale.py:250-256` (the authoritative source) and gives the exact `LANG=ru_RU.UTF-8 LANGUAGE=ru gramps` invocation the reporter found empirically works.
