### PR TITLE
Fix LaTeX report crash when a table has two or more multicolumns

### DIFF
--- a/gramps/plugins/docgen/latexdoc.py
+++ b/gramps/plugins/docgen/latexdoc.py
@@ -509,7 +509,7 @@ def str_incr(str_counter):
                     )
                 )
             )
-        for i in reversed(lili):
+        for i in reversed(range(len(lili))):
             if lili[i] < "z":
                 lili[i] = chr(ord(lili[i]) + 1)
                 break

--- a/gramps/plugins/docgen/test/latexdoc_test.py
+++ b/gramps/plugins/docgen/test/latexdoc_test.py
@@ -1,0 +1,62 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Eduard Ralph
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Unittest for the LaTeX docgen multicolumn counter (bug 13418).
+"""
+
+import unittest
+
+from gramps.plugins.docgen.latexdoc import str_incr, MULTCOL_COUNT_BASE
+
+
+# ------------------------------------------------------------
+#
+# StrIncrTest
+#
+# ------------------------------------------------------------
+class StrIncrTest(unittest.TestCase):
+    """
+    ``str_incr`` generates the column identifiers used when a LaTeX
+    table has spanning (multicolumn) cells. Before the fix the
+    increment loop iterated the list's *elements* rather than its
+    indices, so the second value raised
+    ``TypeError: list indices must be integers or slices, not str``.
+    That second ``next()`` is reached whenever a table has two or more
+    multicolumns, e.g. a styled note containing subscript/strikeout
+    (bug 13418).
+    """
+
+    def test_yields_successive_ids_without_typeerror(self):
+        counter = str_incr(MULTCOL_COUNT_BASE)
+        values = [next(counter) for _ in range(28)]
+        self.assertEqual(values[0], "aaa")
+        self.assertEqual(values[1], "aab")
+        self.assertEqual(values[25], "aaz")
+        self.assertEqual(values[26], "aba")  # carry into the next column
+        self.assertEqual(values[27], "abb")
+
+    def test_carry_with_short_base(self):
+        counter = str_incr("az")
+        self.assertEqual(next(counter), "az")
+        self.assertEqual(next(counter), "ba")  # full carry
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -550,6 +550,11 @@ gramps/plugins/db/dbapi/test/db_test.py
 #
 gramps/plugins/docgen/__init__.py
 #
+# plugins/docgen/test directory
+#
+gramps/plugins/docgen/test/__init__.py
+gramps/plugins/docgen/test/latexdoc_test.py
+#
 # plugins/drawreport directory
 #
 gramps/plugins/drawreport/__init__.py


### PR DESCRIPTION
## Root cause
`str_incr` in `latexdoc.py` generates the column identifiers used for LaTeX
table multicolumns. Its increment loop, `for i in reversed(lili)`, iterates the
character list's *elements* rather than its indices, so `lili[i]` indexes the
list with a string and raises `TypeError: list indices must be integers or
slices, not str`. The first `next()` returns at the `yield` before the loop, so
the crash appears on the second value — reached whenever a table has two or more
multicolumns, such as a styled note containing subscript/strikeout (bug 13418).

## Fix
Iterate the indices instead of the elements:

```python
-        for i in reversed(lili):
+        for i in reversed(range(len(lili))):
```

The carry behaviour is unchanged: `aaa, aab, … aaz, aba, …`.

## Verified against
- `gramps/plugins/docgen/latexdoc.py:496-517` — the `str_incr` generator and its
  carry/`else` branch.
- This is independent of bug 13417 (styled-note markup): that fix is commit
  8b935f1551 and does not touch `str_incr`.

## Test
`gramps/plugins/docgen/test/latexdoc_test.py` adds a headless `StrIncrTest`
asserting `str_incr` yields successive ids (including a carry) without raising.
The second yielded value reproduces the `TypeError` on the unfixed code; both
tests pass after the change.

Fixes #13418.
