### PR TITLE
Display images according to Exif orientation tag

### DIFF
--- a/gramps/gen/lib/mediaref.py
+++ b/gramps/gen/lib/mediaref.py
@@ -255,6 +255,7 @@ class MediaRef(
         """Return the subsection of an image."""
         return self.rect
 
+
 def apply_orientation_to_rect_coords(rect_coords, orientation, invert=False):
     """
     converts the rect_coordinates (x1, y1, x2, y2) such that they are
@@ -286,24 +287,24 @@ def apply_orientation_to_rect_coords(rect_coords, orientation, invert=False):
     # 1 = Horizontal (normal)
     if orientation == "2":
         # 2 = Mirror horizontal
-        return 100-x2, y1, 100-x1, y2
+        return 100 - x2, y1, 100 - x1, y2
     elif orientation == "3":
         # 3 = Rotate 180
-        return 100-x2, 100-y2, 100-x1, 100-y1
+        return 100 - x2, 100 - y2, 100 - x1, 100 - y1
     elif orientation == "4":
         # 4 = Mirror vertical
-        return x1, 100-y2, x2, 100-y1
+        return x1, 100 - y2, x2, 100 - y1
     elif orientation == "5":
         # 5 = Mirror horizontal and rotate 270 CW
         return y1, x1, y2, x2
     elif orientation == "6":
         # 6 = Rotate 90 CW
-        return 100-y2, x1, 100-y1, x2
+        return 100 - y2, x1, 100 - y1, x2
     elif orientation == "7":
         # 7 = Mirror horizontal and rotate 90 CW
-        return 100-y2, 100-x2, 100-y1, 100-x1
+        return 100 - y2, 100 - x2, 100 - y1, 100 - x1
     elif orientation == "8":
         # 8 = Rotate 270 CW
-        return y1, 100-x2, y2, 100-x1
+        return y1, 100 - x2, y2, 100 - x1
     # fallback, no change
     return x1, y1, x2, y2

--- a/gramps/gen/lib/mediaref.py
+++ b/gramps/gen/lib/mediaref.py
@@ -6,6 +6,7 @@
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2013       Doug Blank <doug.blank@gmail.com>
 # Copyright (C) 2017,2024  Nick Hall
+# Copyright (C) 2026       ztlxltl
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -253,3 +254,56 @@ class MediaRef(
     def get_rectangle(self):
         """Return the subsection of an image."""
         return self.rect
+
+def apply_orientation_to_rect_coords(rect_coords, orientation, invert=False):
+    """
+    converts the rect_coordinates (x1, y1, x2, y2) such that they are
+    correct when applying the orientation to the image. Use invert=True
+    to to the inverted conversation, e.g. setting the values in the
+    database.
+    """
+
+    if orientation is None:
+        return rect_coords
+
+    x1, y1, x2, y2 = rect_coords
+    # https://exiftool.org/TagNames/EXIF.html
+    # 0x0112 Orientation
+
+    if invert:
+        if orientation == "6":
+            orientation = "8"
+        elif orientation == "8":
+            orientation = "6"
+        # all other orientations are involutory transformations
+
+    # General logic:
+    # - Mirror: swap values
+    # - Rotate 90 CW: circular right shift
+    # - In all cases: if first and second coordinate values are
+    #   swapped, subtract them from 100.
+
+    # 1 = Horizontal (normal)
+    if orientation == "2":
+        # 2 = Mirror horizontal
+        return 100-x2, y1, 100-x1, y2
+    elif orientation == "3":
+        # 3 = Rotate 180
+        return 100-x2, 100-y2, 100-x1, 100-y1
+    elif orientation == "4":
+        # 4 = Mirror vertical
+        return x1, 100-y2, x2, 100-y1
+    elif orientation == "5":
+        # 5 = Mirror horizontal and rotate 270 CW
+        return y1, x1, y2, x2
+    elif orientation == "6":
+        # 6 = Rotate 90 CW
+        return 100-y2, x1, 100-y1, x2
+    elif orientation == "7":
+        # 7 = Mirror horizontal and rotate 90 CW
+        return 100-y2, 100-x2, 100-y1, 100-x1
+    elif orientation == "8":
+        # 8 = Rotate 270 CW
+        return y1, 100-x2, y2, 100-x1
+    # fallback, no change
+    return x1, y1, x2, y2

--- a/gramps/gen/utils/image.py
+++ b/gramps/gen/utils/image.py
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2000-2006  Donald N. Allingham
 # Copyright (C) 2011       Adam Stein <adam@csh.rit.edu>
+# Copyright (C) 2026       ztlxltl
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -43,6 +44,7 @@ import tempfile
 #
 # -------------------------------------------------------------------------
 from ..const import GRAMPS_LOCALE as glocale
+from gramps.gen.lib.mediaref import apply_orientation_to_rect_coords
 
 _ = glocale.translation.gettext
 
@@ -88,10 +90,13 @@ def resize_to_jpeg(source, destination, width, height, crop=None):
     from gi.repository import GdkPixbuf
 
     img = GdkPixbuf.Pixbuf.new_from_file(source)
+    orientation = img.get_option("orientation")
+    img.apply_embedded_orientation()
 
     if crop:
         start_x, start_y, end_x, end_y = crop_percentage_to_pixel(
-            img.get_width(), img.get_height(), crop
+            img.get_width(), img.get_height(),
+            apply_orientation_to_rect_coords(crop, orientation)
         )
         if end_x - start_x > 0 and end_y - start_y > 0:
             img = img.new_subpixbuf(start_x, start_y, end_x - start_x, end_y - start_y)
@@ -252,10 +257,13 @@ def resize_to_buffer(source, size, crop=None):
     from gi.repository import GdkPixbuf
 
     img = GdkPixbuf.Pixbuf.new_from_file(source)
+    orientation = img.get_option("orientation")
+    img.apply_embedded_orientation()
 
     if crop:
         start_x, start_y, end_x, end_y = crop_percentage_to_pixel(
-            img.get_width(), img.get_height(), crop
+            img.get_width(), img.get_height(),
+            apply_orientation_to_rect_coords(crop, orientation)
         )
         if end_x - start_x > 0 and end_y - start_y > 0:
             img = img.new_subpixbuf(start_x, start_y, end_x - start_x, end_y - start_y)
@@ -294,10 +302,13 @@ def resize_to_jpeg_buffer(source, size, crop=None):
 
     filed, dest = tempfile.mkstemp()
     img = GdkPixbuf.Pixbuf.new_from_file(source)
+    orientation = img.get_option("orientation")
+    img.apply_embedded_orientation()
 
     if crop:
         start_x, start_y, end_x, end_y = crop_percentage_to_pixel(
-            img.get_width(), img.get_height(), crop
+            img.get_width(), img.get_height(),
+            apply_orientation_to_rect_coords(crop, orientation)
         )
         if end_x - start_x > 0 and end_y - start_y > 0:
             img = img.new_subpixbuf(start_x, start_y, end_x - start_x, end_y - start_y)

--- a/gramps/gen/utils/image.py
+++ b/gramps/gen/utils/image.py
@@ -95,8 +95,9 @@ def resize_to_jpeg(source, destination, width, height, crop=None):
 
     if crop:
         start_x, start_y, end_x, end_y = crop_percentage_to_pixel(
-            img.get_width(), img.get_height(),
-            apply_orientation_to_rect_coords(crop, orientation)
+            img.get_width(),
+            img.get_height(),
+            apply_orientation_to_rect_coords(crop, orientation),
         )
         if end_x - start_x > 0 and end_y - start_y > 0:
             img = img.new_subpixbuf(start_x, start_y, end_x - start_x, end_y - start_y)
@@ -262,8 +263,9 @@ def resize_to_buffer(source, size, crop=None):
 
     if crop:
         start_x, start_y, end_x, end_y = crop_percentage_to_pixel(
-            img.get_width(), img.get_height(),
-            apply_orientation_to_rect_coords(crop, orientation)
+            img.get_width(),
+            img.get_height(),
+            apply_orientation_to_rect_coords(crop, orientation),
         )
         if end_x - start_x > 0 and end_y - start_y > 0:
             img = img.new_subpixbuf(start_x, start_y, end_x - start_x, end_y - start_y)
@@ -307,8 +309,9 @@ def resize_to_jpeg_buffer(source, size, crop=None):
 
     if crop:
         start_x, start_y, end_x, end_y = crop_percentage_to_pixel(
-            img.get_width(), img.get_height(),
-            apply_orientation_to_rect_coords(crop, orientation)
+            img.get_width(),
+            img.get_height(),
+            apply_orientation_to_rect_coords(crop, orientation),
         )
         if end_x - start_x > 0 and end_y - start_y > 0:
             img = img.new_subpixbuf(start_x, start_y, end_x - start_x, end_y - start_y)

--- a/gramps/gui/editors/editmediaref.py
+++ b/gramps/gui/editors/editmediaref.py
@@ -7,6 +7,7 @@
 #               2011       Robert Cheramy <robert@cheramy.net>
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2013       Nick Hall
+# Copyright (C) 2026       ztlxltl
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -52,6 +53,7 @@ from gramps.gen.mime import get_description, get_type
 from gramps.gen.utils.thumbnails import get_thumbnail_image, find_mime_type_pixbuf
 from gramps.gen.utils.file import media_path_full, find_file, create_checksum
 from gramps.gen.lib import NoteType
+from gramps.gen.lib.mediaref import apply_orientation_to_rect_coords
 from gramps.gen.db import DbTxn
 from ..glade import Glade
 from .displaytabs import (
@@ -315,6 +317,13 @@ class EditMediaRef(EditReference):
         Initialization that must happen after the window is shown.
         """
         self.draw_preview()
+        self.rectangle = apply_orientation_to_rect_coords(
+            self.rectangle, self.selection.orientation
+        )
+        self.corner1_x_spinbutton.set_value(self.rectangle[0])
+        self.corner1_y_spinbutton.set_value(self.rectangle[1])
+        self.corner2_x_spinbutton.set_value(self.rectangle[2])
+        self.corner2_y_spinbutton.set_value(self.rectangle[3])
         self.update_region()
 
     def set_corner1_x(self, value):
@@ -606,7 +615,9 @@ class EditMediaRef(EditReference):
             (coord[0], coord[1]) * 2,
         ):
             coord = None
-
+        coord = apply_orientation_to_rect_coords(
+            coord, self.selection.orientation, invert=True
+        )
         self.source_ref.set_rectangle(coord)
 
         # call callback if given

--- a/gramps/gui/widgets/selectionwidget.py
+++ b/gramps/gui/widgets/selectionwidget.py
@@ -2,6 +2,7 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
 # Copyright (C) 2013 Artem Glebov <artem.glebov@gmail.com>
+# Copyright (C) 2026 ztlxltl
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -213,6 +214,7 @@ class SelectionWidget(Gtk.ScrolledWindow):
         self.regions = []
         self.translation = None
         self.pixbuf = None
+        self.orientation = None
         self.scaled_pixbuf = None
         self.scale = 1.0
         self.old_viewport_size = None
@@ -308,6 +310,8 @@ class SelectionWidget(Gtk.ScrolledWindow):
 
         try:
             self.pixbuf = GdkPixbuf.Pixbuf.new_from_file(image_path)
+            self.orientation = self.pixbuf.get_option("orientation")
+            self.pixbuf = self.pixbuf.apply_embedded_orientation()
             self.original_image_size = (
                 self.pixbuf.get_width(),
                 self.pixbuf.get_height(),

--- a/gramps/plugins/thumbnailer/imagethumb.py
+++ b/gramps/plugins/thumbnailer/imagethumb.py
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2000-2007  Donald N. Allingham
 # Copyright (C) 2022       Nick Hall
+# Copyright (C) 2026       ztlxltl
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -42,6 +43,7 @@ from gi.repository import GdkPixbuf
 #
 # -------------------------------------------------------------------------
 from gramps.gen.const import THUMBSCALE, THUMBSCALE_LARGE, SIZE_LARGE
+from gramps.gen.lib.mediaref import apply_orientation_to_rect_coords
 from gramps.gen.plug import Thumbnailer
 
 # -------------------------------------------------------------------------
@@ -64,10 +66,15 @@ class ImageThumb(Thumbnailer):
         # routines.
         try:
             pixbuf = GdkPixbuf.Pixbuf.new_from_file(src_file)
+            orientation = pixbuf.get_option("orientation")
+            pixbuf = pixbuf.apply_embedded_orientation()
             width = pixbuf.get_width()
             height = pixbuf.get_height()
 
             if rectangle is not None:
+                rectangle = apply_orientation_to_rect_coords(
+                    rectangle, orientation
+                )
                 upper_x = min(rectangle[0], rectangle[2]) / 100.0
                 lower_x = max(rectangle[0], rectangle[2]) / 100.0
                 upper_y = min(rectangle[1], rectangle[3]) / 100.0

--- a/gramps/plugins/thumbnailer/imagethumb.py
+++ b/gramps/plugins/thumbnailer/imagethumb.py
@@ -72,9 +72,7 @@ class ImageThumb(Thumbnailer):
             height = pixbuf.get_height()
 
             if rectangle is not None:
-                rectangle = apply_orientation_to_rect_coords(
-                    rectangle, orientation
-                )
+                rectangle = apply_orientation_to_rect_coords(rectangle, orientation)
                 upper_x = min(rectangle[0], rectangle[2]) / 100.0
                 lower_x = max(rectangle[0], rectangle[2]) / 100.0
                 upper_y = min(rectangle[1], rectangle[3]) / 100.0


### PR DESCRIPTION
This is a proof of concept to support the orientation Exif tag. It theoretically is ready for merging, but there are still a few open points that likely need to be discussed, see below.

Why considering the Exif orientation is important:
Many cameras, scanners and programs set the orientation tag instead of actually rotating the image. Rotating the image as a post-processing step can reduce image quality of images saved in lossy file formats without increasing the file size significantly or altering the image in some way, e.g. JPEG's Minimum Coded Units (MCUs) after rotation don't necessarily align with original MCUs, see [here](https://betterjpeg.com/lossless-rotation.htm) for some strategies for rotating a JPEG and their disadvantages.

Overview:
I tested two file formats: TIFF and JPEG. The orientation tag of TIFF images is only partially applied while loading them as a `Pixbuf`, see [here](https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/blob/master/gdk-pixbuf/io-tiff.c#L202) for some background info. The orientation tag of JPEG images is not applied while loading them as a `Pixbuf`, but it is available as an "option". If an image is loaded of a file format for which the orientation is not applied, Gramps displays it incorrectly (e.g. rotated or upside down) compared to other programs.
This is fixed by applying the orientation to the `Pixbuf` before it is used. The rectangle coordinates of `MediaRef`s are adjusted accordingly.

Modifications in this PR:
- `pixbuf.apply_embedded_orientation()` is used to apply the orientation to `Pixbuf`s:
  - In `ImageThumb` when creating the thumbnail.
  - In `SelectionWidget` since it shows the image in full size without using a thumbnail.
  - In `resize_to_jpeg`, `resize_to_buffer`, and `resize_to_jpeg_buffer`. These functions are used by `DOCGEN` plugins, which seem to be used to create reports.
- I added a new `apply_orientation_to_rect_coords` function in `mediaref.py`. The rectangle coordinates are available through `MediaRef`s. As this object has no info about the underlying image file's Exif tags, I created it as a module function for now instead of a method of `MediaRef`.
- The value of `pixbuf.get_option("orientation")` is used as an parameter to the function mentioned above:
  - In `ImageThumb` when creating the thumbnail.
  - In `EditMediaRef` applies the orientation to the rectangle and converts the coordinates back when saving.
  - In `resize_to_jpeg`, `resize_to_buffer`, and `resize_to_jpeg_buffer` the orientation is applied to the rectangle coordinated passed to `crop_percentage_to_pixel`.

The definition of the rectangle coordinates in the database isn't changed: They are describing the rectangle on the image without manually applying the orientation.

Advantages of this:
- No change to the database model or definition of fields.
- Already tagged regions of rotated images stay correct. The thumbnails show the same part of the image as before, just rotated correctly once the thumbnails are regenerated.

Disadvantage:
- Actually rotating images with an orientation tag (and thus removing the orientation tag) or editing an image with an orientation tag and saving it actually rotated without an orientation tag after setting the rectangle in Gramps renders the rectangles at the wrong position.
  (I think this is an edge case and won't be a big issue. If you edit the image you should expect that the references also need editing.)

Another disadvantage that is not related to this PR, but that I can think of in general, is that the definition of the `MediaRef.rect` with respect to whether they correspond to the image before or after the orientation tag is applied depends on the fact whether the pixbuf loader of the file format of the image automatically applies the orientation. If the behavior of the loader changes or a different loader or toolkit is used, this can be hard to untangle.

I tested the implementation by using `exiftool` to change the orientation of `1897_expeditionsmannschaft_rio_a.jpg` in the example database. I can't see any issues in the Gramps UI, but I found small thumbnails in the Narrated Web report that aren't rotated (see also below).

Open points:
- Where's the best place to define the `apply_orientation_to_rect_coords` function?
- Should the orientation be applied to the rectangle on a different layer, e.g. always in `MediaRef.set_rectangle()` and `MediaRef.get_rectangle()`? (This requires to store or read the Exif tag when the methods are called the first time!)
- Currently, in `EditMediaRef`, `self.rectangle` is converted in `_post_init`. Is this the best place to do this?  Is there a better alternative to update the `self.corner..._spinbutton`s after `self.rectangle` is converted?
- Should `SelectionWidget`'s `self.regions`, `self.current` and `self.selection` be in coordinates after or before applying the orientation?
- Is Gramps using the images directly somewhere else, i.e. not thumbnails of the images? The orientation needs to be applied there as well.
- The current implementation doesn't apply to all instances of an image in the Narrated Web report (see above). I wasn't able to find the code which creates the problematic thumbnail.
  In fact, the reports have to be analyzed in detail. No changes are likely required for some report formats if the image is simply copied (and renamed) and not processed by Gramps, e.g. maybe an unmodified image is just copied and renamed for an HTML report and the browser considers the orientation tag when displaying the image. I also noticed that `ODFDoc` seems to use the image file directly (only the file path is used, the image is not loaded). I'm not sure how the rectangle is interpreted by this plugin. `LaTeXDoc` doesn't seem to use the rectangle at all.
- Are there special considerations for addons, e.g. the Photo Tagging Gramplet, maybe other report add-ons?
- While this PR only modifies the Gramps UI, maybe the observations are also important for other tools or programs that deal with images that are not loaded by pixbuf, but the user selected the rectangle in the Gramps UI, e.g. GrampsWeb.

Related discussions and issues (some of them link to others):
- 2010-04-04 https://sourceforge.net/p/gramps/mailman/gramps-bugs/thread/h2t8f1bc3591004032204s2947dc40r481629b1b84301bc%40mail.gmail.com/#msg24963348
- 2010-04-10 https://gramps-project.org/bugs/view.php?id=3832
- 2017-04-16 https://sourceforge.net/p/gramps/mailman/gramps-users/thread/456764c1-34a0-fdbc-d255-63254d6e8545%40telus.net/#msg35790977
- 2018-09-01 https://sourceforge.net/p/gramps/mailman/gramps-users/thread/CAOz04Fu7X2p_mwPyp7UCrE6yDfSppy4rppDkwWgQ%3DtndDkSwMA%40mail.gmail.com/#msg36405712
- 2020-10-31 https://sourceforge.net/p/gramps/mailman/gramps-users/thread/1799818261.850427.1604141432901%40mail.yahoo.com/#msg37141151
- 2021-01-19 https://www.reddit.com/r/gramps/comments/l08rda/rotated_image_scans_not_displaying_correctly/
- 2021-01-21 https://gramps-project.org/bugs/view.php?id=12182
- 2022-03-26 https://gramps.discourse.group/t/image-orientation-in-the-media-reference-editor/2354
- 2022-04-24 https://www.reddit.com/r/gramps/comments/ub1fad/media_rotation_not_carried_into_gramps/
- 2024-01-21 https://gramps.discourse.group/t/adding-pictures-to-graphview-they-are-added-sideways/4717
- `Exif.Image.Orientation` is listed as an `IMAGE` tag in `libmetadata.py`.
- "Exif.Image.or<ins>ei</ins>ntation" listed as a "JUNK" Exif tag here: https://gramps-project.org/bugs/view.php?id=3449#c11974