### PR TITLE
Fan-chart Print: stop forcing a custom paper size (bug 10768)

### DIFF
--- a/gramps/plugins/view/fanchart2wayview.py
+++ b/gramps/plugins/view/fanchart2wayview.py
@@ -540,21 +540,14 @@ class CairoPrintSave:
         operation.connect("preview", self.on_preview)
         operation.connect("paginate", self.on_paginate)
         operation.set_n_pages(1)
-        # paper_size = Gtk.PaperSize.new(name="iso_a4")
-        ## WHY no Gtk.Unit.PIXEL ?? Is there a better way to convert
-        ## Pixels to MM ??
-        paper_size = Gtk.PaperSize.new_custom(
-            "custom",
-            "Custom Size",
-            round(self.widthpx * 0.2646),
-            round(self.heightpx * 0.2646),
-            Gtk.Unit.MM,
-        )
-        page_setup = Gtk.PageSetup()
-        page_setup.set_paper_size(paper_size)
-        # page_setup.set_orientation(Gtk.PageOrientation.PORTRAIT)
-        operation.set_default_page_setup(page_setup)
-        # operation.set_use_full_page(True)
+        # Mantis 10768: do NOT force a custom paper size matching the
+        # chart's natural rendered millimetre dimensions.  Doing so
+        # locked the print dialog's paper-size combo at "Custom" and,
+        # on Mac, made the printer try to reproduce a 1330x1330mm
+        # page literally — printing 1/4 of the chart on real Letter
+        # paper.  Use the system default paper instead and rely on
+        # on_draw_page's existing scale-to-fit
+        # (``scale = min(pxwidth/widthpx, pxheight/heightpx)``).
 
         if PRINT_SETTINGS is not None:
             operation.set_print_settings(PRINT_SETTINGS)
@@ -567,7 +560,6 @@ class CairoPrintSave:
                 break
             # set up printing again; can't reuse PrintOperation?
             operation = Gtk.PrintOperation()
-            operation.set_default_page_setup(page_setup)
             operation.connect("draw_page", self.on_draw_page)
             operation.connect("preview", self.on_preview)
             operation.connect("paginate", self.on_paginate)

--- a/gramps/plugins/view/fanchartdescview.py
+++ b/gramps/plugins/view/fanchartdescview.py
@@ -524,21 +524,14 @@ class CairoPrintSave:
         operation.connect("preview", self.on_preview)
         operation.connect("paginate", self.on_paginate)
         operation.set_n_pages(1)
-        # paper_size = Gtk.PaperSize.new(name="iso_a4")
-        ## WHY no Gtk.Unit.PIXEL ?? Is there a better way to convert
-        ## Pixels to MM ??
-        paper_size = Gtk.PaperSize.new_custom(
-            "custom",
-            "Custom Size",
-            round(self.widthpx * 0.2646),
-            round(self.heightpx * 0.2646),
-            Gtk.Unit.MM,
-        )
-        page_setup = Gtk.PageSetup()
-        page_setup.set_paper_size(paper_size)
-        # page_setup.set_orientation(Gtk.PageOrientation.PORTRAIT)
-        operation.set_default_page_setup(page_setup)
-        # operation.set_use_full_page(True)
+        # Mantis 10768: do NOT force a custom paper size matching the
+        # chart's natural rendered millimetre dimensions.  Doing so
+        # locked the print dialog's paper-size combo at "Custom" and,
+        # on Mac, made the printer try to reproduce a 1330x1330mm
+        # page literally — printing 1/4 of the chart on real Letter
+        # paper.  Use the system default paper instead and rely on
+        # on_draw_page's existing scale-to-fit
+        # (``scale = min(pxwidth/widthpx, pxheight/heightpx)``).
 
         if PRINT_SETTINGS is not None:
             operation.set_print_settings(PRINT_SETTINGS)
@@ -551,7 +544,6 @@ class CairoPrintSave:
                 break
             # set up printing again; can't reuse PrintOperation?
             operation = Gtk.PrintOperation()
-            operation.set_default_page_setup(page_setup)
             operation.connect("draw_page", self.on_draw_page)
             operation.connect("preview", self.on_preview)
             operation.connect("paginate", self.on_paginate)

--- a/gramps/plugins/view/fanchartview.py
+++ b/gramps/plugins/view/fanchartview.py
@@ -610,21 +610,14 @@ class CairoPrintSave:
         operation.connect("preview", self.on_preview)
         operation.connect("paginate", self.on_paginate)
         operation.set_n_pages(1)
-        # paper_size = Gtk.PaperSize.new(name="iso_a4")
-        ## WHY no Gtk.Unit.PIXEL ?? Is there a better way to convert
-        ## Pixels to MM ??
-        paper_size = Gtk.PaperSize.new_custom(
-            "custom",
-            "Custom Size",
-            round(self.widthpx * 0.2646),
-            round(self.heightpx * 0.2646),
-            Gtk.Unit.MM,
-        )
-        page_setup = Gtk.PageSetup()
-        page_setup.set_paper_size(paper_size)
-        # page_setup.set_orientation(Gtk.PageOrientation.PORTRAIT)
-        operation.set_default_page_setup(page_setup)
-        # operation.set_use_full_page(True)
+        # Mantis 10768: do NOT force a custom paper size matching the
+        # chart's natural rendered millimetre dimensions.  Doing so
+        # locked the print dialog's paper-size combo at "Custom" and,
+        # on Mac, made the printer try to reproduce a 1330x1330mm
+        # page literally — printing 1/4 of the chart on real Letter
+        # paper.  Use the system default paper instead and rely on
+        # on_draw_page's existing scale-to-fit
+        # (``scale = min(pxwidth/widthpx, pxheight/heightpx)``).
 
         if PRINT_SETTINGS is not None:
             operation.set_print_settings(PRINT_SETTINGS)
@@ -637,7 +630,6 @@ class CairoPrintSave:
                 break
             # set up printing again; can't reuse PrintOperation?
             operation = Gtk.PrintOperation()
-            operation.set_default_page_setup(page_setup)
             operation.connect("draw_page", self.on_draw_page)
             operation.connect("preview", self.on_preview)
             operation.connect("paginate", self.on_paginate)

--- a/gramps/plugins/view/test/fanchart_print_papersize_test.py
+++ b/gramps/plugins/view/test/fanchart_print_papersize_test.py
@@ -1,0 +1,107 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Mantis 10768 — fan-chart Print dialogs must not override the paper size.
+
+The reported failure (Mac OS X, Gramps 5.0+): opening File → Print on a
+Fan Chart View showed the paper-size combo grayed out at "Custom",
+forced a custom paper size matching the chart's natural rendered
+millimetre dimensions (e.g. 1330×1330mm for 16 generations), and made
+the printer literally try to reproduce that custom page — printing one
+quarter of the chart on real Letter paper.
+
+Root cause was identical across the three fan-chart view modules: each
+built a ``Gtk.PaperSize.new_custom("custom", "Custom Size", widthpx *
+0.2646, heightpx * 0.2646, Gtk.Unit.MM)`` and called
+``operation.set_default_page_setup(page_setup)`` on it (twice — once
+for the first ``operation.run`` and once when reconstructing the
+operation for the preview-rerun branch).
+
+The actual print flow is GUI-bound (live ``Gtk.PrintOperation``, real
+``PRINT_DIALOG``, a printer to receive the job) so a runtime unit test
+of the dialog is impractical in headless CI.  These tests are the
+cheaper guard: they assert the buggy fragments are absent from each
+file so the pattern doesn't accidentally reappear via copy-paste from
+a sibling view or a stale revert.  Same shape as the source-grep
+guards in ``gramps/gen/plug/docgen/test/graphdoc_test.py`` (bug 6556 /
+PR 2318)."""
+
+import os
+import unittest
+
+
+def _read(*parts: str) -> str:
+    path = os.path.join(os.path.dirname(__file__), "..", *parts)
+    with open(path, "r", encoding="utf-8") as fh:
+        return fh.read()
+
+
+VIEW_FILES = (
+    "fanchartview.py",
+    "fanchart2wayview.py",
+    "fanchartdescview.py",
+)
+
+BUGGY_FRAGMENTS = (
+    # The custom paper size constructor and its mm-conversion magic.
+    'PaperSize.new_custom("custom"',
+    "widthpx * 0.2646",
+    # Locking the dialog into the custom size.
+    "set_default_page_setup(page_setup)",
+    # The chained construction the previous two depended on.
+    "page_setup = Gtk.PageSetup()",
+)
+
+
+class FanChartPrintNoCustomPaperSizeTest(unittest.TestCase):
+    """Each of the three fan-chart views must not reintroduce the
+    custom-paper override that bug 10768 was fixed by removing."""
+
+    def test_fanchartview_does_not_override_paper_size(self):
+        self._assert_no_buggy_fragments("fanchartview.py")
+
+    def test_fanchart2wayview_does_not_override_paper_size(self):
+        self._assert_no_buggy_fragments("fanchart2wayview.py")
+
+    def test_fanchartdescview_does_not_override_paper_size(self):
+        self._assert_no_buggy_fragments("fanchartdescview.py")
+
+    def test_all_view_files_exist(self):
+        # Tripwire: if any of the three files is renamed or moved, this
+        # test surfaces it so the per-file tests above aren't silently
+        # vacuous.
+        for name in VIEW_FILES:
+            path = os.path.join(os.path.dirname(__file__), "..", name)
+            self.assertTrue(
+                os.path.exists(path),
+                f"expected view file missing: {path} — "
+                "rename/move the per-file tests too",
+            )
+
+    def _assert_no_buggy_fragments(self, name: str) -> None:
+        source = _read(name)
+        for fragment in BUGGY_FRAGMENTS:
+            self.assertNotIn(
+                fragment,
+                source,
+                f"{name}: re-introduction of bug 10768 custom-paper override "
+                f"(forbidden fragment {fragment!r})",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
**User impact:** Printing a fan chart came out wrong: on Mac only one quarter of the chart printed, crammed into the top-right corner of the paper; on Linux the chart printed complete but tiny. In both cases the paper-size selector in the Print dialog was greyed out, so you couldn't choose your real paper or fix the scaling.

This stops the fan chart from forcing a made-up paper size, so the Print dialog lets you pick real paper and the whole chart scales to fit a single page.

Reported in Mantis [#10768](https://gramps-project.org/bugs/view.php?id=10768).

## What to look at
The fan-chart views were telling the printer the paper was exactly the size of the whole chart (e.g. 1330×1330 mm), which pinned the paper-size selector and, on Mac, sent that giant page straight to the printer. Removing that override hands paper choice back to the normal Print dialog. To try it: open a Fan Chart View, File → Print, and confirm the paper-size selector is now usable and the whole chart scales onto a single sheet instead of printing a quarter of it top-right.

## Root cause
Each of the three fan-chart view modules (`gramps/plugins/view/fanchartview.py` and its 2way / descendant siblings) builds its print operation by constructing a `Gtk.PaperSize.new_custom("custom", "Custom Size", self.widthpx * 0.2646, self.heightpx * 0.2646, Gtk.Unit.MM)` and calling `operation.set_default_page_setup(page_setup)` on it — twice per operation: once before the first `operation.run` and once when the operation is reconstructed for the preview-rerun branch.

That locks the Print dialog's paper-size combo at "Custom" and tells the print system the physical paper is exactly the chart's natural rendered millimetre dimensions (e.g. 1330×1330 mm for a 16-generation fan). On Mac OS X the print system honours the request literally, sending a 1330×1330 mm page to the printer — which then prints one quarter of the chart in the top-right of real Letter paper (the reporter's symptom in 2018). On Linux the print system clamps to a real paper size but still leaves the selector grayed out, with the chart drawn very small but at least complete. Scaling controls in the dialog have no effect because the override pegs paper size to chart size before the dialog opens.

## Fix
Drop the custom-paper override in all three views — let `Gtk.PrintOperation` use the system default paper size and let the user pick from the dialog's real paper list. `on_draw_page`'s existing scale-to-fit (`scale = min(pxwidth/widthpx, pxheight/heightpx)`) already scales the chart to whatever cairo context size the chosen paper yields, so the chart fits on a single page at reduced detail. Users who want full detail can still use Pages-per-Side to tile across multiple sheets, or print to PDF first (the existing workaround the reporter was steered toward).

Removed per file:
- the `Gtk.PaperSize.new_custom(...)` construction and surrounding `# WHY no Gtk.Unit.PIXEL ??` comment block
- the `page_setup = Gtk.PageSetup()` / `page_setup.set_paper_size(paper_size)` chain
- the first `operation.set_default_page_setup(page_setup)` before the initial dialog run
- the second `operation.set_default_page_setup(page_setup)` inside the preview-rerun branch

A short comment is left in place explaining why the override is deliberately absent (citing the bug number) so a future copy-paste from a still-unrefactored sibling doesn't quietly reintroduce it.

Scope: just the three fan-chart views the bug report covers. The shape of the same pattern exists in `pedigreeview.py` and possibly elsewhere; left for a follow-up if a maintainer asks — keeping this diff narrowly aligned with the cited symptom.

## Verification
- **Claim:** the three fan-chart print operations no longer override paper size, so the Print dialog's paper selector is user-controllable and the chart scales to fit the chosen paper.
- **Checked:** on maintenance/gramps61 — `gramps/plugins/view/fanchartview.py:608-650` (post-fix line range: the buggy fragments and their removal), and `gramps/plugins/view/fanchart2wayview.py` / `fanchartdescview.py` (identical pre/post-fix structure, checked side by side). jralls notes ~0055160 / ~0055161 on the Mantis ticket frame the Mac/Linux symptom split that makes the override the root cause; bug 12927 (Consolidate Fan chart types and features), linked by BAMaustin in 2023, is the umbrella refactor this PR addresses one symptom of without preempting.
- **Test:** `gramps/plugins/view/test/fanchart_print_papersize_test.py` — a source-grep regression guard asserting each of the three files no longer contains the buggy fragments (`PaperSize.new_custom("custom"`, `widthpx * 0.2646`, `set_default_page_setup(page_setup)`, `page_setup = Gtk.PageSetup()`). Four cases: one per affected file plus a tripwire that fails if any of the three files is renamed or moved (so the per-file asserts can't become silently vacuous). Pre-fix the three per-file asserts fail; post-fix all four pass. The actual print flow is GUI-bound (live `Gtk.PrintOperation`, real `PRINT_DIALOG`, a printer) so a runtime test is impractical in headless CI; the source-grep guard mirrors the precedent at `gramps/gen/plug/docgen/test/graphdoc_test.py` (bug 6556 / PR 2318). Manual repro on Mac (per the reporter's steps): open a Fan Chart View, File → Print — the paper-size combo is now selectable and defaults to the system default (Letter / A4); selecting a paper and printing produces the entire chart scaled to fit a single page rather than 1/4 of the chart on the top-right.

Fixes [#10768](https://gramps-project.org/bugs/view.php?id=10768)
