### PR TITLE
Sort set metadata so unchanged databases are not rewritten

### DIFF
--- a/gramps/gen/lib/serialize.py
+++ b/gramps/gen/lib/serialize.py
@@ -167,7 +167,13 @@ class JSONSerializer:
     @staticmethod
     def object_to_metadata(value):
         type_name = type(value).__name__
-        if type_name in ("set", "tuple"):
+        if type_name == "set":
+            # Sets are unordered, so list(value) yields a hash-dependent
+            # order that varies between processes (string hashing is
+            # randomised). Sort first so the on-disk metadata is stable
+            # across saves and unmodified databases are not rewritten.
+            value = sorted(value)
+        elif type_name == "tuple":
             value = list(value)
         elif type_name == "Researcher":
             value = object_to_dict(value)

--- a/gramps/gen/lib/test/serialize_test.py
+++ b/gramps/gen/lib/test/serialize_test.py
@@ -37,7 +37,8 @@ from .. import (
     Source,
     Tag,
 )
-from ..json_utils import object_to_data, data_to_object
+from ..json_utils import object_to_data, data_to_object, string_to_dict
+from ..serialize import JSONSerializer
 
 EXAMPLE = os.path.join(TEST_DIR, "example.gramps")
 
@@ -110,6 +111,46 @@ class TagCheck(unittest.TestCase, BaseCheck):
     def setUp(self):
         self.cls = Tag
         self.object = self.cls()
+
+
+# ------------------------------------------------------------
+#
+# MetadataSerializeCheck
+#
+# ------------------------------------------------------------
+class MetadataSerializeCheck(unittest.TestCase):
+    """
+    Metadata-set serialization must be order-stable (bug 13747).
+
+    Custom-type metadata (name types, event names, ...) is stored as a
+    Python set. Serializing a set via ``list(value)`` produces a
+    hash-dependent order that changes between processes, so closing an
+    unmodified database rewrote the on-disk file. The serializer now
+    sorts sets before storing them.
+    """
+
+    def test_set_is_serialized_in_sorted_order(self):
+        names = {"Zeta", "Alpha", "Mike", "Bravo", "Yankee", "Charlie", "Delta"}
+        doc = string_to_dict(JSONSerializer.object_to_metadata(names))
+        self.assertEqual(doc["type"], "set")
+        self.assertEqual(doc["value"], sorted(names))
+
+    def test_set_round_trips_to_set(self):
+        original = {"Test", "Test2"}
+        restored = JSONSerializer.metadata_to_object(
+            JSONSerializer.object_to_metadata(original)
+        )
+        self.assertIsInstance(restored, set)
+        self.assertEqual(restored, original)
+
+    def test_tuple_order_is_preserved(self):
+        # Tuples are ordered; the sort must not leak onto them.
+        original = ("zulu", "alpha", "mike")
+        restored = JSONSerializer.metadata_to_object(
+            JSONSerializer.object_to_metadata(original)
+        )
+        self.assertIsInstance(restored, tuple)
+        self.assertEqual(restored, original)
 
 
 class DatabaseCheck(unittest.TestCase):


### PR DESCRIPTION
## Summary
**User impact:** Simply opening a family tree and closing it again — without editing anything — still changed the tree's file on disk. Backup tools and version-control systems then saw the tree as "modified" every single time, creating pointless changes and noisy diffs even though nothing had actually been edited.

This makes the saved order stable, so closing an unchanged tree writes the same file it read.

Reported in Mantis [#13747](https://gramps-project.org/bugs/view.php?id=13747).

## What to look at
The list of custom types a tree remembers (name types, event names, place types, …) was written out in a random order that changed from run to run, so an untouched tree looked different on disk each time. Sorting that list before saving makes an unchanged tree save identically. To try it: open a tree and close it without changes twice, and confirm the on-disk metadata no longer differs between the two closes.

## Root cause
Gramps rewrites all metadata when a database is closed, and custom-type metadata (name types, event names, place types, …) is stored as a Python `set`. The JSON serializer encodes a set with `list(value)`, which yields the set's hash-iteration order; since CPython randomises string hashing per process, that order differs between runs, so closing an unmodified tree rewrites the metadata rows in a new order and needlessly changes the on-disk file.

## Fix
In `JSONSerializer.object_to_metadata`, sort the value when it is a `set` so the serialized order is deterministic. Tuples are kept unsorted (their order is meaningful); the `set`/`tuple` read paths in `metadata_to_object` are unchanged.

## Verification
- **Claim:** a set of custom-type metadata serializes in a deterministic (sorted) order, so closing an unmodified tree does not rewrite the metadata rows, while the reconstructed object is unaffected.
- **Checked:** on maintenance/gramps61 — `gramps/gen/lib/serialize.py:155-186` (`set` is read back with `set(doc["value"])` and the `tuple` path is untouched, so sorting only affects on-disk order, not the reconstructed object), `gramps/gen/db/generic.py:898-914` (the custom-type sets written on close), `gramps/gen/db/generic.py:2082` (set members are `str(type)`, so `sorted()` is a total order and cannot raise), `gramps/plugins/db/dbapi/dbapi.py:111,431-451` (`JSONSerializer` is the live metadata serializer for current databases).
- **Test:** `gramps/gen/lib/test/serialize_test.py::MetadataSerializeCheck` asserts a string set serializes in sorted order, round-trips back to a `set`, and that tuple order is preserved. The sorted-order assertion fails on the unfixed code for all of `PYTHONHASHSEED` 0–7 and passes after the change.

Fixes [#13747](https://gramps-project.org/bugs/view.php?id=13747)
