### PR TITLE
keep gen/db/upgrade.py off gramps.gui/cli imports (bug 6085)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,83 @@
 
 This document specifies rules and conventions that agents should follow when making changes to the Gramps codebase.
 
+## Commands
+
+**Run from source (no install):**
+```bash
+python3 Gramps.py
+```
+
+**Build wheel:**
+```bash
+python3 -m build --wheel
+```
+
+**Run all tests:**
+```bash
+export GDK_BACKEND=-
+export GRAMPS_RESOURCES=build/share
+export LANGUAGE= 
+export LANG=en_US.utf-8 
+python3 -m unittest discover -p "*_test.py"
+```
+
+**Run a single test module or method:**
+```bash
+python3 -m unittest gramps.gen.db.test.db_test
+python3 -m unittest gramps.gen.db.test.db_test.TestGenericDb.test_get_person
+```
+
+**Type checking:**
+```bash
+mypy
+```
+
+**Code formatting (must pass CI):**
+```bash
+black .
+# Check only:
+black --check .
+```
+
+## Architecture
+
+Gramps is a GTK4 genealogy application. The codebase is split into four main packages:
+
+### `gramps/gen/` — Core (no GUI dependency)
+- `lib/` — Data model: `Person`, `Family`, `Event`, `Place`, `Source`, `Citation`, `Repository`, `Media`, `Note`, `Tag`. All inherit from `PrimaryObject` (has a database handle) or `SecondaryObject`.
+- `db/` — Database abstraction layer. `DbReadBase` / `DbBase` are the abstract interfaces. `generic.py` is the DBAPI-based implementation used by SQLite, DuckDB, MySQL, PostgreSQL backends. Transactions via `DbTxn`; undo/redo built-in.
+- `plug/` — Plugin system core: `BasePluginManager` (singleton), `PluginRegister`, plugin metadata, and base `Plugin` class.
+- `filters/`, `datehandler/`, `display/` — Shared utilities with no GUI imports.
+
+### `gramps/gui/` — GTK4 frontend
+- `editors/` — Modal dialogs for editing each primary object type.
+- `views/` — Navigation views (People, Families, Events, etc.) that populate the main window.
+- `grampsgui.py` — Main window and view-switching logic.
+- `dbman.py` — GUI database manager (open/close/import/export).
+- `configure.py` — Preferences dialog.
+- `glade/` — GTK UI definition files (`.glade` / `.ui`).
+
+### `gramps/plugins/` — All plugin implementations
+- `db/` — Database backends (bsddb legacy, dbapi/SQLite default, duckdb, mysql, postgresql).
+- `gramplet/` — ~50 dashboard widgets (mini read-only views). Each is a self-contained gramplet.
+- `importer/`, `export/` — GEDCOM, XML, CSV, and other formats.
+- `view/`, `tool/`, `textreport/`, `drawreport/`, `quickview/`, `sidebar/` — Other plugin categories.
+
+### `gramps/cli/` — Command-line interface
+- `grampscli.py` — Non-GUI entry point (import/export/script automation).
+- `arghandler.py` — Argument parsing and dispatch.
+
+### Plugin system
+Plugins are discovered from `~/.local/share/gramps/grampsx.x/plugins/` (user) and the system prefix. Each plugin registers itself via a `gpr.yaml` file or a `register()` call. The `BasePluginManager` singleton loads and manages them. Categories: Importers, Exporters, DB backends, Gramplets, Views, Tools, Reports, Quick views, Sidebars, Map services.
+
+### Database backends
+The default backend is DBAPI (SQLite via `gramps/plugins/db/dbapi/`). All backends implement the `DbReadBase`/`DbBase` interface from `gramps/gen/db/`. Schema migrations live in `gramps/gen/db/upgrade.py`.
+
+## CI
+
+The CI pipeline (`.github/workflows/gramps-ci.yml`) runs: build wheel → `mypy` → `unittest discover`. The `black.yml` workflow checks formatting on every push. Both must pass before merging.
+
 ## Code Style & Formatting
 
 ### Black
@@ -24,7 +101,16 @@ All functions and methods must have type hints using Python 3.10+ syntax:
 
 ### Docstrings
 
-All functions and methods must have docstrings using Sphinx format:
+All functions and methods must have docstrings. Keep them concise — a short description is almost always enough:
+
+```python
+def close(self):
+    """
+    Close the specified database.
+    """
+```
+
+Use the full Sphinx format (`:param:`, `:type:`, `:returns:`, `:rtype:`) only when the parameters or return value are non-obvious and not already expressed by type hints:
 
 ```python
 def get_person_from_gramps_id(self, gramps_id: PersonGrampsID) -> Person | None:
@@ -38,27 +124,38 @@ def get_person_from_gramps_id(self, gramps_id: PersonGrampsID) -> Person | None:
     """
 ```
 
+Do not add verbose multi-line docstrings to simple functions, and never repeat information already expressed by the function name or type hints.
+
 ### Import Grouping
 
-Imports must be organized into three sections, each separated by a blank line and preceded by a comment header:
+Imports must be organized into sections, each preceded by a comment header of this form:
 
 ```python
-# ------------------------
-# Python modules
-# ------------------------
+# -------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
 import os
 import logging
 
-# ------------------------
-# Gramps modules
-# ------------------------
-from gramps.gen.db.base import DbReadBase
+# -------------------------------------------------------------------------
+#
+# GTK/Gnome modules
+#
+# -------------------------------------------------------------------------
+from gi.repository import Gtk
 
-# ------------------------
-# Gramps specific
-# ------------------------
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from gramps.gen.db.base import DbReadBase
 from .mymodule import MyClass
 ```
+
+Not all sections are required — include only those that apply. Common section names used in the codebase include `Standard Python modules`, `GTK/Gnome modules`, and `Gramps modules`.
 
 ### PEP 8 and Indentation
 
@@ -67,6 +164,8 @@ Code should be PEP 8 compatible, except where that conflicts with Black formatti
 ### Pylint
 
 Run pylint on new code. Ideally new code should score 9 or higher and changes should not reduce the overall pylint score. This is not strictly enforced and should never come at the expense of code clarity, Black formatting, or any other rule in this guide.
+
+Inline suppression comments such as `# pylint: disable=import-outside-toplevel` are not acceptable.
 
 ### Class Headers
 
@@ -104,6 +203,7 @@ raise ValueError(_("Invalid handle: %s") % handle)
 ```
 The alias `_(string , context)` is preferred to `pgettext(context, message)`.
 Use `ngettext(singular, plural, n)` for plural forms.
+
 ## Submodule Import Rules
 
 Files in the `gen` submodule must not import from any other Gramps submodule (e.g., `gui`, `plugins`). The `gen` submodule must remain self-contained.
@@ -146,7 +246,9 @@ Every new `.py` file must include a GPL-2.0-or-later license header with copyrig
 ### Running Tests
 
 ```bash
-GRAMPS_RESOURCES=. python3 -m unittest discover -p "*_test.py"
+export GDK_BACKEND=-
+export GRAMPS_RESOURCES=build/share
+python3 -m unittest discover -p "*_test.py"
 ```
 
 ### Type Checking
@@ -184,7 +286,7 @@ Fixes #12345.
 
 To mark a bug as fixed use the Mantis BT special keywords `Fixes`, `Fixed`, `Resolves` or `Resolved` followed by a `#` and then the bug number without leading zeros. e.g. `Fixes #12345.`.
 To reference an issue the keywords `Bug`, `Bugs`, `Issue`, `Issues`, `Report` or `Reports` may be used with a bug number in the same format for bugs. e.g. `Issue #12345`.
-Multiple issues may be referenced. e.g. `Resolves #12345, #12346.` 
+Multiple issues may be referenced. e.g. `Resolves #12345, #12346.`
 These references should be used in the last line of a commit message.
 
 ## Translation Files
@@ -201,6 +303,11 @@ lists accordingly:
 - Prefer existing exceptions from `gramps/gen/errors.py` and `gramps/gen/db/exceptions.py` over creating new ones.
 - Only introduce a new exception class when none of the existing ones accurately represent the error condition.
 - Raise `HandleError` for invalid or missing handles.
+
 ## Branch merges
 
 Branch merges are not allowed in pull requests.  Rebase rather than merging.
+
+## Pull Requests
+
+All pull requests must be submitted from a branch in your personal fork of the repository, not from a branch pushed directly to the upstream `gramps-project/gramps` remote. Even if you have write access to the upstream remote, create your branch and submit the PR from your fork.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ black --check .
 
 ## Architecture
 
-Gramps is a GTK4 genealogy application. The codebase is split into four main packages:
+Gramps is a GTK3 genealogy application. The codebase is split into four main packages:
 
 ### `gramps/gen/` — Core (no GUI dependency)
 - `lib/` — Data model: `Person`, `Family`, `Event`, `Place`, `Source`, `Citation`, `Repository`, `Media`, `Note`, `Tag`. All inherit from `PrimaryObject` (has a database handle) or `SecondaryObject`.
@@ -51,7 +51,7 @@ Gramps is a GTK4 genealogy application. The codebase is split into four main pac
 - `plug/` — Plugin system core: `BasePluginManager` (singleton), `PluginRegister`, plugin metadata, and base `Plugin` class.
 - `filters/`, `datehandler/`, `display/` — Shared utilities with no GUI imports.
 
-### `gramps/gui/` — GTK4 frontend
+### `gramps/gui/` — GTK3 frontend
 - `editors/` — Modal dialogs for editing each primary object type.
 - `views/` — Navigation views (People, Families, Events, etc.) that populate the main window.
 - `grampsgui.py` — Main window and view-switching logic.

--- a/gramps/cli/clidbman.py
+++ b/gramps/cli/clidbman.py
@@ -67,14 +67,8 @@ _LOG = logging.getLogger(DBLOGNAME)
 #
 # -------------------------------------------------------------------------
 DEFAULT_TITLE = _("Family Tree")
-# Re-exported from ``gramps.gen.db.dbconst`` so existing callers
-# (gramps/gui/dbman.py, gramps/plugins/db/bsddb/bsddb.py and any third-
-# party plugins) keep working.  The canonical location is the gen
-# module so non-CLI consumers — notably ``gramps/gen/db/upgrade.py``
-# — can pull it without violating the gen/cli boundary (Mantis 6085).
-# The redundant ``as NAME_FILE`` is the PEP 484 explicit-re-export form
-# recognised by mypy / pylint / flake8 as intentional, so no lint
-# suppression is required.
+# Canonical location is gramps.gen.db.dbconst (Mantis 6085).
+# ``as NAME_FILE`` is the PEP 484 explicit re-export form for mypy/pylint/flake8.
 from gramps.gen.db.dbconst import NAME_FILE as NAME_FILE
 
 META_NAME = "meta_data.db"

--- a/gramps/cli/clidbman.py
+++ b/gramps/cli/clidbman.py
@@ -67,7 +67,13 @@ _LOG = logging.getLogger(DBLOGNAME)
 #
 # -------------------------------------------------------------------------
 DEFAULT_TITLE = _("Family Tree")
-NAME_FILE = "name.txt"
+# Re-exported from ``gramps.gen.db.dbconst`` so existing callers
+# (gramps/gui/dbman.py, gramps/plugins/db/bsddb/bsddb.py and any third-
+# party plugins) keep working.  The canonical location is the gen
+# module so non-CLI consumers — notably ``gramps/gen/db/upgrade.py``
+# — can pull it without violating the gen/cli boundary (Mantis 6085).
+from gramps.gen.db.dbconst import NAME_FILE  # noqa: F401 (re-export)
+
 META_NAME = "meta_data.db"
 UNAVAILABLE = _("Unavailable")
 

--- a/gramps/cli/clidbman.py
+++ b/gramps/cli/clidbman.py
@@ -72,7 +72,10 @@ DEFAULT_TITLE = _("Family Tree")
 # party plugins) keep working.  The canonical location is the gen
 # module so non-CLI consumers — notably ``gramps/gen/db/upgrade.py``
 # — can pull it without violating the gen/cli boundary (Mantis 6085).
-from gramps.gen.db.dbconst import NAME_FILE  # noqa: F401 (re-export)
+# The redundant ``as NAME_FILE`` is the PEP 484 explicit-re-export form
+# recognised by mypy / pylint / flake8 as intentional, so no lint
+# suppression is required.
+from gramps.gen.db.dbconst import NAME_FILE as NAME_FILE
 
 META_NAME = "meta_data.db"
 UNAVAILABLE = _("Unavailable")

--- a/gramps/gen/db/dbconst.py
+++ b/gramps/gen/db/dbconst.py
@@ -45,6 +45,7 @@ __all__ = (
     "SCHVERSFN",
     "PCKVERSFN",
     "DBBACKEND",
+    "NAME_FILE",
     "PERSON_KEY",
     "FAMILY_KEY",
     "SOURCE_KEY",
@@ -70,6 +71,7 @@ DBLOCKFN = "lock"  # File name of lock file
 DBRECOVFN = "need_recover"  # File name of recovery file
 BDBVERSFN = "bdbversion.txt"  # File name of Berkeley DB version file
 DBBACKEND = "database.txt"  # File name of Database backend file
+NAME_FILE = "name.txt"  # File name of the Family Tree display-name file
 SCHVERSFN = "schemaversion.txt"  # File name of schema version file
 PCKVERSFN = "pickleupgrade.txt"  # Indicator that pickle has been upgrade t Python3
 DBLOGNAME = ".Db"  # Name of logger

--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -660,6 +660,12 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         self.surname_list = []
         self.genderStats = GenderStats()  # can pass in loaded stats as dict
         self.owner = Researcher()
+        # Set by ``gen/db/upgrade.gramps_upgrade_16`` so the GUI caller
+        # in ``gramps/gui/dbloader.py`` can display the v15→v16 upgrade
+        # statistics via ``InfoDialog`` after ``load()`` returns.  Kept
+        # here so ``gen/db/upgrade.py`` does not have to import from
+        # ``gramps.gui`` (Mantis 6085).
+        self.upgrade_summary: str | None = None
         if directory:
             self.load(directory)
 

--- a/gramps/gen/db/test/gen_db_upgrade_imports_test.py
+++ b/gramps/gen/db/test/gen_db_upgrade_imports_test.py
@@ -1,6 +1,8 @@
 #
 # Gramps - a GTK+/GNOME based genealogy program
 #
+# Copyright (C) 2026  Eduard Ralph
+#
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/gramps/gen/db/test/gen_db_upgrade_imports_test.py
+++ b/gramps/gen/db/test/gen_db_upgrade_imports_test.py
@@ -1,0 +1,102 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Architectural guard against the Mantis 6085 regression class.
+
+bmcage's 2012 audit (Mantis 6085, "Import outside of the gen submodule")
+listed five files under ``gramps/gen/`` that pulled symbols from
+``gramps.gui`` or ``gramps.cli``.  Four of those — ``filters/rules/
+_changedsincebase.py``, ``filters/rules/person/
+_deeprelationshippathbetween.py``, ``plug/_gramplet.py`` and
+``merge/diff.py`` — were cleared up over the years.  The fifth,
+``gen/db/upgrade.py``, kept two imports until this commit:
+
+  * ``from gramps.cli.clidbman import NAME_FILE``
+  * ``from gramps.gui.dialog import InfoDialog``
+
+Now ``NAME_FILE`` lives in ``gramps/gen/db/dbconst.py`` (re-exported
+from ``gramps/cli/clidbman.py`` for the gui / bsddb-converter callers
+that still pull it from there) and ``gramps_upgrade_16``'s upgrade-
+statistics dialog text is stored on ``self.upgrade_summary`` so the
+``gramps/gui/dbloader.py`` GUI caller can display it.
+
+This test fails if any module under ``gramps/gen/`` re-introduces an
+``import`` or ``from`` statement that references ``gramps.gui`` or
+``gramps.cli``.  It is intentionally a source-grep — the architectural
+invariant lives at the module-import level, and the diagnostic value
+is in catching new violations early, not in exercising every code
+path.
+"""
+
+import os
+import re
+import unittest
+
+import gramps.gen
+
+# Anchor to the actual ``gramps.gen`` package directory.  ``DATA_DIR``
+# from ``gramps.gen.const`` points at the build-artifact data folder,
+# not the source tree, so using ``gramps.gen.__file__`` is the only
+# reliable way to find the .py files we want to grep.
+GEN_DIR = os.path.dirname(os.path.abspath(gramps.gen.__file__))
+
+# Match real import statements, not docstring mentions or comments.
+# Examples that match:
+#     from gramps.gui.dialog import InfoDialog
+#     from gramps.cli.clidbman import NAME_FILE
+#     import gramps.gui.utils
+# Examples that do *not* match:
+#     # See gramps.gui.dbloader for how this is consumed.
+#     """GUI orchestration lives in gramps.gui.fs.fs_import."""
+_FORBIDDEN_IMPORT = re.compile(
+    r"^\s*(?:from\s+gramps\.(?:gui|cli)\b|import\s+gramps\.(?:gui|cli)\b)",
+    re.MULTILINE,
+)
+
+
+class GenImportBoundaryTest(unittest.TestCase):
+    def test_gen_does_not_import_from_gui_or_cli(self):
+        """No file under gramps/gen/ may import from gramps.gui or
+        gramps.cli — gen is meant to be the GUI-agnostic core
+        (Mantis 6085)."""
+        offenders = []
+        for dirpath, _dirnames, filenames in os.walk(GEN_DIR):
+            for name in filenames:
+                if not name.endswith(".py"):
+                    continue
+                # Skip the per-module test directories — tests are free
+                # to import GUI/CLI helpers if they need to drive them.
+                if os.path.basename(dirpath) == "test":
+                    continue
+                path = os.path.join(dirpath, name)
+                with open(path, encoding="utf-8") as fp:
+                    source = fp.read()
+                for match in _FORBIDDEN_IMPORT.finditer(source):
+                    line_no = source.count("\n", 0, match.start()) + 1
+                    rel = os.path.relpath(path, os.path.dirname(GEN_DIR))
+                    offenders.append(f"{rel}:{line_no}: {match.group().strip()}")
+        self.assertFalse(
+            offenders,
+            "Files under gramps/gen/ must not import from gramps.gui or "
+            "gramps.cli (Mantis 6085).  Re-add by moving the symbol into "
+            "gramps/gen/ and re-exporting it from the old location if "
+            "third-party callers depend on the old path.\n  " + "\n  ".join(offenders),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gen/db/test/gen_db_upgrade_imports_test.py
+++ b/gramps/gen/db/test/gen_db_upgrade_imports_test.py
@@ -70,6 +70,11 @@ _FORBIDDEN_IMPORT = re.compile(
 )
 
 
+# ------------------------------------------------------------
+#
+# GenImportBoundaryTest
+#
+# ------------------------------------------------------------
 class GenImportBoundaryTest(unittest.TestCase):
     def test_gen_does_not_import_from_gui_or_cli(self):
         """No file under gramps/gen/ may import from gramps.gui or
@@ -82,7 +87,11 @@ class GenImportBoundaryTest(unittest.TestCase):
                     continue
                 # Skip the per-module test directories — tests are free
                 # to import GUI/CLI helpers if they need to drive them.
-                if os.path.basename(dirpath) == "test":
+                # Match any path component named "test" so fixture sub-
+                # directories under a test/ dir are skipped too, not just
+                # the leaf.
+                rel = os.path.relpath(dirpath, GEN_DIR)
+                if "test" in rel.split(os.sep):
                     continue
                 path = os.path.join(dirpath, name)
                 with open(path, encoding="utf-8") as fp:

--- a/gramps/gen/db/upgrade.py
+++ b/gramps/gen/db/upgrade.py
@@ -1324,7 +1324,10 @@ def gramps_upgrade_16(self):
     # from inside ``gen`` — the GUI caller (gramps/gui/dbloader.py) is
     # responsible for displaying it via ``InfoDialog`` once ``db.load``
     # returns.  Keeps ``gen/db/upgrade.py`` free of any ``gramps.gui``
-    # or ``gramps.cli`` imports (Mantis 6085).
+    # or ``gramps.cli`` imports (Mantis 6085).  Also log it so headless
+    # / CLI runs (which never read ``upgrade_summary``) still surface
+    # the upgrade statistics at ``--debug`` / verbose log level.
+    LOG.info(txt)
     self.upgrade_summary = txt
 
 

--- a/gramps/gen/db/upgrade.py
+++ b/gramps/gen/db/upgrade.py
@@ -1324,10 +1324,11 @@ def gramps_upgrade_16(self):
     # from inside ``gen`` — the GUI caller (gramps/gui/dbloader.py) is
     # responsible for displaying it via ``InfoDialog`` once ``db.load``
     # returns.  Keeps ``gen/db/upgrade.py`` free of any ``gramps.gui``
-    # or ``gramps.cli`` imports (Mantis 6085).  Also log it so headless
-    # / CLI runs (which never read ``upgrade_summary``) still surface
-    # the upgrade statistics at ``--debug`` / verbose log level.
-    LOG.info(txt)
+    # or ``gramps.cli`` imports (Mantis 6085).  Also log it at DEBUG so
+    # CLI runs (which never read ``upgrade_summary``) can still surface
+    # the upgrade statistics at ``--debug`` level, matching the level
+    # of the surrounding upgrade log calls.
+    LOG.debug(txt)
     self.upgrade_summary = txt
 
 

--- a/gramps/gen/db/upgrade.py
+++ b/gramps/gen/db/upgrade.py
@@ -36,13 +36,12 @@ import logging
 # Gramps Modules
 #
 # ------------------------------------------------------------------------
-from gramps.cli.clidbman import NAME_FILE
-from gramps.gen.db.dbconst import CLASS_TO_KEY_MAP
 from gramps.gen.lib import EventType, FamilySearchSync, NameOriginType, Tag, MarkerType
 from gramps.gen.utils.file import create_checksum
 from gramps.gen.utils.id import create_id
-from gramps.gui.dialog import InfoDialog
 from .dbconst import (
+    CLASS_TO_KEY_MAP,
+    NAME_FILE,
     PERSON_KEY,
     FAMILY_KEY,
     EVENT_KEY,
@@ -1321,7 +1320,12 @@ def gramps_upgrade_16(self):
         "in order to merge citations that contain similar\n"
         "information"
     )
-    InfoDialog(_("Upgrade Statistics"), txt, monospaced=True)  # TODO no-parent
+    # Stash the summary on the db instance instead of popping a dialog
+    # from inside ``gen`` — the GUI caller (gramps/gui/dbloader.py) is
+    # responsible for displaying it via ``InfoDialog`` once ``db.load``
+    # returns.  Keeps ``gen/db/upgrade.py`` free of any ``gramps.gui``
+    # or ``gramps.cli`` imports (Mantis 6085).
+    self.upgrade_summary = txt
 
 
 def upgrade_media_list_16(self, media_list):

--- a/gramps/gui/dbloader.py
+++ b/gramps/gui/dbloader.py
@@ -216,14 +216,16 @@ class DbLoader(CLIDbLoader):
                                 dbstate=self.dbstate,
                             )
                         )
-                    self.dbstate.change_database(db)
                     # Display the v15→v16 upgrade statistics if
                     # ``gramps_upgrade_16`` stashed a summary on the db
                     # during the load.  Previously this dialog was
                     # popped from inside ``gramps/gen/db/upgrade.py``,
                     # which forced ``gen`` to import from ``gramps.gui``;
                     # the summary is now handed up here so the gen/gui
-                    # boundary stays clean (Mantis 6085).
+                    # boundary stays clean (Mantis 6085).  Shown *before*
+                    # ``change_database`` so the dialog precedes the main
+                    # window opening — matches the pre-fix UX where the
+                    # dialog popped from inside ``db.load()``.
                     if db.upgrade_summary:
                         InfoDialog(
                             _("Upgrade Statistics"),
@@ -232,6 +234,7 @@ class DbLoader(CLIDbLoader):
                             monospaced=True,
                         )
                         db.upgrade_summary = None
+                    self.dbstate.change_database(db)
                     break
                 except (DbSupportedError, DbUpgradeRequiredError) as msg:
                     if (

--- a/gramps/gui/dbloader.py
+++ b/gramps/gui/dbloader.py
@@ -66,7 +66,13 @@ from gramps.gen.db.exceptions import (
     DbConnectionError,
 )
 from .pluginmanager import GuiPluginManager
-from .dialog import DBErrorDialog, ErrorDialog, QuestionDialog2, WarningDialog
+from .dialog import (
+    DBErrorDialog,
+    ErrorDialog,
+    InfoDialog,
+    QuestionDialog2,
+    WarningDialog,
+)
 from .user import User
 from gramps.gen.errors import DbError
 from .managedwindow import ManagedWindow
@@ -211,6 +217,22 @@ class DbLoader(CLIDbLoader):
                             )
                         )
                     self.dbstate.change_database(db)
+                    # Display the v15→v16 upgrade statistics if
+                    # ``gramps_upgrade_16`` stashed a summary on the db
+                    # during the load.  Previously this dialog was
+                    # popped from inside ``gramps/gen/db/upgrade.py``,
+                    # which forced ``gen`` to import from ``gramps.gui``;
+                    # the summary is now handed up here so the gen/gui
+                    # boundary stays clean (Mantis 6085).
+                    upgrade_summary = getattr(db, "upgrade_summary", None)
+                    if upgrade_summary:
+                        InfoDialog(
+                            _("Upgrade Statistics"),
+                            upgrade_summary,
+                            parent=self.uistate.window,
+                            monospaced=True,
+                        )
+                        db.upgrade_summary = None
                     break
                 except (DbSupportedError, DbUpgradeRequiredError) as msg:
                     if (

--- a/gramps/gui/dbloader.py
+++ b/gramps/gui/dbloader.py
@@ -224,11 +224,10 @@ class DbLoader(CLIDbLoader):
                     # which forced ``gen`` to import from ``gramps.gui``;
                     # the summary is now handed up here so the gen/gui
                     # boundary stays clean (Mantis 6085).
-                    upgrade_summary = getattr(db, "upgrade_summary", None)
-                    if upgrade_summary:
+                    if db.upgrade_summary:
                         InfoDialog(
                             _("Upgrade Statistics"),
-                            upgrade_summary,
+                            db.upgrade_summary,
                             parent=self.uistate.window,
                             monospaced=True,
                         )

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -90,6 +90,11 @@ gramps/gen/db/utils.py
 gramps/gen/db/conversion_tools/__init__.py
 gramps/gen/db/conversion_tools/conversion_21.py
 #
+# gen.db.test package
+#
+gramps/gen/db/test/__init__.py
+gramps/gen/db/test/gen_db_upgrade_imports_test.py
+#
 # gen.display package
 #
 gramps/gen/display/__init__.py


### PR DESCRIPTION
## Summary
**User impact:** When Gramps upgrades an old family tree, the end-of-upgrade "Upgrade Statistics" message popped up as a stray window not attached to the main Gramps window, and even the text-only command-line version of Gramps had to load graphical code it should never need — a long-standing tangle where the shared core reached up into the graphical and command-line layers.

This untangles the core so it no longer depends on those layers: the statistics message is now shown by the graphical layer attached to the main window, and the command line skips the popup entirely.

Reported in Mantis [#6085](https://gramps-project.org/bugs/view.php?id=6085).

## What to look at
The shared core (`gramps/gen/`) is meant to have no dependence on the graphical or command-line front-ends; this removes the last two such imports. To see the user-visible half: run a database upgrade in the GUI and confirm the "Upgrade Statistics" dialog now appears parented to the main window; run the same upgrade on the command line and confirm no dialog pops up. A source-grep test asserts `gen/` imports nothing from `gramps.gui`/`gramps.cli`.

## Root cause
bmcage's 2012 audit (Mantis 6085) listed five files under `gramps/gen/` that imported from `gramps.gui` or `gramps.cli` — the gen submodule is the GUI-agnostic core and was never meant to depend on either. Four sites were cleared over the years; `gen/db/upgrade.py` kept two:

- `from gramps.cli.clidbman import NAME_FILE` (line 39) — the `"name.txt"` constant.
- `from gramps.gui.dialog import InfoDialog` (line 44) — the end-of-upgrade statistics dialog popped from `gramps_upgrade_16`, carrying a `# TODO no-parent` comment from whoever first wrote it.

## Fix
**`NAME_FILE` moves to `gramps/gen/db/dbconst.py`** (the existing database-constants module) and joins its `__all__`. `gramps/cli/clidbman.py` keeps a `from gramps.gen.db.dbconst import NAME_FILE` re-export so the existing callers — `gramps/gui/dbman.py`, `gramps/plugins/db/bsddb/bsddb.py`, and any third-party plugin importing from there — keep working unchanged.

**`gramps_upgrade_16`** now stores the upgrade-statistics text on `self.upgrade_summary` instead of popping a dialog. The GUI caller `gramps/gui/dbloader.py`, after `db.load(…)` returns successfully, reads `db.upgrade_summary` and displays it via `InfoDialog` — and because the call site is now in the GUI layer the dialog gets a proper transient parent (the main window), fixing the historical `# TODO no-parent`. The CLI flow never touches `db.upgrade_summary` and so gets the cleaner no-dialog behaviour it should have had all along.

After the change, `grep -rn -E '^(from gramps\.(gui|cli)|import gramps\.(gui|cli))' gramps/gen/` returns no matches — `gen/` is fully clean for the first time since bmcage filed the bug.

## Verification
- **Claim:** `gramps/gen/` imports nothing from `gramps.gui` or `gramps.cli`; the upgrade-statistics text is handed to the GUI to display (parented to the main window) and left undisplayed on the CLI.
- **Checked:** on master — `gramps/gen/db/upgrade.py:1322` (`gramps_upgrade_16` summary assignment, was `InfoDialog(_("Upgrade Statistics"), txt, …)`), `gramps/gui/dbloader.py:213` (display point after `db.load()`), `gramps/cli/clidbman.py:71` (re-export of `NAME_FILE` from gen), `gramps/gen/db/dbconst.py:48` (`NAME_FILE` declaration). After the change, `grep -rn -E '^(from gramps\.(gui|cli)|import gramps\.(gui|cli))' gramps/gen/` returns no matches.
- **Test:** `gramps/gen/db/test/gen_db_upgrade_imports_test.py` — architectural guard that walks every `.py` under `gramps/gen/` (excluding `test/` subdirs) and asserts no `from gramps.(gui|cli)` / `import gramps.(gui|cli)` statement exists. Pre-fix it fails with `['gen/db/upgrade.py:39: from gramps.cli', 'gen/db/upgrade.py:44: from gramps.gui']`; post-fix it passes. It is intentionally a source-grep rather than an upgrade-run test — the bug class is import architecture, and a runtime test would need a v15-schema database fixture (not in the test data) and a heavyweight db-upgrade harness that does not exist; the grep catches the same regression class with O(file-count) speed and no fixtures.

Fixes [#6085](https://gramps-project.org/bugs/view.php?id=6085)
