### PR TITLE
GEDCOM import: warn on bare-numeric DATE values (bug 9298)

### DIFF
--- a/gramps/plugins/importer/test/importgedcom_ambiguous_date_test.py
+++ b/gramps/plugins/importer/test/importgedcom_ambiguous_date_test.py
@@ -1,0 +1,130 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Mantis 9298 — GEDCOM importer must warn on bare-numeric DATE values.
+
+GEDCOM 5.5.1 requires three-letter month abbreviations (``7 NOV 1959``),
+but some tools (notably ancestry.com exports) emit bare numeric
+``D/M/YYYY`` dates that the spec does not define.  ``libgedcom`` parses
+them as ``MM/DD/YYYY`` per :class:`GedcomDateParser.dhformat_changed`,
+which silently swaps day and month for sources that use ``DD/MM/YYYY``.
+The fix adds a warning per affected event so the user can audit; it does
+not change the parse direction (US users still get the same result they
+always did).
+
+Asserts:
+
+  * Bare numeric date with day ≤ 12 (the silent-swap case) triggers an
+    "Ambiguous numeric date" warning quoting the original GEDCOM text.
+  * Spec-compliant ``5 MAR 1899`` is silent.
+  * Bare numeric date with day > 12 falls back to text-only storage
+    (already visually flagged in Events view) and stays silent — adding
+    a second warning would be noise.
+  * The warning is advisory: ``number_of_errors`` stays at 0 and the
+    summary line remains "GEDCOM import report: No errors detected"."""
+
+import io
+import os
+import tempfile
+import unittest
+
+from gramps.cli.user import User as CliUser
+from gramps.gen.db.utils import import_as_dict
+
+GEDCOM_FIXTURE = """\
+0 HEAD
+1 SOUR Ancestry.com Family Trees
+2 VERS (2026.1)
+1 GEDC
+2 VERS 5.5.1
+2 FORM LINEAGE-LINKED
+1 CHAR UTF-8
+1 SUBM @SUBM@
+0 @SUBM@ SUBM
+1 NAME Bug 9298 fixture
+0 @I1@ INDI
+1 NAME Day Less /Than Thirteen/
+1 SEX M
+1 BIRT
+2 DATE 7/11/1959
+0 @I2@ INDI
+1 NAME Day Greater /Than Twelve/
+1 SEX F
+1 BIRT
+2 DATE 25/3/1934
+0 @I3@ INDI
+1 NAME Spec Compliant /Date/
+1 SEX U
+1 BIRT
+2 DATE 5 MAR 1899
+0 TRLR
+"""
+
+
+class CapturingUser(CliUser):
+    """CLI ``User`` whose ``info`` / ``error`` / ``warn`` output is
+    captured into a :class:`io.StringIO` so tests can assert against it."""
+
+    def __init__(self):
+        self.buf = io.StringIO()
+        super().__init__(error=self.buf, callback=lambda *a, **k: None)
+        # ``info()`` writes through ``self._fileout`` which defaults to
+        # sys.stdout — redirect into our buffer.
+        self._fileout = self.buf
+
+
+class GedcomAmbiguousNumericDateWarningTest(unittest.TestCase):
+    def setUp(self):
+        fd, self.path = tempfile.mkstemp(suffix=".ged", text=True)
+        with os.fdopen(fd, "w") as f:
+            f.write(GEDCOM_FIXTURE)
+        self.user = CapturingUser()
+
+    def tearDown(self):
+        os.unlink(self.path)
+
+    def _import(self):
+        db = import_as_dict(self.path, self.user)
+        self.assertIsNotNone(db, "import_as_dict returned None — import failed")
+        return db, self.user.buf.getvalue()
+
+    def test_silent_swap_case_emits_warning(self):
+        _, out = self._import()
+        # The actionable phrase + the original text both have to land in
+        # the user-visible report.
+        self.assertIn("Ambiguous numeric date", out)
+        self.assertIn("'7/11/1959'", out)
+        self.assertIn("1959-07-11", out)
+
+    def test_spec_compliant_date_is_silent(self):
+        _, out = self._import()
+        self.assertNotIn("'5 MAR 1899'", out)
+
+    def test_textonly_fallback_is_silent(self):
+        # 25/3/1934 — day > 12 — parser fails over to text-only storage,
+        # which is already visually flagged in the Events view as a bold
+        # date.  A second warning would be noise.
+        _, out = self._import()
+        self.assertNotIn("'25/3/1934'", out)
+
+    def test_warning_does_not_count_as_error(self):
+        _, out = self._import()
+        self.assertIn("GEDCOM import report: No errors detected", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -893,6 +893,14 @@ SPAN1 = re.compile(r"\s*FROM\s+\s*(.*)\s+TO\s+@#D?([^@]+)@\s*(.*)$")
 SPAN2 = re.compile(r"\s*FROM\s+@#D?([^@]+)@\s*(.*)\s+TO\s+\s*(.*)$")
 NAME_RE = re.compile(r"/?([^/]*)(/([^/]*)(/([^/]*))?)?")
 SURNAME_RE = re.compile(r"/([^/]*)/([^/]*)")
+# Bare numeric date in DATE values (e.g. "7/11/1959").  GEDCOM requires
+# 3-letter month names; numeric dates are out of spec and unavoidably
+# ambiguous between MM/DD/YYYY and DD/MM/YYYY.  The parser interprets
+# them as MM/DD/YYYY (US format, see GedcomDateParser.dhformat_changed),
+# which silently swaps day and month for exports from tools that emit
+# DD/MM/YYYY (notably ancestry.com — see Mantis 9298).  Used to flag
+# such dates with a warning so the user can audit them after import.
+BARE_NUMERIC_DATE = re.compile(r"^\s*\d{1,2}/\d{1,2}/\d{2,4}\s*$")
 
 
 # -----------------------------------------------------------------------
@@ -3557,6 +3565,54 @@ class GedcomParser(UpdateCallback):
             state.msg += message
         self.errors.append(message)
 
+    def __add_warn(self, problem, line=None, state=None):
+        """Add an advisory message to the import report that does NOT
+        count as an error.  Mirrors the +1/-1 pattern used at the end
+        of ``__finish_import`` for the unknown-references note.
+        Used for things like ambiguous-numeric-date warnings (Mantis 9298)
+        where the importer made a choice the user may want to audit
+        but no record was rejected or truncated."""
+        self.__add_msg(problem, line, state)
+        self.number_of_errors -= 1
+
+    def __warn_if_ambiguous_numeric_date(self, line, state):
+        """If ``line.data`` (a :class:`Date`) was parsed from a bare
+        numeric GEDCOM DATE (e.g. ``7/11/1959``) and the parser
+        committed to a day/month reading, log a warning so the user
+        can verify it.  Bare numerics are not GEDCOM-spec and are
+        unavoidably ambiguous; the importer defaults to MM/DD/YYYY,
+        which silently swaps day and month for sources that emit
+        DD/MM/YYYY (Mantis 9298)."""
+        date = line.data
+        if date.get_modifier() == Date.MOD_TEXTONLY:
+            # day > 12 or otherwise unparseable — already visibly
+            # flagged in the Events view as a textual (bold) date.
+            return
+        text = date.get_text()
+        if not text or not BARE_NUMERIC_DATE.match(text):
+            return
+        # ``line`` is intentionally not passed: ``__add_msg`` truncates
+        # the problem string to 66 columns when a line is supplied, which
+        # drops the actionable half of the warning.  The text below
+        # contains the original GEDCOM date string verbatim, so the user
+        # can still grep their .ged for it without the line number.
+        self.__add_warn(
+            _(
+                "Ambiguous numeric date '%(orig)s' interpreted as "
+                "MM/DD/YYYY (US format) = %(year)d-%(month)02d-%(day)02d. "
+                "If your source uses DD/MM/YYYY (e.g. ancestry.com "
+                "exports), verify and correct after import."
+            )
+            % {
+                "orig": text,
+                "year": date.get_year(),
+                "month": date.get_month(),
+                "day": date.get_day(),
+            },
+            None,
+            state,
+        )
+
     def __check_msgs(self, record_name, state, obj):
         if state.msg == "":
             return
@@ -6092,6 +6148,7 @@ class GedcomParser(UpdateCallback):
         @type state: CurrentState
         """
         state.event.set_date_object(line.data)
+        self.__warn_if_ambiguous_numeric_date(line, state)
 
     def __event_place(self, line, state):
         """

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -572,6 +572,7 @@ gramps/plugins/importer/__init__.py
 #
 # plugins/importer/test directory
 #
+gramps/plugins/importer/test/importgedcom_ambiguous_date_test.py
 gramps/plugins/importer/test/importgeneweb_test.py
 gramps/plugins/importer/test/importvcard_test.py
 #


### PR DESCRIPTION
## Root cause
GEDCOM 5.5.1 requires three-letter month abbreviations (`7 NOV 1959`), but tools such as ancestry.com export bare numeric `D/M/YYYY` dates the spec does not define. `libgedcom.GedcomDateParser` hardcodes `dhformat = "%m/%d/%y"` (en_US locale, `libgedcom.py:925`), so a bare numeric date is unconditionally read MM/DD/YYYY. When the source actually uses DD/MM/YYYY and the day is ≤ 12 (both readings syntactically valid), the importer silently swaps day and month and emits no warning — `GEDCOM import report: No errors detected` despite a wrong date being written to the database. Day > 12 already falls back to text-only storage (visually flagged in the Events view as bold), so only the day ≤ 12 case is silently dangerous.

This was reported in 2016 and re-confirmed in 2022/2023 across multiple discourse threads; multiple developers have discussed narrower-scope fixes (warn-only, source-detect ancestry, switch in import dialog) but none have shipped. No code-side parse-direction change is possible without breaking US users who currently rely on the existing MM/DD/YYYY default for legitimately-shaped numeric input.

## Fix
The smallest defensible change: emit an advisory warning per ambiguous bare-numeric date during import, no parse-direction change. US users see no behaviour change; European users importing ancestry.com-shaped GEDCOMs get a per-event audit list with both the original GEDCOM text and the chosen interpretation.

- `BARE_NUMERIC_DATE` regex added next to the other module-level GEDCOM patterns (`libgedcom.py:894`).
- `GedcomParser.__add_warn` (new) wraps `__add_msg` with the `number_of_errors -= 1` pattern already used at the end of `__finish_import` for the unknown-references note; the summary line stays "No errors detected" when the warnings are advisory.
- `GedcomParser.__warn_if_ambiguous_numeric_date` (new) is called from `__event_date` after the date object is attached to the event. Suppresses on `MOD_TEXTONLY` (already visually flagged) and on non-numeric inputs. `line` is intentionally not passed through `__add_warn` because `__add_msg` truncates the problem string to 66 columns when a line is supplied, which drops the actionable half of the message — and the warning text already contains the original GEDCOM date string verbatim.

Scope is limited to `__event_date` (the only date sink the bug report cites). `__name_date` / `__lds_ord_date` / `__addr_date` / `__citation_date` / `__media_date` could call the same helper in a follow-up if a maintainer asks; left out here to keep the diff focused on the cited symptom.

## Verified against
- `gramps/plugins/lib/libgedcom.py:925` — the hardcoded `dhformat = "%m/%d/%y"` that drives the silent swap.
- `gramps/plugins/lib/libgedcom.py:3797` — existing precedent for the `__add_msg` then `number_of_errors -= 1` pattern used to attach an advisory note without polluting the error count.
- `gramps/gen/lib/date.py:590` — `Date.MOD_TEXTONLY = 6` (the fallback used when the parser can't make sense of the input, recognised in the helper to suppress the warning).

## Test
`gramps/plugins/importer/test/importgedcom_ambiguous_date_test.py` imports an Ancestry-shaped GEDCOM fixture via `import_as_dict` with a `CapturingUser` that intercepts the summary dialog text. Four assertions:

1. `7/11/1959` (day ≤ 12, the silent-swap case) triggers an "Ambiguous numeric date" warning naming the original text and the chosen interpretation.
2. `5 MAR 1899` (spec-compliant) stays silent.
3. `25/3/1934` (day > 12, text-only fallback) stays silent.
4. The summary still reads "GEDCOM import report: No errors detected".

Pre-fix, test 1 fails (`'Ambiguous numeric date' not found in 'GEDCOM import report: No errors detected'`); the other three pass. Post-fix all four pass.

Fixes #9298