### PR TITLE
Russian dates: fix stale .f attribute name in dd_dformat05 Lexeme guard (bug 14231)

### DIFF
--- a/gramps/gen/datehandler/_date_ru.py
+++ b/gramps/gen/datehandler/_date_ru.py
@@ -162,7 +162,7 @@ class DateDisplayRU(DateDisplay):
                 )
         elif date_val[1] == 0:  # month is zero but day is not (see 8477)
             return self.display_iso(date_val)
-        elif not hasattr(short_months[date_val[1]], "f"):  # not a Lexeme
+        elif not hasattr(short_months[date_val[1]], "forms"):  # not a Lexeme
             return "{day:d} {short_month} {year}".format(
                 day=date_val[0], short_month=short_months[date_val[1]], year=year
             )

--- a/gramps/gen/datehandler/test/date_ru_test.py
+++ b/gramps/gen/datehandler/test/date_ru_test.py
@@ -1,0 +1,167 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Unit test for the Russian short-format date display.
+
+In jralls's 2023-07-14 commit ``7f8455c867`` "Extract translation
+classes from grampslocale.py", the ``Lexeme`` attribute used to
+access inflected forms was renamed from ``.f`` to ``.forms``. That
+commit updated every format-spec usage and almost every guard --
+but missed the guard at ``_date_ru.py:165`` in
+``DateDisplayRU.dd_dformat05``. The result is that ``hasattr(lexeme,
+"f")`` always returns False (no ``Lexeme`` has ``.f`` after the
+rename), so the no-Lexeme fallback always runs and the inflected
+``.forms[Р]`` branch is dead code. Russian short-format dates
+therefore skip inflection even when the Russian translations are
+installed -- the *opposite* failure mode of bug 12283 (which is
+about the *missing*-translation case).
+
+The same idiom in the sibling ``dd_dformat04`` (line 142) was
+correctly migrated, as were the format-spec accesses on lines 147
+and 170. Only line 165 was forgotten.
+"""
+
+import unittest
+
+from ...utils.grampslocale import GrampsLocale
+from ...utils.grampstranslation import Lexeme
+from .._date_ru import DateDisplayRU
+
+
+class RussianDateDFormat05InflectionTest(unittest.TestCase):
+    """
+    Exercise ``DateDisplayRU.dd_dformat05`` with a ``Lexeme`` short
+    month list (the translation-installed scenario) and verify the
+    Russian-genitive (``Р``) form is selected, not the default str
+    coercion.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # The Russian translation catalog isn't required for this test
+        # since we feed dd_dformat05 a synthetic Lexeme tuple directly.
+        cls.dd = DateDisplayRU(blocale=GrampsLocale(lang="ru"))
+
+    @staticmethod
+    def _lexeme_months(genitive_prefix="GEN", nominative_prefix="NOM"):
+        """Build a tuple of 13 entries (index 0 unused, 1..12 are
+        Lexemes carrying a Russian-genitive (``Р``) form and a
+        nominative fallback).
+
+        The nominative form is intentionally placed *first* in the
+        ordered dict, so that ``str(lexeme)`` (the bug path's
+        fallback view, since Lexeme inherits from str and uses its
+        first form as the str value) yields the nominative -- making
+        the bug-path output distinguishable from the inflected-path
+        output that uses the genitive ``.forms[Р]``. Without this
+        ordering, both paths would render the same string and the
+        test couldn't catch the regression.
+        """
+        return ("",) + tuple(
+            Lexeme(
+                [
+                    ("И", f"{nominative_prefix}{m}"),
+                    ("Р", f"{genitive_prefix}{m}"),
+                ]
+            )
+            for m in range(1, 13)
+        )
+
+    def test_full_date_uses_genitive_form_when_lexemes_present(self):
+        """
+        Bug regression: with a Lexeme-bearing ``short_months`` and a
+        day-non-zero date, ``dd_dformat05`` must emit the genitive
+        (``Р``) form. Pre-fix the guard at ``_date_ru.py:165`` checked
+        ``hasattr(..., "f")`` which never matches post-2023 Lexemes,
+        so the function silently returned the nominative.
+        """
+        short_months = self._lexeme_months()
+        # date_val = (day, month, year, slash)
+        date_val = (9, 5, 1945, False)
+        result = self.dd.dd_dformat05(date_val, inflect="", short_months=short_months)
+        self.assertIn("GEN5", result)
+        self.assertNotIn("NOM5", result)
+
+    def test_genitive_form_across_all_months(self):
+        """
+        Same regression, exercised across every month. Asserts that
+        the inflected branch is reached for each.
+        """
+        short_months = self._lexeme_months()
+        for month in range(1, 13):
+            with self.subTest(month=month):
+                date_val = (9, month, 1945, False)
+                result = self.dd.dd_dformat05(
+                    date_val, inflect="", short_months=short_months
+                )
+                self.assertIn(f"GEN{month}", result)
+                self.assertNotIn(f"NOM{month}", result)
+
+    def test_full_date_with_non_lexeme_short_months_falls_back(self):
+        """
+        Regression guard: when ``short_months`` are plain ``str``
+        (the no-translation-installed scenario), the function must
+        still fall back to the uninflected form without raising.
+        Mirrors the bug-12283 defensive-guard test on the Finnish
+        side.
+        """
+        non_lexeme_months = (
+            "",
+            "Jan",
+            "Feb",
+            "Mar",
+            "Apr",
+            "May",
+            "Jun",
+            "Jul",
+            "Aug",
+            "Sep",
+            "Oct",
+            "Nov",
+            "Dec",
+        )
+        date_val = (9, 5, 1945, False)
+        result = self.dd.dd_dformat05(
+            date_val, inflect="", short_months=non_lexeme_months
+        )
+        # No assertion on exact text; just no exception and a
+        # non-empty render. The exact str-fallback format is
+        # "{day} {short_month} {year}" -> "9 May 1945".
+        self.assertIn("9", result)
+        self.assertIn("May", result)
+        self.assertIn("1945", result)
+
+    def test_dd_dformat04_long_form_unaffected(self):
+        """
+        Regression guard: the long-form guard at ``_date_ru.py:142``
+        was already correctly updated to ``"forms"`` in the 2023
+        rename. Confirm the long-form path still inflects properly.
+        """
+        long_months = self._lexeme_months(
+            genitive_prefix="LGEN", nominative_prefix="LNOM"
+        )
+        date_val = (9, 5, 1945, False)
+        result = self.dd.dd_dformat04(date_val, inflect="", long_months=long_months)
+        self.assertIn("LGEN5", result)
+        self.assertNotIn("LNOM5", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes https://gramps-project.org/bugs/view.php?id=14231 (MantisBT bug 0014231).

## Root cause

jralls's [commit `7f8455c867`](https://github.com/gramps-project/gramps/commit/7f8455c867) "Extract translation classes from grampslocale.py" (2023-07-14) renamed the `Lexeme` attribute used to access inflected forms from `.f` to `.forms`. That commit updated every format-spec usage in the Russian date handler and every other guard:

| Location | Updated to `.forms` in 7f8455c867? |
|---|---|
| `_date_ru.py:142` (long-month guard in `dd_dformat04`) | ✅ |
| `_date_ru.py:147` (long-month format spec) | ✅ |
| `_date_ru.py:170` (short-month format spec) | ✅ |
| **`_date_ru.py:165` (short-month guard in `dd_dformat05`)** | ❌ **missed** |

The short-month guard still reads:

```python
elif not hasattr(short_months[date_val[1]], "f"):  # not a Lexeme
```

After the rename, `Lexeme` has `.forms` but no `.f`. So `hasattr(any_Lexeme, "f")` always returns `False`, the `not …` is always `True`, and execution always falls into the no-Lexeme str-fallback branch at lines 166-168. The inflected branch at lines 170-172 — which the same commit *specifically* updated to use `.forms[Р]` — is **dead code**.

## Effect

Russian short-format date display silently skips grammatical inflection even when the Russian translations are fully installed. Users see e.g. `9 декабрь 1945` (nominative abbreviation) instead of the grammatically-correct `9 декабря 1945` (genitive case).

This is the *opposite* failure mode of [bug 12283 / PR #2320](https://github.com/gramps-project/gramps/pull/2320) (which fixed the *missing*-translation case in Finnish): here the guard fires too eagerly when it shouldn't, rather than failing to fire when it should.

## How this was discovered

While auditing the bug-12283 pattern across all locale handlers — checking whether any other locale shared Finnish's missing-guard hole. The audit found:

- Only `_date_fi.py` and `_date_ru.py` use the `.forms[X]` format spec at all.
- The bug-12283 pattern itself doesn't appear in Russian (the day-zero path in `dd_dformat04` routes through `format_long_month_year` which is independently guarded).
- But the stale-attribute-name defect at `_date_ru.py:165` turned up during the same read-through.

No corresponding Mantis ticket existed when this was discovered. Filing one separately so the fix is cross-referenced upstream.

## Fix

Change `"f"` to `"forms"` on `_date_ru.py:165`. One-character change in the source; the resulting guard matches the sibling at line 142 word-for-word.

## Verified against

- `gramps-project/gramps@6235c3ba3abe25940ca7beb2eed261d18d6641b4:gramps/gen/datehandler/_date_ru.py:165` — the stale `"f"` guard this PR fixes.
- `gramps-project/gramps@7f8455c86745a5c2fd1fb1bf05601f46b16fe979` — the 2023 rename commit that missed this line. The commit's own diff against `_date_ru.py` correctly updated lines 142, 147, 170 to `.forms`, but didn't touch 165.
- `gramps-project/gramps@6235c3ba3abe25940ca7beb2eed261d18d6641b4:gramps/gen/utils/grampstranslation.py:159-162` — `Lexeme.forms` is declared via `@property`, and there is no `.f` attribute on the class. Confirms the `hasattr("f")` check is unconditionally False post-rename.

## Test

New `gramps/gen/datehandler/test/date_ru_test.py` — 4 cases driving `dd_dformat05` and `dd_dformat04` directly:

- `test_full_date_uses_genitive_form_when_lexemes_present` — the primary bug regression: with a `Lexeme`-bearing `short_months` tuple, the genitive `Р` form must appear in the output.
- `test_genitive_form_across_all_months` — same regression across all 12 months via `subTest`.
- `test_full_date_with_non_lexeme_short_months_falls_back` — regression guard for the legitimate str-fallback case (no translation installed).
- `test_dd_dformat04_long_form_unaffected` — regression guard for the sibling long-month path that was already correct in 7f8455c867.

The test discriminates between the str-fallback and inflected paths by placing the *nominative* form first in the `Lexeme`'s ordered dict — since `Lexeme` inherits from `str` and uses its first form as the str value, the bug-path (str fallback) renders the nominative, while the fix-path (inflected `forms[Р]`) renders the genitive. Without that ordering choice both paths render the same text and the test couldn't catch the regression.

Pre-fix verification: with the stash-and-rerun pattern, the test correctly produces 13 failures (1 + 12 subtests) of the form `AssertionError: 'GEN12' not found in '9 NOM12 1945'` — exactly the user-visible symptom.

Run:

```
GDK_BACKEND=- GRAMPS_RESOURCES=build/share LANGUAGE= LANG=en_US.utf-8 \
  python3 -m unittest gramps.gen.datehandler.test.date_ru_test
```

4/4 pass post-fix; the broader datehandler test suite (52 existing tests) is also still green.

