### PR TITLE
Fix memory leak caused by stale link tags in GuiGramplet

### DIFF
--- a/gramps/gui/widgets/grampletpane.py
+++ b/gramps/gui/widgets/grampletpane.py
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2000-2007  Donald N. Allingham
 # Copyright (C) 2011 Nick Hall
+# Copyright (C) 2026 ztlxltl
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -464,6 +465,7 @@ class GuiGramplet:
     def clear_text(self):
         self.buffer.set_text("")
         self.text_length = 0
+        self._tags = []
 
     def get_text(self):
         start = self.buffer.get_start_iter()
@@ -570,8 +572,7 @@ class GuiGramplet:
             tag_table.foreach(lambda tag, data: tag_table.remove(tag))
 
     def set_text(self, text, scroll_to="start"):
-        self.buffer.set_text("")
-        self.text_length = 0
+        self.clear_text()
         self.append_text(text, scroll_to)
         self.buffer.reset()
 

--- a/gramps/plugins/gramplet/pedigreegramplet.py
+++ b/gramps/plugins/gramplet/pedigreegramplet.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2007-2009  Douglas S. Blank <doug.blank@gmail.com>
 # Copyright (C) 2009       Gary Burton
+# Copyright (C) 2026       ztlxltl
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -241,7 +242,7 @@ class PedigreeGramplet(Gramplet):
         """
         self._boxes = [0] * (self.max_generations + 1)
         self._generations = {}
-        self.gui.buffer.set_text("")
+        self.clear_text()
         active_handle = self.get_active("Person")
         if active_handle is None:
             return


### PR DESCRIPTION
How to reproduce the leak:
1. Open the example database.
2. Switch to the people list view.
3. Add the Pedigree Gramplet to the sidebar.
4. Open the config of the Pedigree Gramplet and make sure the "Max generations" is set to 100.
5. Select Warner, Allen Carl.
6. Move the mouse over the names in the pedigree.
7. The names are underlined while the mouse pointer is hovering over them.
8. Select Warner, Amanda.
9. Repeat switching between Warner, Allen Carl and Warner, Amanda about 20 (loading the pedigree of both 10 times).
10. Move the mouse again over the names in the pedigree.
11. The underlining appears delayed.
12. Repeat switching between Warner, Allen Carl and Warner, Amanda a few dozens of times, depending on your machine.
13. Updating the pedigree becomes slower and slower.

The reason for the delays is that `PedigreeGramplet.gui._tags` is never cleared, but new tags are added every time the content is updated.

This PR fixes this by:
- setting `GuiGramplet._tags` to an empty list in `GuiGramplet.clear_text()`
- calling `GuiGramplet.clear_text()` in `GuiGramplet.set_text`
- calling `Gramplet.clear_text()` in `PedigreeGramplet.main()`
  (`Gramplet.clear_text()` calls `GuiGramplet.clear_text()`)

I couldn't find a bug report about this. I'm happy to create one if a discussion about this is preferred.