### PR TITLE
Fix Top Surnames gramplet opening report for the wrong surname

### DIFF
--- a/gramps/plugins/gramplet/test/topsurnamesgramplet_test.py
+++ b/gramps/plugins/gramplet/test/topsurnamesgramplet_test.py
@@ -1,0 +1,156 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Brian Caudill
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Unittest for the Top Surnames gramplet surname tally.
+"""
+
+# -------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import unittest
+from collections import defaultdict
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from gramps.gen.lib import Name, Person, Surname
+from gramps.gen.types import PersonHandle
+from gramps.plugins.gramplet.topsurnamesgramplet import record_surnames
+
+
+# -------------------------------------------------------------------------
+#
+# Test helpers
+#
+# -------------------------------------------------------------------------
+def make_name(surname_text: str) -> Name:
+    """
+    Build a Name carrying a single surname.
+    """
+    name = Name()
+    surname = Surname()
+    surname.set_surname(surname_text)
+    name.add_surname(surname)
+    return name
+
+
+def make_person(handle: str, primary: str, alternates: tuple[str, ...] = ()) -> Person:
+    """
+    Build a Person with the given primary surname and alternate surnames.
+    """
+    person = Person()
+    person.set_handle(handle)
+    person.set_primary_name(make_name(primary))
+    for alt in alternates:
+        person.add_alternate_name(make_name(alt))
+    return person
+
+
+def tally(people: list[Person]) -> tuple[dict[str, int], dict[str, PersonHandle]]:
+    """
+    Run record_surnames over a list of people and return the tallies.
+    """
+    surnames: dict[str, int] = defaultdict(int)
+    representative_handle: dict[str, PersonHandle] = {}
+    for person in people:
+        record_surnames(person, surnames, representative_handle)
+    return surnames, representative_handle
+
+
+# -------------------------------------------------------------------------
+#
+# TopSurnamesTest
+#
+# -------------------------------------------------------------------------
+class TopSurnamesTest(unittest.TestCase):
+    """
+    Test surname tallying and representative selection (bug #11101).
+    """
+
+    def test_counts_primary_and_alternate_names(self):
+        """
+        A person is counted under both their primary and alternate surnames.
+        """
+        people = [make_person("P1", "Webb", alternates=("Allen",))]
+        surnames, _ = tally(people)
+        self.assertEqual(surnames["Webb"], 1)
+        self.assertEqual(surnames["Allen"], 1)
+
+    def test_representative_has_matching_primary_surname(self):
+        """
+        Bug #11101: the representative for a surname must be a person whose
+        primary surname matches it, even when an alternate-name carrier is
+        processed last.
+
+        "Allen" has "Webb" as an alternate name and is iterated after the real
+        Webb, so the pre-fix code left her as Webb's representative.
+        """
+        webb = make_person("WEBB", "Webb")
+        allen = make_person("ALLEN", "Allen", alternates=("Webb",))
+        # Order matters: the alternate-name carrier comes last.
+        _, representative_handle = tally([webb, allen])
+        self.assertEqual(representative_handle["Webb"], "WEBB")
+        self.assertEqual(representative_handle["Allen"], "ALLEN")
+
+    def test_representative_correct_regardless_of_order(self):
+        """
+        The primary-name carrier wins even when processed after the alternate.
+        """
+        allen = make_person("ALLEN", "Allen", alternates=("Webb",))
+        webb = make_person("WEBB", "Webb")
+        _, representative_handle = tally([allen, webb])
+        self.assertEqual(representative_handle["Webb"], "WEBB")
+
+    def test_alternate_only_surname_falls_back_to_first_seen(self):
+        """
+        When no person carries a surname as their primary name, a deterministic
+        fallback (the first person seen with it as an alternate) is used.
+
+        Such surnames are inherently best-effort: the Same Surnames quick view
+        derives the surname from the representative's primary name, so no
+        representative can make the report match a surname nobody holds as a
+        primary name.
+        """
+        smith = make_person("SMITH", "Smith", alternates=("Jones",))
+        brown = make_person("BROWN", "Brown", alternates=("Jones",))
+        _, representative_handle = tally([smith, brown])
+        self.assertEqual(representative_handle["Jones"], "SMITH")
+
+    def test_multiple_primary_carriers_keep_a_matching_representative(self):
+        """
+        With several primary-name carriers, the representative still has a
+        matching primary surname.
+        """
+        people = [
+            make_person("W1", "Webb"),
+            make_person("ALLEN", "Allen", alternates=("Webb",)),
+            make_person("W2", "Webb"),
+        ]
+        surnames, representative_handle = tally(people)
+        self.assertIn(representative_handle["Webb"], ("W1", "W2"))
+        self.assertEqual(surnames["Webb"], 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/plugins/gramplet/topsurnamesgramplet.py
+++ b/gramps/plugins/gramplet/topsurnamesgramplet.py
@@ -30,7 +30,9 @@ from collections import defaultdict
 from gramps.gen.plug import Gramplet
 from gramps.gen.config import config
 from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.lib import Person
 from gramps.gen.plug.menu import NumberOption
+from gramps.gen.types import PersonHandle
 
 _ = glocale.translation.sgettext
 
@@ -42,6 +44,38 @@ _ = glocale.translation.sgettext
 _YIELD_INTERVAL = 350
 
 NUM_SURNAMES = _("Number of Surnames to display")
+
+
+# ------------------------------------------------------------------------
+#
+# Helper functions
+#
+# ------------------------------------------------------------------------
+def record_surnames(
+    person: Person,
+    surnames: dict[str, int],
+    representative_handle: dict[str, PersonHandle],
+) -> None:
+    """
+    Tally one person's surnames and choose representatives for them.
+
+    The person is counted under every group name taken from their primary and
+    alternate names.  They become the representative for a surname only when it
+    is their primary group name, or when no representative has been chosen yet.
+    The Same Surnames quick view re-derives the surname from the
+    representative's primary name, so a representative whose primary surname
+    differs would open a report for a different surname than the one clicked.
+    """
+    primary_name = person.get_primary_name()
+    primary_surname = primary_name.get_group_name().strip()
+    allnames = set(
+        name.get_group_name().strip()
+        for name in [primary_name] + person.get_alternate_names()
+    )
+    for surname in allnames:
+        surnames[surname] += 1
+        if surname == primary_surname or surname not in representative_handle:
+            representative_handle[surname] = person.handle
 
 
 # ------------------------------------------------------------------------
@@ -78,16 +112,12 @@ class TopSurnamesGramplet(Gramplet):
 
     def main(self):
         self.set_text(_("Processing...") + "\n")
-        surnames = defaultdict(int)
-        representative_handle = {}
+        surnames: dict[str, int] = defaultdict(int)
+        representative_handle: dict[str, PersonHandle] = {}
 
         cnt = 0
         for person in self.dbstate.db.iter_people():
-            allnames = [person.get_primary_name()] + person.get_alternate_names()
-            allnames = set([name.get_group_name().strip() for name in allnames])
-            for surname in allnames:
-                surnames[surname] += 1
-                representative_handle[surname] = person.handle
+            record_surnames(person, surnames, representative_handle)
             cnt += 1
             if not cnt % _YIELD_INTERVAL:
                 yield True

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -569,6 +569,11 @@ gramps/plugins/gramplet/gallery.py
 gramps/plugins/gramplet/mediapreview.py
 gramps/plugins/gramplet/metadataviewer.py
 #
+# plugins/gramplet/test directory
+#
+gramps/plugins/gramplet/test/__init__.py
+gramps/plugins/gramplet/test/topsurnamesgramplet_test.py
+#
 # plugins/graph directory
 #
 gramps/plugins/graph/__init__.py


### PR DESCRIPTION
Fixes [#11101](https://gramps-project.org/bugs/view.php?id=11101).

## Problem

In the *Top Surnames* gramplet (Dashboard), double-clicking a surname opens a Same Surnames report for a **different** surname. Depending on the tree it shows up on the top entry or the 2nd/3rd. Reproducibility is "always" for affected trees; also reported on the [forum](https://gramps.discourse.group/t/top-surnames-gramplet-reports-wrong-surname/3870).

## Root cause

`TopSurnamesGramplet.main()` counts each person under **every** group name from their primary *and* alternate names, and sets `representative_handle[surname] = person.handle` for each. The stored representative is therefore the last person iterated who carries that surname among *any* of their names — possibly someone whose **primary** surname is different (they matched only via an "also known as" alternate name).

The `samesurnames` quick view (category `CATEGORY_QR_PERSON`) re-derives the surname from that person:

```python
rsurname = person.get_primary_name().get_group_name()
```

If the representative's primary surname differs from the clicked surname, the report is for the wrong surname. This matches the analysis in #11101 (note ~0065258): the triggering person had redundant "Also known as" alternate names matching the top surname, while her *primary* surname differed.

## Fix

Prefer a representative whose **primary** surname matches the group name, so the quick view's re-derivation matches what was clicked. Surnames that appear only as alternate names (no primary carrier) use a deterministic first-seen fallback and remain best-effort, since `samesurnames` always derives from the primary name.

The per-person tally is extracted into a module-level `record_surnames()` helper so the selection logic is testable without GTK or a database; the gramplet's incremental `yield` behaviour is unchanged.

## Tests

Adds `gramps/plugins/gramplet/test/topsurnamesgramplet_test.py` covering surname counting across primary/alternate names, representative selection regardless of iteration order, and the alternate-only fallback. Built with `gramps.gen.lib` objects — no display or database required. `black --check` clean.