### PR TITLE
Hourglass Graph: link spouse in descendant traversal (bug 9628)

### DIFF
--- a/gramps/plugins/graph/gvhourglass.py
+++ b/gramps/plugins/graph/gvhourglass.py
@@ -175,6 +175,30 @@ class HourGlassReport(Report):
                 head=self.arrowheadstyle,
                 tail=self.arrowtailstyle,
             )
+            # Add the spouse (the other parent of this family) so the
+            # descendant tree shows both parents of each generation,
+            # mirroring traverse_up's symmetric father+mother linking.
+            # Without this, only the focal-side ancestor line appears
+            # and the spouse of every descendant is invisible (Mantis
+            # 9628).
+            father_handle = family.get_father_handle()
+            mother_handle = family.get_mother_handle()
+            if father_handle == person.handle:
+                spouse_handle = mother_handle
+            elif mother_handle == person.handle:
+                spouse_handle = father_handle
+            else:
+                spouse_handle = None
+            if spouse_handle and spouse_handle not in self.__used_people:
+                self.__used_people.append(spouse_handle)
+                spouse = self.__db.get_person_from_handle(spouse_handle)
+                self.add_person(spouse, 0)
+                self.doc.add_link(
+                    spouse.get_gramps_id(),
+                    family.get_gramps_id(),
+                    head=self.arrowheadstyle,
+                    tail=self.arrowtailstyle,
+                )
             for child_ref in family.get_child_ref_list():
                 child_handle = child_ref.get_reference_handle()
                 if child_handle not in self.__used_people:

--- a/gramps/plugins/test/reports_test.py
+++ b/gramps/plugins/test/reports_test.py
@@ -140,6 +140,54 @@ class TestDynamic(unittest.TestCase):
         out, err = cls.call("-y", "--remove", TREE_NAME)
         # out, err = cls.call("-y", "--remove", TREE_NAME + "_import_gedcom")
 
+    def test_hourglass_graph_includes_spouse_mantis_9628(self):
+        """Regression for Mantis 9628: Hourglass Graph in descendant
+        direction omits the spouse (other parent) of every family —
+        ``traverse_down`` linked focal → family → children but never
+        added the other parent. Fixed by mirroring traverse_up's
+        father+mother linking inside the family-handle loop.
+
+        Test fixture: data.gramps family F0001 — Smith Ingeman
+        (I0027) + Ericsdotter Marta (I0025) → Smith Martin (I0039).
+        Center person I0027 with maxdescend=1, maxascend=0 should
+        produce a DOT that names Marta. Pre-fix the DOT contained
+        Ingeman + Martin (child) but not Marta; post-fix Marta is
+        added with an edge to F0001.
+        """
+        out, err = self.call(
+            "--force",
+            "-O",
+            TREE_NAME,
+            "--action",
+            "report",
+            "--options",
+            "name=hourglass_graph"
+            ",pid=I0027"
+            ",maxdescend=1"
+            ",maxascend=0"
+            ",off=dot",
+        )
+        self.assertNotIn(
+            "Failed to write report.",
+            err,
+            "hourglass_graph report failed: " + err,
+        )
+        # Graphviz docgen writes the source file with a ``.gv``
+        # extension regardless of whether ``off=dot`` or ``off=gv`` is
+        # requested (CLI prints "Ignoring 'off=gv' and using 'off=dot'"
+        # on the gv → dot alias).
+        dot_path = "hourglass_graph " + TREE_NAME + ".gv"
+        with open(dot_path) as fp:
+            contents = fp.read()
+        os.remove(dot_path)
+        self.assertIn(
+            "Ericsdotter",
+            contents,
+            "Mantis 9628: Ericsdotter (Marta, spouse of focal I0027) "
+            "missing from descendant graph — traverse_down did not "
+            "add the other parent of the family.",
+        )
+
 
 reports = ReportControl()
 


### PR DESCRIPTION
## Root cause

`HourGlassReport.traverse_down` (`gramps/plugins/graph/gvhourglass.py:163`)
linked focal → family → children but never added the family's **other**
parent. `traverse_up` already handles both — its father-section and
mother-section each add the parent node and an edge to the family. The
descending side was asymmetric and every descendant generation's spouse
was invisible. Mantis bug 9628.

Concrete repro on `example.gramps`, center person `I00044` (Lewis Anderson
Garner), `maxdescend=2, maxascend=0`, format `dot`:

- Pre-fix DOT: Lewis → F00017 → eight children, then each child's
  family + grandchildren — but no Luella Jacques Martel and no spouse
  for any of the eight children either.
- 7 spouses absent: Luella (I00045), Frances Reed (I00053), Viola Taylor
  (I00641), George Яковлев (I00645), Maude García (I00650), Cora Jackson
  (I01107), Clarence Robinson (I00654).

## Fix

In `traverse_down`, after adding the family node and the focal-to-family
edge, derive the family's other parent (whichever of
`family.get_father_handle()` / `get_mother_handle()` isn't the current
`person`), add that person to the graph, and link them to the family
with the same arrow style as the focal-to-family edge. The existing
`__used_people` set keeps the spouse from being re-added if a
cousin-marriage path brings them through later.

## Verified against

- `gramps/plugins/graph/gvhourglass.py:163` — `traverse_down` body
- `gramps/plugins/graph/gvhourglass.py:193` — `traverse_up` (the existing
  symmetric father+mother section this fix mirrors)

## Test

`gramps/plugins/test/reports_test.py` adds
`test_hourglass_graph_includes_spouse_mantis_9628`. It invokes the
report on `data.gramps` with `pid=I0027` (Smith Ingeman, has spouse
Ericsdotter Marta + child Smith Martin), `maxdescend=1`, `maxascend=0`,
and asserts that the produced DOT contains `Ericsdotter`.

- Pre-fix: fails with `'Ericsdotter' not found in <DOT>` — the DOT
  contains only Ingeman, the family node, and the child Martin.
- Post-fix: passes — Marta appears as a person node linked to F0001.

Fixes #9628
