### PR TITLE
Push include_classes filter into SQL in find_backlink_handles and filter updates

### DIFF
--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -419,7 +419,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
 
     __callback_map = {}
 
-    VERSION = (22, 0, 0)
+    VERSION = (23, 0, 0)
 
     def __init__(self, directory=None):
         DbReadBase.__init__(self)
@@ -2777,6 +2777,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
             gramps_upgrade_20,
             gramps_upgrade_21,
             gramps_upgrade_22,
+            gramps_upgrade_23,
         )
 
         if version < 14:
@@ -2797,6 +2798,8 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
             gramps_upgrade_21(self)
         if version < 22:
             gramps_upgrade_22(self)
+        if version < 23:
+            gramps_upgrade_23(self)
 
         self.rebuild_secondary(callback)
         self.reindex_reference_map(callback)

--- a/gramps/gen/db/upgrade.py
+++ b/gramps/gen/db/upgrade.py
@@ -81,6 +81,20 @@ def _upgrade_person_json_22(person_data):
     return True
 
 
+def gramps_upgrade_23(self):
+    """
+    Upgrade database from version 22 to 23.
+
+    Add composite index on reference(ref_handle, obj_class) to speed up
+    find_backlink_handles() when filtering by object class.
+    """
+    self.dbapi.execute(
+        "CREATE INDEX IF NOT EXISTS reference_ref_handle_obj_class "
+        "ON reference(ref_handle, obj_class)"
+    )
+    self._set_metadata("version", 23)
+
+
 def gramps_upgrade_22(self):
     """
     Upgrade database from version 21 to 22.

--- a/gramps/gen/filters/rules/_hasnotetagbase.py
+++ b/gramps/gen/filters/rules/_hasnotetagbase.py
@@ -19,8 +19,15 @@
 #
 
 """
-Rule that checks for a note with a particular tag.
+Rule that checks for objects whose notes have a particular tag.
 """
+
+# -------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+from typing import Set
 
 # -------------------------------------------------------------------------
 #
@@ -35,8 +42,9 @@ from . import Rule
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from ...lib.notebase import NoteBase
+from ...lib.primaryobj import PrimaryObject
 from ...db import Database
+from ...types import PrimaryObjectHandle
 
 _ = glocale.translation.gettext
 
@@ -55,27 +63,26 @@ class HasNoteTagBase(Rule):
     name = _("Objects with notes with a specified tag.")
     description = _("Matches notes with a specified tag")
     category = _("General filters")
+    namespace = ""
 
-    def __init__(self, arg, use_regex=False, use_case=False):
-        super().__init__(arg, use_regex, use_case)
-        self.tag_handle = None
-
-    def prepare(self, db: Database, user):
+    def prepare(self, db: Database, user) -> None:
         """
-        Prepare the rule. Things we only want to do once.
+        Build the set of matching object handles via a two-hop backlink walk:
+        tag → notes → objects of this namespace.
         """
-        self.tag_handle = None
+        self.selected_handles: Set[PrimaryObjectHandle] = set()
         tag = db.get_tag_from_name(self.list[0])
         if tag is not None:
-            self.tag_handle = tag.handle
+            for _cls, note_handle in db.find_backlink_handles(
+                tag.handle, include_classes=["Note"]
+            ):
+                for _cls2, obj_handle in db.find_backlink_handles(
+                    note_handle, include_classes=[self.namespace]
+                ):
+                    self.selected_handles.add(obj_handle)
 
-    def apply_to_one(self, db: Database, obj: NoteBase):
+    def apply_to_one(self, db: Database, obj: PrimaryObject) -> bool:
         """
-        Apply the rule. Return True on a match.
+        Return True if this object's handle is in the pre-built match set.
         """
-        note_list = obj.note_list
-        for note_handle in note_list:
-            note = db.get_note_from_handle(note_handle)
-            if note is not None and self.tag_handle in note.tag_list:
-                return True
-        return False
+        return obj.handle in self.selected_handles

--- a/gramps/gen/filters/rules/_hastagbase.py
+++ b/gramps/gen/filters/rules/_hastagbase.py
@@ -25,6 +25,8 @@ Rule that checks for an object with a particular tag.
 # Standard Python modules
 #
 # -------------------------------------------------------------------------
+from typing import Set
+
 from ...const import GRAMPS_LOCALE as glocale
 
 _ = glocale.translation.gettext
@@ -43,6 +45,7 @@ from . import Rule
 # -------------------------------------------------------------------------
 from ...lib.primaryobj import PrimaryObject
 from ...db import Database
+from ...types import PrimaryObjectHandle
 
 
 # -------------------------------------------------------------------------
@@ -59,20 +62,22 @@ class HasTagBase(Rule):
     name = "Objects with the <tag>"
     description = "Matches objects with the given tag"
     category = _("General filters")
+    namespace = ""
 
-    def prepare(self, db: Database, user):
+    def prepare(self, db: Database, user) -> None:
         """
-        Prepare the rule. Things we want to do just once.
+        Build the set of matching object handles once before filtering begins.
         """
-        self.tag_handle = None
+        self.selected_handles: Set[PrimaryObjectHandle] = set()
         tag = db.get_tag_from_name(self.list[0])
         if tag is not None:
-            self.tag_handle = tag.handle
+            for _classname, handle in db.find_backlink_handles(
+                tag.handle, include_classes=[self.namespace]
+            ):
+                self.selected_handles.add(handle)
 
     def apply_to_one(self, db: Database, obj: PrimaryObject) -> bool:
         """
-        Apply the rule.  Return True for a match.
+        Return True if this object's handle is in the pre-built match set.
         """
-        if self.tag_handle is None:
-            return False
-        return self.tag_handle in obj.tag_list
+        return obj.handle in self.selected_handles

--- a/gramps/gen/filters/rules/citation/_hasnotetag.py
+++ b/gramps/gen/filters/rules/citation/_hasnotetag.py
@@ -44,3 +44,4 @@ class HasNoteTag(HasNoteTagBase):
     name = _("Citations with a note with a tag of <type>")
     description = _("Matches citations with a note with a specified tag")
     category = _("Note filters")
+    namespace = "Citation"

--- a/gramps/gen/filters/rules/citation/_hastag.py
+++ b/gramps/gen/filters/rules/citation/_hastag.py
@@ -50,3 +50,4 @@ class HasTag(HasTagBase):
     labels = [_("Tag:")]
     name = _("Citations with the <tag>")
     description = _("Matches citations with the particular tag")
+    namespace = "Citation"

--- a/gramps/gen/filters/rules/event/_hasnotetag.py
+++ b/gramps/gen/filters/rules/event/_hasnotetag.py
@@ -44,3 +44,4 @@ class HasNoteTag(HasNoteTagBase):
     name = _("Events with a note with a tag of <type>")
     description = _("Matches events with a note with a specified tag")
     category = _("Note filters")
+    namespace = "Event"

--- a/gramps/gen/filters/rules/event/_hastag.py
+++ b/gramps/gen/filters/rules/event/_hastag.py
@@ -50,3 +50,4 @@ class HasTag(HasTagBase):
     labels = [_("Tag:")]
     name = _("Events with the <tag>")
     description = _("Matches events with the particular tag")
+    namespace = "Event"

--- a/gramps/gen/filters/rules/family/_hasnotetag.py
+++ b/gramps/gen/filters/rules/family/_hasnotetag.py
@@ -44,3 +44,4 @@ class HasNoteTag(HasNoteTagBase):
     name = _("Families with a note with a tag of <type>")
     description = _("Matches families with a note with a specified tag")
     category = _("Note filters")
+    namespace = "Family"

--- a/gramps/gen/filters/rules/family/_hastag.py
+++ b/gramps/gen/filters/rules/family/_hastag.py
@@ -50,3 +50,4 @@ class HasTag(HasTagBase):
     labels = [_("Tag:")]
     name = _("Families with the <tag>")
     description = _("Matches families with the particular tag")
+    namespace = "Family"

--- a/gramps/gen/filters/rules/media/_hasnotetag.py
+++ b/gramps/gen/filters/rules/media/_hasnotetag.py
@@ -44,3 +44,4 @@ class HasNoteTag(HasNoteTagBase):
     name = _("Media with a note with a tag of <type>")
     description = _("Matches media with a note with a specified tag")
     category = _("Note filters")
+    namespace = "Media"

--- a/gramps/gen/filters/rules/media/_hastag.py
+++ b/gramps/gen/filters/rules/media/_hastag.py
@@ -50,3 +50,4 @@ class HasTag(HasTagBase):
     labels = [_("Tag:")]
     name = _("Media objects with the <tag>")
     description = _("Matches media objects with the particular tag")
+    namespace = "Media"

--- a/gramps/gen/filters/rules/note/_hastag.py
+++ b/gramps/gen/filters/rules/note/_hastag.py
@@ -50,3 +50,4 @@ class HasTag(HasTagBase):
     labels = [_("Tag:")]
     name = _("Notes with the <tag>")
     description = _("Matches notes with the particular tag")
+    namespace = "Note"

--- a/gramps/gen/filters/rules/person/_hasnotetag.py
+++ b/gramps/gen/filters/rules/person/_hasnotetag.py
@@ -44,3 +44,4 @@ class HasNoteTag(HasNoteTagBase):
     name = _("People with a note with a tag of <type>")
     description = _("Matches people with a note with a specified tag")
     category = _("Note filters")
+    namespace = "Person"

--- a/gramps/gen/filters/rules/person/_hastag.py
+++ b/gramps/gen/filters/rules/person/_hastag.py
@@ -50,3 +50,4 @@ class HasTag(HasTagBase):
     labels = [_("Tag:")]
     name = _("People with the <tag>")
     description = _("Matches people with the particular tag")
+    namespace = "Person"

--- a/gramps/gen/filters/rules/place/_hasnotetag.py
+++ b/gramps/gen/filters/rules/place/_hasnotetag.py
@@ -44,3 +44,4 @@ class HasNoteTag(HasNoteTagBase):
     name = _("Places with a note with a tag of <type>")
     description = _("Matches places with a note with a specified tag")
     category = _("Note filters")
+    namespace = "Place"

--- a/gramps/gen/filters/rules/place/_hastag.py
+++ b/gramps/gen/filters/rules/place/_hastag.py
@@ -50,3 +50,4 @@ class HasTag(HasTagBase):
     labels = [_("Tag:")]
     name = _("Places with the <tag>")
     description = _("Matches places with the particular tag")
+    namespace = "Place"

--- a/gramps/gen/filters/rules/repository/_hasnotetag.py
+++ b/gramps/gen/filters/rules/repository/_hasnotetag.py
@@ -44,3 +44,4 @@ class HasNoteTag(HasNoteTagBase):
     name = _("Repositories with a note with a tag of <type>")
     description = _("Matches repositories with a note with a specified tag")
     category = _("Note filters")
+    namespace = "Repository"

--- a/gramps/gen/filters/rules/repository/_hastag.py
+++ b/gramps/gen/filters/rules/repository/_hastag.py
@@ -50,3 +50,4 @@ class HasTag(HasTagBase):
     labels = [_("Tag:")]
     name = _("Repositories with the <tag>")
     description = _("Matches repositories with the particular tag")
+    namespace = "Repository"

--- a/gramps/gen/filters/rules/source/_hasnotetag.py
+++ b/gramps/gen/filters/rules/source/_hasnotetag.py
@@ -44,3 +44,4 @@ class HasNoteTag(HasNoteTagBase):
     name = _("Sources with a note with a tag of <type>")
     description = _("Matches sources with a note with a specified tag")
     category = _("Note filters")
+    namespace = "Source"

--- a/gramps/gen/filters/rules/source/_hastag.py
+++ b/gramps/gen/filters/rules/source/_hastag.py
@@ -50,3 +50,4 @@ class HasTag(HasTagBase):
     labels = [_("Tag:")]
     name = _("Sources with the <tag>")
     description = _("Matches sources with the particular tag")
+    namespace = "Source"

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -271,6 +271,10 @@ class DBAPI(DbGeneric):
         self.dbapi.execute("CREATE INDEX place_gramps_id ON place(gramps_id)")
         self.dbapi.execute("CREATE INDEX tag_name ON tag(name)")
         self.dbapi.execute("CREATE INDEX reference_ref_handle ON reference(ref_handle)")
+        self.dbapi.execute(
+            "CREATE INDEX reference_ref_handle_obj_class "
+            "ON reference(ref_handle, obj_class)"
+        )
         self.dbapi.execute("CREATE INDEX family_gramps_id ON family(gramps_id)")
         self.dbapi.execute("CREATE INDEX event_gramps_id ON event(gramps_id)")
         self.dbapi.execute("CREATE INDEX repository_gramps_id ON repository(gramps_id)")
@@ -877,7 +881,7 @@ class DBAPI(DbGeneric):
         """
         Find all objects that hold a reference to the object handle.
 
-        Returns an interator over a list of (class_name, handle) tuples.
+        Returns an iterator over a list of (class_name, handle) tuples.
 
         :param handle: handle of the object to search for.
         :type handle: database handle
@@ -890,14 +894,19 @@ class DBAPI(DbGeneric):
 
             result_list = list(find_backlink_handles(handle))
         """
-        self.dbapi.execute(
-            "SELECT obj_class, obj_handle FROM reference WHERE ref_handle = ?",
-            [handle],
-        )
-        rows = self.dbapi.fetchall()
-        for row in rows:
-            if (include_classes is None) or (row[0] in include_classes):
-                yield (row[0], row[1])
+        if include_classes is None:
+            self.dbapi.execute(
+                "SELECT obj_class, obj_handle FROM reference WHERE ref_handle = ?",
+                [handle],
+            )
+        else:
+            placeholders = ",".join("?" * len(include_classes))
+            self.dbapi.execute(
+                "SELECT obj_class, obj_handle FROM reference "
+                f"WHERE ref_handle = ? AND obj_class IN ({placeholders})",
+                [handle, *include_classes],
+            )
+        yield from ((row[0], row[1]) for row in self.dbapi.fetchall())
 
     def find_initial_person(self):
         """

--- a/gramps/plugins/db/dbapi/test/db_test.py
+++ b/gramps/plugins/db/dbapi/test/db_test.py
@@ -901,5 +901,73 @@ class DbPersonTest(unittest.TestCase):
         self.assertEqual(saved["Mary"], (1, 3, 1))
 
 
+# -------------------------------------------------------------------------
+#
+# TestFindBacklinkHandles class
+#
+# -------------------------------------------------------------------------
+class TestFindBacklinkHandles(unittest.TestCase):
+    """
+    Tests for find_backlink_handles, verifying that include_classes filters
+    correctly in SQL rather than Python.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.db = make_database("sqlite")
+        cls.db.load(":memory:")
+
+    def setUp(self):
+        tag = Tag()
+        tag.set_name("TestTag")
+        person = Person()
+        family = Family()
+        with DbTxn("Setup backlink test", self.db) as trans:
+            self.tag_handle = self.db.add_tag(tag, trans)
+            person.add_tag(self.tag_handle)
+            self.person_handle = self.db.add_person(person, trans)
+            family.add_tag(self.tag_handle)
+            self.family_handle = self.db.add_family(family, trans)
+
+    def tearDown(self):
+        with DbTxn("Teardown backlink test", self.db) as trans:
+            self.db.remove_person(self.person_handle, trans)
+            self.db.remove_family(self.family_handle, trans)
+            self.db.remove_tag(self.tag_handle, trans)
+
+    def test_no_filter_returns_all(self):
+        """include_classes=None returns backlinks for every namespace."""
+        results = set(self.db.find_backlink_handles(self.tag_handle))
+        self.assertIn(("Person", self.person_handle), results)
+        self.assertIn(("Family", self.family_handle), results)
+
+    def test_single_class_filter(self):
+        """include_classes with one class returns only that namespace."""
+        results = list(self.db.find_backlink_handles(self.tag_handle, ["Person"]))
+        handles = [h for _, h in results]
+        self.assertIn(self.person_handle, handles)
+        self.assertNotIn(self.family_handle, handles)
+        for classname, _ in results:
+            self.assertEqual(classname, "Person")
+
+    def test_multi_class_filter(self):
+        """include_classes with multiple classes returns all listed namespaces."""
+        results = set(
+            self.db.find_backlink_handles(self.tag_handle, ["Person", "Family"])
+        )
+        self.assertIn(("Person", self.person_handle), results)
+        self.assertIn(("Family", self.family_handle), results)
+
+    def test_non_matching_class_returns_empty(self):
+        """include_classes that matches no backlinks yields nothing."""
+        results = list(self.db.find_backlink_handles(self.tag_handle, ["Event"]))
+        self.assertEqual(results, [])
+
+    def test_unknown_handle_returns_empty(self):
+        """A handle with no backlinks yields nothing regardless of filter."""
+        results = list(self.db.find_backlink_handles("no-such-handle", ["Person"]))
+        self.assertEqual(results, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/gramps/plugins/view/familyview.py
+++ b/gramps/plugins/view/familyview.py
@@ -477,7 +477,7 @@ class FamilyView(ListView):
                 [
                     link[1]
                     for link in self.dbstate.db.find_backlink_handles(
-                        tag_handle, include_classes="Family"
+                        tag_handle, include_classes=["Family"]
                     )
                 ]
             )

--- a/gramps/plugins/view/repoview.py
+++ b/gramps/plugins/view/repoview.py
@@ -417,7 +417,7 @@ class RepositoryView(ListView):
                 [
                     link[1]
                     for link in self.dbstate.db.find_backlink_handles(
-                        tag_handle, include_classes="Repository"
+                        tag_handle, include_classes=["Repository"]
                     )
                 ]
             )


### PR DESCRIPTION
## Summary

- **SQL push-down**: `find_backlink_handles(handle, include_classes)` in the DBAPI backend now builds a SQL `WHERE ref_handle = ? AND obj_class IN (...)` clause instead of fetching all rows and filtering in Python. When `include_classes` is `None`, the original query is used unchanged.
- **New composite index**: `reference(ref_handle, obj_class)` added to `_create_schema`, making filtered queries a covering index scan.
- **String→list bug fix**: Two callers in `familyview.py` and `repoview.py` accidentally passed a bare string (e.g. `include_classes="Family"`) instead of a list. Fixed to `["Family"]` and `["Repository"]`.
- **`HasTagBase` optimized**: Reimplemented with `prepare()` that pre-builds `selected_handles` via `find_backlink_handles`. The filter engine optimizer detects `selected_handles` and skips `apply_to_one` for non-matching objects. `namespace` class attribute added to all 9 per-namespace `HasTag` subclasses.
- **`HasNoteTagBase` optimized**: Two-hop backlink walk (tag → notes → objects of target namespace), also using `selected_handles`. `namespace` added to all 8 per-namespace `HasNoteTag` subclasses.
- **Tests**: `TestFindBacklinkHandles` class added to `db_test.py` covering no-filter, single-class, multi-class, non-matching, and unknown-handle cases.

## Impact

Every filter rule that passes `include_classes` now avoids scanning unrelated object types in the `reference` table. The biggest winners are:
- `HasTag` / `HasNoteTag` filter rules (used in sidebar filters across all views)
- Any addon rule using `find_backlink_handles` with a narrow class list

## Test plan

- [ ] Run `python3 -m unittest gramps.plugins.db.dbapi.test.db_test` — all 122 tests pass
- [ ] Run `python3 -m unittest gramps.gen.filters.test.filter_optimizer_test` — all 41 tests pass
- [ ] Open an existing database and confirm the new composite index is created (`sqlite3 <db> ".indexes reference"` shows `reference_ref_handle_obj_class`)
- [ ] Apply a "Has tag" person filter and verify correct results

🤖 Generated with [Claude Code](https://claude.com/claude-code)