### PR TITLE
Add regression test for Glade() construction guard

### DIFF
--- a/gramps/gui/test/glade_test.py
+++ b/gramps/gui/test/glade_test.py
@@ -1,0 +1,89 @@
+"""Unittest for glade.py
+
+Regression test for the ``Glade.__setattr__`` guard introduced by
+f8c1fc0f50 ("Don't use slots on GObject-derived classes."), which made every
+``Glade()`` construction abort GUI startup (testbed #1):
+
+  1. The guard whitelisted the *unmangled* names ``__toplevel``/``__filename``/
+     ``__dirname``, but ``__init__`` assigns ``self.__dirname`` etc., which
+     Python name-mangles to ``_Glade__dirname`` -- so the guard rejected the
+     class's own assignments with ``AttributeError`` at the very first
+     ``self.__dirname, self.__filename = os.path.split(path)`` line.
+  2. ``super().__setattr__(self, name, value)`` passed ``self`` twice to an
+     already-bound ``super()`` method, raising ``TypeError`` once the guard was
+     satisfied.
+
+The test drives the *real* ``Glade.__init__`` path end-to-end -- it loads an
+actual ``.glade`` file through ``Gtk.Builder`` -- so the fix is exercised the
+way GUI startup uses it, not via a synthetic ``__setattr__`` bypass. To stay
+runnable under the headless C4 unittest runner (no display / D-Bus / AT-SPI),
+the loaded glade file contains a single *non-widget* toplevel (a
+``GtkListStore``): building it needs the GObject type system but no display.
+"""
+
+import os
+import tempfile
+import unittest
+
+from gramps.gui.glade import Glade
+
+# A minimal, display-free glade file: one non-widget toplevel object so that
+# Gtk.Builder can build it on a headless box (no realised widgets).
+_GLADE_LISTSTORE = """<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <object class="GtkListStore" id="test_store">
+    <columns>
+      <column type="gchararray"/>
+    </columns>
+  </object>
+</interface>
+"""
+
+
+class GladeConstructionTest(unittest.TestCase):
+    """Constructing a Glade must run __init__'s guarded assignments cleanly."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._dirname = self._tmpdir.name
+        self._filename = "regtest.glade"
+        with open(
+            os.path.join(self._dirname, self._filename), "w", encoding="utf-8"
+        ) as handle:
+            handle.write(_GLADE_LISTSTORE)
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def test_real_construction_succeeds(self):
+        # The real __init__ path. Pre-fix this aborts with AttributeError
+        # ("Ad-hoc attribute _Glade__dirname is not permitted.") at the first
+        # `self.__dirname, self.__filename = os.path.split(path)` assignment,
+        # or TypeError from the doubled `self` once the whitelist is corrected.
+        # Post-fix it loads the file and assigns all three mangled privates.
+        glade = Glade(
+            filename=self._filename,
+            dirname=self._dirname,
+            toplevel="test_store",
+        )
+        # The three private attributes __init__ assigns via the guarded
+        # __setattr__, exposed through the public @property getters.
+        self.assertEqual(glade.dirname, self._dirname)
+        self.assertEqual(glade.filename, self._filename)
+        self.assertIsNotNone(glade.toplevel)
+        self.assertIsNotNone(glade.get_object("test_store"))
+
+    def test_adhoc_attr_still_rejected(self):
+        # The guard's purpose -- rejecting genuinely unexpected attributes --
+        # must be preserved by the fix.
+        glade = Glade(
+            filename=self._filename,
+            dirname=self._dirname,
+            toplevel="test_store",
+        )
+        with self.assertRaises(AttributeError):
+            glade.some_unexpected_attr = 1
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -461,6 +461,7 @@ gramps/gui/selectors/selectorfactory.py
 # gui.test package
 #
 gramps/gui/test/display_test.py
+gramps/gui/test/glade_test.py
 gramps/gui/test/user_test.py
 #
 # gui/views - the GUI views package


### PR DESCRIPTION
## Summary
**User impact:** Gramps crashed on startup: opening a family tree, the Database Manager, or any of the standard dialogs failed before a window ever appeared. It was a regression introduced by an earlier change and left the program effectively unusable.

This repairs the broken attribute guard so windows build again, while still blocking the stray attributes the guard was meant to catch.

Reported in Mantis [#14153](https://gramps-project.org/bugs/view.php?id=14153).

## What to look at
A recent change replaced a `__slots__` mechanism with a hand-written attribute guard, but the guard rejected the class's own private attributes — Python renames those internally, and the guard's whitelist held the un-renamed names — so every window failed to build at its first private assignment. The fix whitelists the renamed names and corrects a doubled argument. To confirm: with the fix, opening a tree / the Database Manager / dialogs works; a new headless test builds a real Glade file end-to-end.

## Root cause
`Glade.__setattr__` guards against ad-hoc attributes by comparing the incoming `name` against a whitelist, but the whitelist holds the source-level names `__toplevel`/`__filename`/`__dirname` while `__init__` assigns `self.__dirname` etc., which Python name-mangles inside class `Glade` to `_Glade__dirname` — so the guard rejects the class's own assignments with `AttributeError: Ad-hoc attribute _Glade__dirname is not permitted.` at the first private assignment, and the same method passes `self` twice to the already-bound `super().__setattr__`, which would raise `TypeError` once the guard is satisfied. Both faults were introduced by `f8c1fc0f507b30d2bd4ec949bd8b95de489b7c4d` ("Don't use slots on GObject-derived classes."), which replaced `__slots__` with this `__setattr__` and touched only `gramps/gui/glade.py`; every `Glade()` — opening a tree, the Database Manager, the standard dialogs — aborted before a window appeared.

Removing `__slots__` was itself the correct, upstream-recommended fix: per GNOME/pygobject work item #734, PyGObject wrapper objects do not play well with `__slots__` (slot data lives on the wrapper, not the instance `__dict__`), which crashed Gramps once pygobject 3.55.1 shortened the wrapper lifecycle. pygobject `!508` removed slot support and added the `PyGIWarning: GObject derived class Glade shouldn't use slots` that prompted `f8c1fc0f50`. The problem is only in the hand-written guard that replaced the slots — and it did not survive review: petr-fedorov reported on PR #2313 that the fix "does not work" (naming the name-mangling), and hgohel reproduced the same exception on Windows / Python 3.14.

## Fix
Whitelist the *mangled* names `_Glade__toplevel`/`_Glade__filename`/`_Glade__dirname` so the guard accepts `__init__`'s own private assignments, and drop the duplicate `self` from the `super().__setattr__(name, value)` call. Ad-hoc attributes outside the whitelist are still rejected, so the guard's purpose is preserved. The change is two lines, contained entirely in the method the regression created.

## Verification
- **Claim:** `Glade()` construction completes — the guard accepts `__init__`'s own mangled private assignments and the `super().__setattr__` call is well-formed — while ad-hoc attributes outside the whitelist are still rejected.
- **Checked:** on maintenance/gramps61 — `gramps/gui/glade.py:64-66` (whitelist changed from the unmangled `__toplevel`/`__filename`/`__dirname` to the mangled `_Glade__toplevel`/`_Glade__filename`/`_Glade__dirname`), `gramps/gui/glade.py:69` (`super().__setattr__(self, name, value)` corrected to `super().__setattr__(name, value)`), `gramps/gui/glade.py:146` (`self.__dirname, self.__filename = os.path.split(path)`, the first mangled assignment the broken guard rejected at runtime). `git show --stat f8c1fc0f507b30d2bd4ec949bd8b95de489b7c4d` confirms it touched only `gramps/gui/glade.py`, so this PR reverses the regression in full with no other file to change.
- **Test:** new regression test `gramps/gui/test/glade_test.py` (alongside the existing `display_test.py`/`user_test.py`/`utils_test.py`). It drives the real `Glade.__init__` path end-to-end — loading an actual `.glade` file through `Gtk.Builder`, the same construction shape GUI startup uses, rather than a synthetic `__setattr__` bypass. To run on the headless unittest runner (no display / D-Bus / AT-SPI), the loaded file contains a single non-widget `GtkListStore` toplevel, which `Gtk.Builder` builds via the GObject type system without a display connection. `test_real_construction_succeeds` asserts the construction completes and reads back `dirname`/`filename`/`toplevel` through the public property getters; `test_adhoc_attr_still_rejected` confirms the guard still rejects unexpected attributes. Red pre-fix (the real `__init__` raises `AttributeError: Ad-hoc attribute _Glade__dirname is not permitted.`), green post-fix.

Fixes [#14153](https://gramps-project.org/bugs/view.php?id=14153)
