### PR TITLE
Add regression test for RelationshipPathBetween filter rule (bug 13820)

### DIFF
--- a/gramps/gen/filters/rules/test/person_rules_test.py
+++ b/gramps/gen/filters/rules/test/person_rules_test.py
@@ -101,6 +101,7 @@ from ..person import (
     PersonWithIncompleteEvent,
     ProbablyAlive,
     RegExpName,
+    RelationshipPathBetween,
     RelationshipPathBetweenBookmarks,
 )
 
@@ -1324,6 +1325,38 @@ class BaseTest(unittest.TestCase):
                     "AWFKQCJELLUWDY2PD3",
                     "D3WJQCCGV58IP8PNHZ",
                     "Q8HKQC3VMRM1M6M7ES",
+                ]
+            ),
+        )
+
+    def test_relationshippathbetween(self):
+        """
+        Test RelationshipPathBetween rule.
+
+        Regression for Mantis 13830: ``init_list`` previously contained
+        ``for person_handle in firstList and secondList:``, which Python
+        evaluates as ``secondList`` via short-circuit ``and``. The loop
+        then read ``firstMap[person_handle]`` with handles drawn only
+        from secondList, so any handle reachable from the second root
+        but not the first triggered ``KeyError`` — the symptom users
+        saw via Graph View's "Show path to home person" menu.
+
+        Two persons in different family lines exercise the regression
+        case: the second root's ancestors are not a subset of the
+        first's, so the buggy iteration raised ``KeyError`` on the
+        first non-shared handle. With the fix the rule returns the
+        two endpoints unchanged when no common ancestor exists.
+        """
+        # I0044 (Lewis Anderson Garner, home person of example.gramps)
+        # and I2127 (a member of the unrelated Δεληπέτρου family) share
+        # no common ancestor.
+        rule = RelationshipPathBetween(["I0044", "I2127"])
+        self.assertEqual(
+            self.filter_with_rule(rule),
+            set(
+                [
+                    "GNUJQCL9MD64AM56OH",  # I0044
+                    "d583a5ba5ca6b698463",  # I2127
                 ]
             ),
         )


### PR DESCRIPTION
## Root cause
`RelationshipPathBetween.init_list` regressed in 1280aa45a5f47581badfb655021ce1d430f8a581 when `for person_handle in firstList & secondList` became `for person_handle in firstList and secondList` — Python's short-circuit `and` returns `secondList`, so `firstMap[person_handle]` raised `KeyError` on the first handle reachable from the second root but not the first. The rule has no direct test (only the `RelationshipPathBetweenBookmarks` wrapper is tested), which is why the regression slipped through and could reappear.

## Fix
Test-only. Adds `test_relationshippathbetween` to `gramps/gen/filters/rules/test/person_rules_test.py`, exercising the rule with two example.gramps persons (`I0044`, the home person, and `I2127`, a member of the unrelated Δεληπέτρου family) that share no ancestor — the configuration that triggered the original `KeyError`.

## Verified against
- `gramps/gen/filters/rules/person/_relationshippathbetween.py:127` — current `init_list` uses `firstSet & secondSet`, confirming the fix is live on this branch.
- Pre-fix file (checked out at `48a6cbfb0541d429a3e3fba778c611f6e1843a6a^`): the new test fails with `KeyError` at `_relationshippathbetween.py:130` — same line and exception class as in Mantis 13830's traceback.
- Regression-introducing commit: 1280aa45a5f47581badfb655021ce1d430f8a581 ("Refactor, fix, and optimize filters/rules").
- Fix commit (already on this branch): 48a6cbfb0541d429a3e3fba778c611f6e1843a6a ("Fix regression in relationship path between people filter").

## Test
`test_relationshippathbetween` — passes on current branch (88/88 in `person_rules_test.py` pass), fails on the pre-fix file with the original `KeyError`.

Issue #13830.