### PR TITLE
Fix underscores and escaping in menu labels

### DIFF
--- a/gramps/gui/displaystate.py
+++ b/gramps/gui/displaystate.py
@@ -5,6 +5,7 @@
 # Copyright (C) 2008       Brian G. Matherly
 # Copyright (C) 2010       Nick Hall
 # Copyright (C) 2011       Tim G L Lyons
+# Copyright (C) 2026       ztlxltl
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -306,15 +307,17 @@ class RecentDocsMenu:
 
         for item in rfiles:
             try:
-                title = html.escape(item.get_name())
+                title = item.get_name()
+                menu_title = html.escape(title.replace("_", "__"))
+                bar_title = html.escape(title)
                 filename = os.path.basename(item.get_path())
                 action_id = "RecentMenu%d" % count
                 # add the menuitem for this file
-                menu += _RCT_MENU % (action_id, title)
+                menu += _RCT_MENU % (action_id, menu_title)
                 # add the action for this file
                 actionlist.append((action_id, make_callback(item, self.load)))
                 # add the toolbar menuitem
-                bar += _RCT_BAR % (action_id, title)
+                bar += _RCT_BAR % (action_id, bar_title)
             except RuntimeError:
                 # ignore no longer existing files
                 _LOG.info("Ignoring the RecentItem %s (%s)" % (title, filename))

--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -9,6 +9,7 @@
 # Copyright (C) 2012       Gary Burton
 # Copyright (C) 2012       Doug Blank <doug.blank@gmail.com>
 # Copyright (C) 2026       Gabriel Rios
+# Copyright (C) 2026       ztlxltl
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -1776,7 +1777,8 @@ class ViewManager(CLIManager):
             pdatas.sort(key=lambda x: x.name)
             for pdata in pdatas:
                 new_key = valid_action_name(pdata.id)
-                ofile.write(menuitem % (new_key, pdata.name))
+                name = html.escape(pdata.name.replace("_", "__"))
+                ofile.write(menuitem % (new_key, name))
                 actions.append((new_key, func(pdata, self.dbstate, self.uistate)))
             ofile.write("</submenu>\n")
 
@@ -1790,8 +1792,9 @@ class ViewManager(CLIManager):
             pdatas = hash_data[_UNSUPPORTED]
             pdatas.sort(key=lambda x: x.name)
             for pdata in pdatas:
-                new_key = pdata.id.replace(" ", "-")
-                ofile.write(menuitem % (new_key, pdata.name))
+                new_key = valid_action_name(pdata.id)
+                name = html.escape(pdata.name.replace("_", "__"))
+                ofile.write(menuitem % (new_key, name))
                 actions.append((new_key, func(pdata, self.dbstate, self.uistate)))
             ofile.write("</submenu>\n")
 

--- a/gramps/gui/views/bookmarks.py
+++ b/gramps/gui/views/bookmarks.py
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2000-2007  Donald N. Allingham
 # Copyright (C) 2011       Tim G L Lyons
+# Copyright (C) 2026       ztlxltl
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -174,7 +175,9 @@ class Bookmarks(metaclass=ABCMeta):
                     func = self.callback(item)
                     action_id = "BM.%s" % item
                     actions.append((action_id, func))
-                    text.write(menuitem % (action_id, html.escape(label)))
+                    text.write(
+                        menuitem % (action_id, html.escape(label.replace("_", "__")))
+                    )
                     count += 1
                 except AttributeError:
                     pass

--- a/gramps/gui/views/tags.py
+++ b/gramps/gui/views/tags.py
@@ -1,6 +1,7 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
 # Copyright (C) 2010    Nick Hall
+# Copyright (C) 2026    ztlxltl
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -254,7 +255,7 @@ class Tags(DbGUIElement):
         for tag_name, handle in self.__tag_list:
             tag_menu += menuitem % (
                 "TAG-%s" % handle,
-                _("Add tag '%s'") % escape(tag_name),
+                _("Add tag '%s'") % escape(tag_name.replace("_", "__")),
             )
             actions.append(
                 ("TAG-%s" % handle, make_callback(self.tag_selected_rows, handle))
@@ -262,7 +263,7 @@ class Tags(DbGUIElement):
         for tag_name, handle in self.__tag_list:
             tag_menu += menuitem % (
                 "R-TAG-%s" % handle,
-                _("Remove tag '%s'") % escape(tag_name),
+                _("Remove tag '%s'") % escape(tag_name.replace("_", "__")),
             )
             actions.append(
                 (


### PR DESCRIPTION
This PR fixes the display of underscores in the menu, especially for user-defined names, like database or tag names. 

In GTK, an underscore in menu labels is used to mark the following letter as keyboard accelerator called a mnemonic. The letter appears underlined, or becomes underlined when pressing the `Alt` key. In case the user defines a database name or a tag name that includes an underscore, the underscore will not be shown in the menu. By using `.replace("_", "__")`, the underscore is escaped so it will appear in the menu. The same applies for bookmarked people with an underscore in their formatted name (e.g. many names in the [`royal92.ged`](https://github.com/emyoulation/example-Gramps-Trees/blob/main/royal92.ged)).

While checking other custom strings in the menu, I also noticed that plugin names used in the Reports and Tools menus are not escaped using `html.escape()` or `xml.sax.saxutils.escape`. While I don't know a plugin name that requires this, devs of new plugins could have a hard time debugging the resulting error message.

I also saw that less thorough cleaning up of plugin IDs happens when handling "unsupported items" in `ViewManager.build_plugin_menu()`. I'm not sure what those unsupported items can be, but from my limited understanding their IDs have a similar risk of having invalid chars as the IDs of other plugins. I wasn't able to test this, so I would appreciate it if someone who has more knowledge of this part could have a closer look. 

In summary, this PR does the following:
- Recent databases: add `.replace("_", "__")`
- Reports and Tools menus: add `html.escape()` and `.replace("_", "__"))`
  - For "unsupported" items: additionally add `valid_action_name()`
- Bookmarks: add `.replace("_", "__")`
- Tags: add `.replace("_", "__"))`