### PR TITLE
Requirements.info: omit empty (label, table) pairs

### DIFF
--- a/gramps/gen/utils/requirements.py
+++ b/gramps/gen/utils/requirements.py
@@ -146,29 +146,37 @@ class Requirements:
     def info(self, addon):
         """
         Provide the requirements status of a given addon.
+
+        Returns a flat sequence of alternating label / table entries -
+        one pair per non-empty requires section. Sections whose addon
+        list is present but empty (e.g. ``"re": []``) are omitted, so
+        every label in the result is paired with a non-empty table.
         """
         info = []
         if "rm" in addon:
-            info.append(_("Python modules"))
             table = []
             for module in addon.get("rm"):
                 result = self.check_mod(module)
                 table.append([module, tick_cross(result)])
-            info.append(table)
+            if table:
+                info.append(_("Python modules"))
+                info.append(table)
         if "rg" in addon:
-            info.append(_("GObject introspection modules"))
             table = []
             for module_spec in addon.get("rg"):
                 result = self.check_gi(module_spec)
                 table.append([" ".join(module_spec), tick_cross(result)])
-            info.append(table)
+            if table:
+                info.append(_("GObject introspection modules"))
+                info.append(table)
         if "re" in addon:
-            info.append(_("Executables"))
             table = []
             for executable in addon.get("re"):
                 result = self.check_exe(executable)
                 table.append([executable, tick_cross(result)])
-            info.append(table)
+            if table:
+                info.append(_("Executables"))
+                info.append(table)
         return info
 
 

--- a/gramps/gen/utils/test/requirements_test.py
+++ b/gramps/gen/utils/test/requirements_test.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Eduard Ralph
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Tests for :class:`gramps.gen.utils.requirements.Requirements`.
+"""
+
+# -------------------------------------------------------------------------
+#
+# Standard python modules
+#
+# -------------------------------------------------------------------------
+import unittest
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from ..requirements import Requirements
+
+
+# ------------------------------------------------------------
+#
+# TestRequirementsInfoOmitsEmptyPairs
+#
+# ------------------------------------------------------------
+class TestRequirementsInfoOmitsEmptyPairs(unittest.TestCase):
+    """
+    ``Requirements.info`` must return only label + populated-table pairs.
+
+    A present-but-empty requires list - e.g. an addon listing carrying
+    ``"re": []`` because its .gpr.py declares ``requires_exe=[]`` - must
+    not produce a labelled section with an empty table. The previous
+    contract emitted the label + empty table, which (a) rendered an
+    empty labelled section in the core Addon Manager's Requirements
+    dialog, and (b) was the shape that crashed the Plugin Manager
+    Enhanced addon's row-click handler (Mantis 13979, fixed
+    addon-side in addons-source PR 916).
+    """
+
+    def setUp(self):
+        self.req = Requirements()
+
+    # ----- single shapes -------------------------------------------------
+
+    def test_no_requires_keys(self):
+        """An addon with no requires keys returns an empty list."""
+        self.assertEqual(self.req.info({"i": "x"}), [])
+
+    def test_present_but_empty_re_omits_pair(self):
+        """``"re": []`` must not produce an ``Executables`` pair."""
+        self.assertEqual(self.req.info({"i": "x", "re": []}), [])
+
+    def test_present_but_empty_rm_omits_pair(self):
+        """``"rm": []`` must not produce a ``Python modules`` pair."""
+        self.assertEqual(self.req.info({"i": "x", "rm": []}), [])
+
+    def test_present_but_empty_rg_omits_pair(self):
+        """``"rg": []`` must not produce a GI pair."""
+        self.assertEqual(self.req.info({"i": "x", "rg": []}), [])
+
+    def test_all_three_present_but_empty_omits_all_pairs(self):
+        """All three keys present-but-empty returns an empty list."""
+        self.assertEqual(
+            self.req.info({"i": "x", "rm": [], "rg": [], "re": []}),
+            [],
+        )
+
+    # ----- the live trigger shape ----------------------------------------
+
+    def test_postgresql_enhanced_listing_shape(self):
+        """
+        The live PostgreSQL Enhanced listing shape - ``rm`` populated,
+        ``re`` empty - must produce only the Python-modules pair, with
+        no trailing Executables pair to crash downstream consumers.
+        """
+        result = self.req.info({"i": "postgresqlenhanced", "rm": ["psycopg"], "re": []})
+        self.assertEqual(len(result), 2, result)
+        label, table = result
+        self.assertIn("Python modules", label)
+        self.assertEqual(len(table), 1)
+        self.assertEqual(table[0][0], "psycopg")
+
+    # ----- positive cases: existing behaviour preserved ------------------
+
+    def test_non_empty_rm_still_renders(self):
+        """A populated ``rm`` still produces its label + table unchanged."""
+        result = self.req.info({"i": "x", "rm": ["psycopg", "Pillow"]})
+        self.assertEqual(len(result), 2, result)
+        label, table = result
+        self.assertIn("Python modules", label)
+        self.assertEqual([row[0] for row in table], ["psycopg", "Pillow"])
+
+    def test_non_empty_rm_and_re_both_render_in_order(self):
+        """
+        Multiple populated sections still emit their pairs in the same
+        rm / rg / re order Requirements.info has always used - the change
+        only suppresses empty sections, it does not reorder anything.
+        """
+        result = self.req.info({"i": "x", "rm": ["psycopg"], "re": ["dot"]})
+        self.assertEqual(len(result), 4, result)
+        self.assertIn("Python modules", result[0])
+        self.assertEqual(result[1][0][0], "psycopg")
+        self.assertIn("Executables", result[2])
+        self.assertEqual(result[3][0][0], "dot")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -331,6 +331,7 @@ gramps/gen/utils/test/file_test.py
 gramps/gen/utils/test/grampslocale_test.py
 gramps/gen/utils/test/keyword_test.py
 gramps/gen/utils/test/place_test.py
+gramps/gen/utils/test/requirements_test.py
 #
 # gui - GUI code
 #


### PR DESCRIPTION
## What this changes
`Requirements.info` previously appended a label whenever an addon
dict carried a `"rm"` / `"rg"` / `"re"` key, regardless of whether
the value was a non-empty list. A present-but-empty key — e.g. an
addon listing with `"re": []` because its `.gpr.py` declares
`requires_exe=[]` — produced a labelled section paired with an
empty table.

The live user-visible effect is in gramps core's own AddonManager:
the "Requirements" InfoDialog
([`_windows.py:349`](gramps/gui/plug/_windows.py#L349)) renders an
empty labelled section for every present-but-empty requires key.
The PostgreSQL Enhanced listing surfaces this today — clicking
Requires shows an empty "Executables" section after the real
"Python modules" section.

## Verified behaviour change

| input addon dict                                                  | before                                                                                                    | after                                              |
|-------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|----------------------------------------------------|
| `{}`                                                              | `[]`                                                                                                      | `[]` (unchanged)                                   |
| `{"re": []}`                                                      | `["Executables", []]`                                                                                     | `[]`                                               |
| `{"rm": []}`                                                      | `["Python modules", []]`                                                                                  | `[]`                                               |
| `{"rg": []}`                                                      | `["GObject introspection modules", []]`                                                                   | `[]`                                               |
| `{"rm": ["psycopg"], "re": []}` (live PostgreSQL Enhanced shape)  | `["Python modules", [["psycopg", "❌"]], "Executables", []]`                                              | `["Python modules", [["psycopg", "❌"]]]`         |
| `{"rm": [], "rg": [], "re": []}`                                  | `["Python modules", [], "GObject introspection modules", [], "Executables", []]`                          | `[]`                                               |
| `{"rm": ["psycopg", "Pillow"]}`                                   | `["Python modules", [["psycopg", "❌"], ["Pillow", "❌"]]]`                                               | identical — populated sections unchanged           |
| `{"rm": ["psycopg"], "re": ["dot"]}`                              | `["Python modules", [["psycopg", "❌"]], "Executables", [["dot", "❌"]]]`                                 | identical — rm / rg / re order preserved           |

The change is uniform across all three sections (`rm` / `rg` /
`re`): build the section's table first, then append BOTH label and
table only if the table has entries. Behaviour for any non-empty
key is preserved exactly.

## Context — Mantis 13979 (already fixed elsewhere)
The same empty-pair shape was also the trigger for the IndexError
crash reported in Mantis 13979 against the Plugin Manager Enhanced
addon: its row-click handler does `txt = " ".join(req_lst[0])` and
indexes an empty list. That crash is resolved in addons-source PR
916 with a defensive guard at the consumer.

This core-side change is **complementary, not a substitute**: the
two fixes ship on independent release cadences (the addon update
reaches users separately from a gramps point release), and the
upstream contract hardening protects any future caller of
`Requirements.info`. 13979 is not being closed here — it is closed
by PR 916 once that merges and ships.

## Blast radius
`Requirements.info` is a public-ish API; tightening it is a
contract change. Reviewers should confirm no unlisted consumer
relies on receiving a label-without-rows pair. Known consumers,
both surveyed:

1. **gramps core** —
   [`EnhancedAddonStatus.__on_requires_clicked`](gramps/gui/plug/_windows.py#L345)
   passes the list straight to `InfoDialog`. The empty labelled
   section no longer renders — this is the visible improvement.
2. **addons-source — `PluginManager` Enhanced addon** —
   `PluginStatus.__info` iterates the list. With the addon-side
   PR 916 fix, the addon already guards empty tables; this change
   also fixes the producer so the guard becomes defence-in-depth
   rather than load-bearing.

`gramps/gen/plug/_pluginreg.py:1373` instantiates `Requirements()`
but only calls `check_plugin`, never `info`, so it is unaffected.

## Test
[`gramps/gen/utils/test/requirements_test.py`](gramps/gen/utils/test/requirements_test.py)
ships in this PR. 8 `unittest.TestCase` methods cover:

- All six pre-change shapes from the verified-behaviour table —
  asserts none of them now emits an empty pair.
- A positive case for non-empty `rm` (populated label + table
  preserved).
- A positive case for non-empty `rm` + non-empty `re` (order
  preserved as well).

The 5 empty-section tests fail on the pre-change file; the 3
positive tests continue to pass. With the change, all 8 pass.

Headless — runs under plain `python3 -m unittest`, no display,
matching the AGENTS.md command:

```
GRAMPS_RESOURCES=. python3 -m unittest gramps.gen.utils.test.requirements_test
```