### PR TITLE
Fix AttributeError on iconlist when GalleryTab parent dialog closes (bug 13326)

### DIFF
--- a/gramps/gui/editors/displaytabs/gallerytab.py
+++ b/gramps/gui/editors/displaytabs/gallerytab.py
@@ -229,7 +229,9 @@ class GalleryTab(ButtonTab, DbGUIElement):
         self.iconlist.set_selection_mode(Gtk.SelectionMode.SINGLE)
 
         # connect the signals
-        self.iconlist.connect("selection-changed", self._selection_changed)
+        self._sel_changed_handler = self.iconlist.connect(
+            "selection-changed", self._selection_changed
+        )
         self.iconlist.connect("button_press_event", self.double_click)
         self.iconlist.connect("key_press_event", self.key_pressed)
         self._connect_icon_model()
@@ -657,4 +659,14 @@ class GalleryTab(ButtonTab, DbGUIElement):
         return self.get_data().index(obj)
 
     def clean_up(self):
+        # Disconnect selection-changed before super() deletes self.iconlist via
+        # track_ref_for_deletion. Otherwise a late selection-changed emission
+        # (e.g. when the parent dialog tears down on Cancel) re-enters
+        # _selection_changed -> get_selected() and crashes because self.iconlist
+        # no longer exists. Bug 13326.
+        sel_handler = getattr(self, "_sel_changed_handler", None)
+        if sel_handler and hasattr(self, "iconlist"):
+            if GObject.signal_handler_is_connected(self.iconlist, sel_handler):
+                self.iconlist.disconnect(sel_handler)
+            self._sel_changed_handler = None
         super(ButtonTab, self).clean_up()

--- a/gramps/gui/editors/displaytabs/test/gallerytab_test.py
+++ b/gramps/gui/editors/displaytabs/test/gallerytab_test.py
@@ -22,6 +22,7 @@
 # ------------------------
 # Python modules
 # ------------------------
+import os
 import tempfile
 import unittest
 import warnings
@@ -37,11 +38,44 @@ from gramps.gen.dbstate import DbState
 from gramps.gui.editors.displaytabs import GalleryTab
 
 
+def _has_gtk_display():
+    """
+    Return True only if a real Gtk display is available.
+
+    The gramps CI exports GDK_BACKEND=- and runs without an X server, so
+    constructing a Gtk.IconView "succeeds" against a NULL screen and then
+    segfaults at process cleanup. Skip cleanly on those hosts; run when
+    the test is invoked under xvfb-run or on a real desktop.
+    """
+    if not os.environ.get("DISPLAY"):
+        return False
+    if os.environ.get("GDK_BACKEND") == "-":
+        return False
+    try:
+        import gi
+
+        gi.require_version("Gtk", "3.0")
+        from gi.repository import Gtk
+
+        return bool(Gtk.init_check([])[0])
+    except Exception:
+        return False
+
+
+_HAS_GTK_DISPLAY = _has_gtk_display()
+
+
 # ------------------------------------------------------------
 #
 # TestGalleryTabCleanup
 #
 # ------------------------------------------------------------
+@unittest.skipUnless(
+    _HAS_GTK_DISPLAY,
+    "needs a real Gtk display (run under xvfb-run); "
+    "gramps CI sets GDK_BACKEND=- and constructing a Gtk.IconView "
+    "against a NULL screen segfaults at process cleanup.",
+)
 class TestGalleryTabCleanup(unittest.TestCase):
     """
     Regression tests for the GalleryTab teardown path.

--- a/gramps/gui/editors/displaytabs/test/gallerytab_test.py
+++ b/gramps/gui/editors/displaytabs/test/gallerytab_test.py
@@ -1,0 +1,126 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Eduard Ralph
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Unittests for the GalleryTab display tab."""
+
+# ------------------------
+# Python modules
+# ------------------------
+import tempfile
+import unittest
+from unittest.mock import Mock
+
+# ------------------------
+# Gramps modules
+# ------------------------
+from gi.repository import GObject
+
+from gramps.gen.db.utils import make_database
+from gramps.gen.dbstate import DbState
+from gramps.gui.editors.displaytabs import GalleryTab
+
+
+# ------------------------------------------------------------
+#
+# TestGalleryTabCleanup
+#
+# ------------------------------------------------------------
+class TestGalleryTabCleanup(unittest.TestCase):
+    """
+    Regression tests for the GalleryTab teardown path.
+    """
+
+    def _make_gallery(self):
+        """
+        Build a minimal GalleryTab against a fresh sqlite db.
+        """
+        dbstate = DbState()
+        db = make_database("sqlite")
+        tmpdir = tempfile.mkdtemp()
+        db.load(tmpdir)
+        dbstate.change_database(db)
+        uistate = Mock()
+        uistate.window = Mock()
+        gallery = GalleryTab(dbstate, uistate, [], [])
+        return gallery, db
+
+    def test_clean_up_disconnects_selection_changed(self):
+        """
+        Regression for bug 13326.
+
+        GalleryTab.clean_up() must disconnect the iconlist
+        'selection-changed' signal handler before super().clean_up() deletes
+        the iconlist attribute via track_ref_for_deletion. Otherwise a late
+        selection-changed emission (which happens when the parent dialog
+        tears down on Cancel, e.g. when the Forms addon hosts a GalleryTab)
+        re-enters _selection_changed -> get_selected() ->
+        self.iconlist.get_selected_items() and crashes with AttributeError:
+        'GalleryTab' object has no attribute 'iconlist'.
+
+        PyGObject prints but does not propagate exceptions raised inside a
+        signal handler, so this test asserts on the connection state
+        directly rather than trying to observe the AttributeError from an
+        emit() call.
+        """
+        gallery, db = self._make_gallery()
+        try:
+            iconlist = gallery.iconlist
+            signal_id, _detail = GObject.signal_parse_name(
+                "selection-changed", iconlist, True
+            )
+
+            self.assertGreater(
+                GObject.signal_handler_find(
+                    iconlist,
+                    GObject.SignalMatchType.ID,
+                    signal_id,
+                    0,
+                    None,
+                    None,
+                    None,
+                ),
+                0,
+                "Sanity: a 'selection-changed' handler should be wired "
+                "during build_interface().",
+            )
+
+            gallery.clean_up()
+
+            self.assertEqual(
+                GObject.signal_handler_find(
+                    iconlist,
+                    GObject.SignalMatchType.ID,
+                    signal_id,
+                    0,
+                    None,
+                    None,
+                    None,
+                ),
+                0,
+                "Bug 13326: GalleryTab.clean_up() must disconnect the "
+                "iconlist 'selection-changed' handler so a late emission "
+                "cannot fire _selection_changed after self.iconlist has "
+                "been deleted by track_ref_for_deletion.",
+            )
+        finally:
+            db.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gui/editors/displaytabs/test/gallerytab_test.py
+++ b/gramps/gui/editors/displaytabs/test/gallerytab_test.py
@@ -24,6 +24,7 @@
 # ------------------------
 import tempfile
 import unittest
+import warnings
 from unittest.mock import Mock
 
 # ------------------------
@@ -117,6 +118,46 @@ class TestGalleryTabCleanup(unittest.TestCase):
                 "iconlist 'selection-changed' handler so a late emission "
                 "cannot fire _selection_changed after self.iconlist has "
                 "been deleted by track_ref_for_deletion.",
+            )
+        finally:
+            db.close()
+
+    def test_clean_up_after_iconlist_destroyed_emits_no_warning(self):
+        """
+        Regression guard for the warning commit 37395da262 silenced.
+
+        That 2023 commit removed the disconnect in clean_up() because GTK
+        emitted a critical when the disconnect ran on an iconlist whose
+        underlying GObject had already been disposed (the normal close
+        path). Restoring the disconnect for bug 13326 must not bring that
+        warning back. The fix gates the disconnect with
+        GObject.signal_handler_is_connected, which returns False on a
+        disposed widget.
+
+        Simulate the normal-close path by destroying the iconlist widget
+        before clean_up(), then assert that no PyGObject warning of the
+        shape ``instance '...' has no handler with id '...'`` is raised.
+        PyGObject promotes the underlying GObject critical to a Python
+        Warning, so warnings.catch_warnings is sufficient.
+        """
+        gallery, db = self._make_gallery()
+        try:
+            gallery.iconlist.destroy()
+
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                gallery.clean_up()
+
+            stale_handler_warnings = [
+                w for w in caught if "has no handler with id" in str(w.message)
+            ]
+            self.assertEqual(
+                stale_handler_warnings,
+                [],
+                "GalleryTab.clean_up() must stay silent when the iconlist "
+                "widget has already been disposed (the case commit "
+                "37395da262 was working around). Got: %r"
+                % [str(w.message) for w in stale_handler_warnings],
             )
         finally:
             db.close()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -384,6 +384,11 @@ gramps/gui/editors/displaytabs/srcattrmodel.py
 gramps/gui/editors/displaytabs/surnamemodel.py
 gramps/gui/editors/displaytabs/webmodel.py
 #
+# gui/editors/displaytabs/test
+#
+gramps/gui/editors/displaytabs/test/__init__.py
+gramps/gui/editors/displaytabs/test/gallerytab_test.py
+#
 # gui.editors.test package
 #
 gramps/gui/editors/test/editreference_test.py


### PR DESCRIPTION
## Root cause
`GalleryTab.clean_up()` calls `super().clean_up()`, which removes
`self.iconlist` via `track_ref_for_deletion("iconlist")`, but never
disconnects the `'selection-changed'` signal handler on the iconlist
widget. When the parent dialog tears down on Cancel — the Forms
addon's GalleryTab-in-a-dialog path exercises this reliably — GTK
dispatches a final `selection-changed` to the still-live widget; the
handler calls `self.get_selected()` → `self.iconlist.get_selected_items()`
and raises `AttributeError: 'GalleryTab' object has no attribute
'iconlist'`.

## Fix
Capture the `'selection-changed'` handler id in `build_interface`,
then disconnect it at the head of `clean_up()` — before
`super().clean_up()` removes the attribute. Guard the disconnect
with `GObject.signal_handler_is_connected` so the already-disposed
case (the reason the original disconnect was removed in 37395da262)
stays silent.

## Verified against
- `gramps/gui/editors/displaytabs/gallerytab.py:232,659-660` — the
  unguarded `connect` and the no-op `clean_up` that the reported
  trace fingers.
- `gramps/gui/editors/displaytabs/buttontab.py:319` — the call site
  in the inherited `_selection_changed` callback that reaches into
  `self.get_selected()`.
- The 2012 disconnect (svn r20849 / `51a53ccebd`) — same defect
  class, same fix shape; removed in `37395da262` to silence a GTK
  warning on the normal close path. The new
  `signal_handler_is_connected` guard keeps that path silent while
  restoring teardown-race safety.

## Test
`gramps/gui/editors/displaytabs/test/gallerytab_test.py` covers both
the bug and the warning the original disconnect was removed to
silence:

- `test_clean_up_disconnects_selection_changed` constructs a real
  `GalleryTab`, records the `'selection-changed'` signal id, and
  asserts via `GObject.signal_handler_find` that no handler remains
  after `clean_up()`. Pre-fix `42 != 0`; post-fix passes.
- `test_clean_up_after_iconlist_destroyed_emits_no_warning` destroys
  the iconlist widget before `clean_up()` — the normal close path
  where commit 37395da262 was seeing the GTK critical — and asserts
  via `warnings.catch_warnings` that no `instance '...' has no
  handler with id '...'` warning is recorded. Mutating the fix to
  drop the `signal_handler_is_connected` guard surfaces exactly that
  warning, so future removals of the guard regress here.

Both need a display (`Gtk.IconView`), so run under `xvfb-run`:

```
xvfb-run -a python3 -m unittest \
    gramps.gui.editors.displaytabs.test.gallerytab_test -v
```

Fixes [#13326](https://gramps-project.org/bugs/view.php?id=13326).