### PR TITLE
Fall back to uninflected date format on an unknown inflection (bug 14100)

### DIFF
--- a/gramps/gen/datehandler/_datedisplay.py
+++ b/gramps/gen/datehandler/_datedisplay.py
@@ -577,24 +577,29 @@ class DateDisplay:
             return "{long_month} {year}".format(
                 long_month=long_months[month], year=year
             )
-        return self.FORMATS_long_month_year[inflect].format(
-            long_month=long_months[month], year=year
-        )
+        # bug 14100: an inflection key not present in the dict (e.g. from a
+        # locale whose .po mistranslated the inflection context) falls back
+        # to the uninflected format ("") instead of raising KeyError.
+        return self.FORMATS_long_month_year.get(
+            inflect, self.FORMATS_long_month_year[""]
+        ).format(long_month=long_months[month], year=year)
 
     def format_short_month_year(self, month, year, inflect, short_months):
         if not hasattr(short_months[1], "forms"):  # not a Lexeme: no inflection
             return "{short_month} {year}".format(
                 short_month=short_months[month], year=year
             )
-        return self.FORMATS_short_month_year[inflect].format(
-            short_month=short_months[month], year=year
-        )
+        # bug 14100: fall back to the uninflected format on an unknown key.
+        return self.FORMATS_short_month_year.get(
+            inflect, self.FORMATS_short_month_year[""]
+        ).format(short_month=short_months[month], year=year)
 
     def format_long_month(self, month, inflect, long_months):
         if not hasattr(long_months[1], "forms"):  # not a Lexeme: no inflection
             return "{long_month}".format(long_month=long_months[month])
+        # bug 14100: fall back to the uninflected format on an unknown key.
         return (
-            self.FORMATS_long_month_year[inflect]
+            self.FORMATS_long_month_year.get(inflect, self.FORMATS_long_month_year[""])
             .format(long_month=long_months[month], year="")
             .rstrip()
         )
@@ -602,8 +607,11 @@ class DateDisplay:
     def format_short_month(self, month, inflect, short_months):
         if not hasattr(short_months[1], "forms"):  # not a Lexeme: no inflection
             return "{short_month}".format(short_month=short_months[month])
+        # bug 14100: fall back to the uninflected format on an unknown key.
         return (
-            self.FORMATS_short_month_year[inflect]
+            self.FORMATS_short_month_year.get(
+                inflect, self.FORMATS_short_month_year[""]
+            )
             .format(short_month=short_months[month], year="")
             .rstrip()
         )

--- a/gramps/gen/datehandler/test/datedisplay_test.py
+++ b/gramps/gen/datehandler/test/datedisplay_test.py
@@ -149,5 +149,59 @@ class DateDisplayInflectionsTestRU(DateDisplayTest):
             self.assertIn("по май", self.dd.display(f1945may_t1946may))
 
 
+# Regression test for bug #14100. The format_*_month* methods looked up the
+# ``inflect`` key in FORMATS_long_month_year / FORMATS_short_month_year with a
+# bare subscript, so a key absent from the dict raised KeyError instead of
+# degrading. A Finnish fi.po that mistranslated the "about-date" inflection
+# context to the native word "noin" (instead of the English keyword "about"
+# the dicts are keyed by) made Gramps crash with KeyError: 'noin' whenever an
+# "about <Month> <Year>" date was displayed under the long-month format -- in
+# the Detailed Ancestral Report, the Relationship View and elsewhere. An
+# unknown key must now fall back to the uninflected ("") format.
+class DateDisplayInflectionFallbackTest(DateDisplayTest):
+    # The literal key from the bug report; stands in for any inflection a
+    # locale's .po might emit that the FORMATS dicts do not define.
+    UNKNOWN_INFLECTION = "noin"
+
+    def setUp(self):
+        DateDisplayTest.setUp(self)
+        self.dd = self.display_RU  # a displayer whose months are Lexemes
+        if not hasattr(self.dd.long_months[1], "forms"):
+            self.skipTest(
+                "Russian translation unavailable; inflected month formats "
+                "cannot be exercised in this environment"
+            )
+
+    def test_long_month_year_unknown_inflection_falls_back(self):
+        self.assertEqual(
+            self.dd.format_long_month_year(
+                5, "1945", self.UNKNOWN_INFLECTION, self.dd.long_months
+            ),
+            self.dd.format_long_month_year(5, "1945", "", self.dd.long_months),
+        )
+
+    def test_short_month_year_unknown_inflection_falls_back(self):
+        self.assertEqual(
+            self.dd.format_short_month_year(
+                5, "1945", self.UNKNOWN_INFLECTION, self.dd.short_months
+            ),
+            self.dd.format_short_month_year(5, "1945", "", self.dd.short_months),
+        )
+
+    def test_long_month_unknown_inflection_falls_back(self):
+        self.assertEqual(
+            self.dd.format_long_month(5, self.UNKNOWN_INFLECTION, self.dd.long_months),
+            self.dd.format_long_month(5, "", self.dd.long_months),
+        )
+
+    def test_short_month_unknown_inflection_falls_back(self):
+        self.assertEqual(
+            self.dd.format_short_month(
+                5, self.UNKNOWN_INFLECTION, self.dd.short_months
+            ),
+            self.dd.format_short_month(5, "", self.dd.short_months),
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Root cause

`DateDisplay.format_long_month_year()` and its short / month-only siblings
look up the modifier-derived `inflect` key in `FORMATS_long_month_year` /
`FORMATS_short_month_year` with a bare subscript. `display_formatted()`
builds that key from a translatable string (`_("", "about-date")` and
friends), and Finnish `fi.po` translates the `about-date` context to the
native word "noin" instead of the English keyword the dict is keyed by — so
displaying an `about <Month> <Year>` date under a long-month format
evaluates `FORMATS_long_month_year["noin"]` and raises `KeyError: 'noin'`.

## Fix

Look the inflection key up with `dict.get()`, falling back to the
uninflected (`""`) format that is always present in both dicts, so a
mistranslated locale degrades to a readable (if grammatically plain) date
instead of aborting report or view rendering.

## Verified against

- `gramps/gen/datehandler/_datedisplay.py:182` and `:244` — the `""`
  (uninflected) key is unconditionally defined in `FORMATS_long_month_year`
  and `FORMATS_short_month_year`, so it is a safe fallback key.
- `gramps/gen/datehandler/_datedisplay.py:505-509` — `display_formatted()`
  derives the key from `_("", "about-date")`, whose translator note asks for
  the English keyword or no translation, not a native-language word.
- `gramps/plugins/view/relview.py:1440` — `info_string()` reaches the same
  `get_date()` unguarded, so the Relationship View crashes on such a date
  too, not only the Detailed Ancestral Report named in the report.

## Test

`gramps/gen/datehandler/test/datedisplay_test.py` —
`DateDisplayInflectionFallbackTest`: an inflection key absent from the
`FORMATS_*` dicts must fall back to the uninflected format. The four cases
(long/short month-year and long/short month) raise `KeyError` before this
change and pass after it.

Fixes [#14100](https://gramps-project.org/bugs/view.php?id=14100).
