### PR TITLE
Finnish dates: guard month-only / no-inflect path against non-Lexeme months (bug 12283)

### DIFF
--- a/gramps/gen/datehandler/_date_fi.py
+++ b/gramps/gen/datehandler/_date_fi.py
@@ -165,6 +165,10 @@ class DateDisplayFI(DateDisplay):
                         date_val[1], year, inflect, long_months
                     )
                 else:
+                    if not hasattr(long_months[date_val[1]], "forms"):  # not a Lexeme
+                        return "{long_month} {year}".format(
+                            long_month=long_months[date_val[1]], year=year
+                        )
                     return "{long_month.forms[IN]} {year}".format(
                         long_month=long_months[date_val[1]], year=year
                     )

--- a/gramps/gen/datehandler/test/date_fi_test.py
+++ b/gramps/gen/datehandler/test/date_fi_test.py
@@ -1,0 +1,132 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Unit tests for the Finnish date display.
+
+Bug 0012283: when the Finnish translation message catalog is not
+installed (typical on Windows AIO where the user picked English
+only), Gramps still loads the Finnish date handler, but the
+``long_months`` list it gets from the localised DateStrings is a
+list of plain ``str`` (English fallback) rather than a list of
+``Lexeme``. The day-zero / no-inflect branch of
+``DateDisplayFI.dd_dformat04`` then tried to format
+``"{long_month.forms[IN]}"``, which raises
+``AttributeError: 'str' object has no attribute 'forms'`` (or
+``'f'`` on 5.1.x where the Lexeme attribute was named ``f``). All
+the other branches of the same function already had the canonical
+``hasattr(..., "forms")`` guard; only this one was missing.
+"""
+
+import unittest
+
+from ...utils.grampslocale import GrampsLocale
+from .._date_fi import DateDisplayFI
+
+
+class FinnishDateNoLexemeTest(unittest.TestCase):
+    """
+    Exercise ``DateDisplayFI.dd_dformat04`` with a plain-``str``
+    ``long_months`` list, mimicking the no-translation-installed
+    environment that triggered bug 12283.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # A Finnish DateDisplayFI works without the Finnish .mo
+        # being installed -- it just falls back to English message
+        # strings, which is exactly the bug scenario.
+        cls.dd = DateDisplayFI(blocale=GrampsLocale(lang="fi"))
+
+    # Non-Lexeme month list: index 0 unused, indices 1..12 are
+    # plain English month names (what gettext returns when the
+    # Finnish catalog is missing).
+    NON_LEXEME_MONTHS = (
+        "",
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
+    )
+
+    def test_month_only_no_inflect_does_not_raise(self):
+        """
+        Bug 12283 repro: day-zero date + ``inflect=""`` +
+        non-Lexeme ``long_months`` used to raise ``AttributeError``.
+        Must now return a plain "Month Year" string instead.
+        """
+        # date_val = (day, month, year, slash)
+        date_val = (0, 5, 1945, False)
+        result = self.dd.dd_dformat04(
+            date_val, inflect="", long_months=self.NON_LEXEME_MONTHS
+        )
+        self.assertEqual(result, "May 1945")
+
+    def test_month_only_no_inflect_no_exception_across_months(self):
+        """
+        Same guard, all 12 months. Asserts the defensive fallback
+        never raises and always yields "<month> <year>".
+        """
+        for month in range(1, 13):
+            with self.subTest(month=month):
+                date_val = (0, month, 1900, False)
+                result = self.dd.dd_dformat04(
+                    date_val, inflect="", long_months=self.NON_LEXEME_MONTHS
+                )
+                self.assertEqual(result, f"{self.NON_LEXEME_MONTHS[month]} 1900")
+
+    def test_year_only_unchanged(self):
+        """
+        Regression guard: a date with day=0 *and* month=0 still
+        returns just the year, the same as before the fix.
+        """
+        date_val = (0, 0, 1945, False)
+        result = self.dd.dd_dformat04(
+            date_val, inflect="", long_months=self.NON_LEXEME_MONTHS
+        )
+        self.assertEqual(result, "1945")
+
+    def test_full_date_unchanged(self):
+        """
+        Regression guard: the ``date_val[0] != 0`` branch already
+        had a ``hasattr(..., "forms")`` guard before this PR. With
+        non-Lexeme ``long_months`` it falls through to
+        ``dd_dformat01`` (numeric). Make sure the bug fix didn't
+        disturb that path.
+        """
+        date_val = (9, 5, 1945, False)
+        result = self.dd.dd_dformat04(
+            date_val, inflect="", long_months=self.NON_LEXEME_MONTHS
+        )
+        # dd_dformat01 returns numeric "DD.MM.YYYY" form for Finnish.
+        # We don't assert the exact format string (that's a separate
+        # concern); we just assert no exception and a non-empty result.
+        self.assertTrue(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes https://gramps-project.org/bugs/view.php?id=12283 (MantisBT bug 0012283).

## Root cause

When the Finnish translation message catalog is not installed (typical on Windows AIO when the user picked only English during install), Gramps still loads the Finnish date handler, but the localised DateStrings hand it back a list of plain `str` (English fallback) instead of a list of `Lexeme`. The day-zero / no-inflect branch of `DateDisplayFI.dd_dformat04` at [`gramps/gen/datehandler/_date_fi.py:168`](gramps/gen/datehandler/_date_fi.py#L168) tried to format `"{long_month.forms[IN]}"`, which raises `AttributeError: 'str' object has no attribute 'forms'` (or `'f'` on 5.1.x where the Lexeme attribute was named `f` — matching the bug's title).

The reporter's reproduction (note ~0062336): open a person whose birth date has only month + year (no day) in the Relationships view. The crash brings down `relview.write_family` for that person. daleathan confirmed in note ~0062335: re-running the AIO installer and selecting Finnish makes the crash go away, but "the Finnish handler needs to be fixed to handle this situation."

## Fix

Every other branch of the same function already has the canonical `hasattr(long_months[...], "forms")` guard with the same no-Lexeme fallback — see the `date_val[0] != 0` outer branch at [`_date_fi.py:172`](gramps/gen/datehandler/_date_fi.py#L172) and the `if inflect:` sub-branch at [`_date_fi.py:163`](gramps/gen/datehandler/_date_fi.py#L163) which routes through `format_long_month_year` (whose own guard is at [`_datedisplay.py:556`](gramps/gen/datehandler/_datedisplay.py#L556)). The only unguarded path was the no-inflect / day-zero branch the reporter triggered.

This PR adds the same guard there. On the no-Lexeme path it falls back to a plain `"{long_month} {year}".format(...)` rendering — matching the existing fallback in `format_long_month_year`.

## Verified against

- gramps-project/gramps@6235c3ba3abe25940ca7beb2eed261d18d6641b4:gramps/gen/datehandler/_date_fi.py:168 — the unguarded `forms[IN]` access this PR adds the guard around.
- gramps-project/gramps@6235c3ba3abe25940ca7beb2eed261d18d6641b4:gramps/gen/datehandler/_date_fi.py:172 — sibling branch already guarded the same way; this PR mirrors its pattern.
- gramps-project/gramps@6235c3ba3abe25940ca7beb2eed261d18d6641b4:gramps/gen/datehandler/_datedisplay.py:555-559 — `format_long_month_year` already does the same no-Lexeme fallback the bug fix uses (`"{long_month} {year}".format(...)`).

## Test

New `gramps/gen/datehandler/test/date_fi_test.py` — 4 cases exercising `dd_dformat04` directly with a plain-`str` `long_months` list (the bug scenario):

- `test_month_only_no_inflect_does_not_raise` — reporter's case: day-zero, `inflect=""`, non-Lexeme months. Pre-fix raised `AttributeError`; post-fix returns `"May 1945"`.
- `test_month_only_no_inflect_no_exception_across_months` — same guard, all 12 months via `subTest`, asserts `"<month> <year>"` for each.
- `test_year_only_unchanged` — regression guard: day=0 and month=0 still returns just the year.
- `test_full_date_unchanged` — regression guard: `date_val[0] != 0` branch already had the `hasattr` guard before this PR. With non-Lexeme `long_months` it falls through to `dd_dformat01` (numeric). Make sure the new guard didn't disturb that path.

Run:

```
GDK_BACKEND=- GRAMPS_RESOURCES=build/share LANGUAGE= LANG=en_US.utf-8 \
  python3 -m unittest gramps.gen.datehandler.test.date_fi_test
```

All 4 pass; the broader datehandler test suite (52 existing tests) also still passes.

## Out of scope

This PR only fixes the Finnish day-zero / no-inflect path. Other locale-specific date handlers (`_date_cs`, `_date_de`, `_date_ru`, etc.) may share the same defensive-guard gap; the related #10855 was already resolved by prculley for Russian. Each affected locale is its own focused fix and its own Mantis bug.
