### PR TITLE
Fix headless crash: don't build a Gtk widget at import in LinkTag

### DIFF
--- a/gramps/gui/test/headless_import_test.py
+++ b/gramps/gui/test/headless_import_test.py
@@ -1,0 +1,118 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  The Gramps project
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Regression test: importing a Gramps GUI widget module must not crash the
+interpreter when there is no display (headless).
+
+Background
+----------
+``gramps/gui/widgets/grampletpane.py`` computed the theme link colour in the
+body of ``class LinkTag`` -- code that runs at *import* time -- by constructing
+a ``Gtk.Label`` and reading its style context::
+
+    linkcolor = Gtk.Label(label="test")
+    linkcolor = get_link_color(linkcolor.get_style_context())
+
+With no display connection Gtk turns "can't create a GtkStyleContext" into a
+fatal ``Gtk-ERROR``, which raises ``SIGTRAP`` and aborts the whole process
+("Trace/breakpoint trap (core dumped)").  Any headless import of this module --
+directly, or transitively via ``gramps.gui.views.listview`` /
+``gramps.plugins.lib.libpersonview`` -- therefore killed the interpreter.  In a
+``python3 -m unittest discover`` run that takes down the entire core unit suite.
+
+A segfault/abort cannot be caught in-process, so this test spawns a child
+``python3 -c "import ..."`` with the display stripped from its environment and
+asserts the child exits cleanly (returncode 0).  Pre-fix the child dies on
+``SIGTRAP`` (returncode -5 / 133); post-fix the colour is computed lazily on
+first use, so nothing display-dependent runs at import and the child exits 0.
+
+This module imports no ``gi``/``gramps.gui`` symbol itself, so it loads and runs
+under a plain headless ``python3 -m unittest`` (the C4 verify / T3-unit env).
+"""
+
+import os
+import subprocess
+import sys
+import unittest
+
+# The module whose class-body widget construction triggered the abort. Importing
+# it is the minimal reproduction of the crashing import chain that the headless
+# core unit run hit (libpersonview -> listview -> pageview -> grampletbar ->
+# grampletpane:LinkTag).
+_TARGET_MODULES = (
+    "gramps.gui.widgets.grampletpane",
+    "gramps.plugins.lib.libpersonview",
+)
+
+
+def _import_headless(module_name):
+    """
+    Import *module_name* in a fresh interpreter with no display connection.
+
+    Returns the completed ``subprocess.run`` result. ``returncode`` is 0 on a
+    clean import, negative (``-signal``) or 128+signal if the child was killed
+    by a signal such as ``SIGTRAP`` from a fatal ``Gtk-ERROR``.
+    """
+    env = dict(os.environ)
+    # Force the headless condition regardless of how the suite is launched.
+    for var in ("DISPLAY", "WAYLAND_DISPLAY"):
+        env.pop(var, None)
+    # gramps.gen imports need the resource root; default to the checkout cwd.
+    env.setdefault("GRAMPS_RESOURCES", ".")
+    return subprocess.run(
+        [sys.executable, "-c", "import %s" % module_name],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=300,
+    )
+
+
+class HeadlessImportTest(unittest.TestCase):
+    """Importing GUI widget modules headless must not abort the interpreter."""
+
+    def test_grampletpane_imports_headless(self):
+        """The faulting module imports cleanly with no display."""
+        result = _import_headless("gramps.gui.widgets.grampletpane")
+        self.assertEqual(
+            result.returncode,
+            0,
+            "Headless `import gramps.gui.widgets.grampletpane` did not exit 0 "
+            "(returncode %r) -- the class-body Gtk widget construction aborts "
+            "without a display.\n--- child output ---\n%s"
+            % (result.returncode, result.stdout.decode("utf-8", "replace")),
+        )
+
+    def test_libpersonview_chain_imports_headless(self):
+        """The transitive chain the unit suite hit imports cleanly headless."""
+        result = _import_headless("gramps.plugins.lib.libpersonview")
+        self.assertEqual(
+            result.returncode,
+            0,
+            "Headless `import gramps.plugins.lib.libpersonview` did not exit 0 "
+            "(returncode %r) -- it pulls in grampletpane, whose class-body "
+            "widget construction aborts without a display.\n"
+            "--- child output ---\n%s"
+            % (result.returncode, result.stdout.decode("utf-8", "replace")),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gui/widgets/grampletpane.py
+++ b/gramps/gui/widgets/grampletpane.py
@@ -217,13 +217,21 @@ class LinkTag(Gtk.TextTag):
     """
 
     lid = 0
-    # obtaining the theme link color once. Restart needed on theme change!
-    linkcolor = Gtk.Label(label="test")  # needed to avoid label destroyed to early
-    linkcolor = get_link_color(linkcolor.get_style_context())
+    # The theme link colour, obtained once and cached. Restart needed on theme
+    # change! Computed lazily on first use rather than in the class body: doing it
+    # at class-body level runs at import time, and constructing a Gtk.Label /
+    # reading its style context with no display aborts the interpreter
+    # ("Gtk-ERROR: Can't create a GtkStyleContext without a display connection",
+    # SIGTRAP). A LinkTag is only ever built while rendering links, i.e. with a
+    # display, so the colour is computed there instead.
+    linkcolor = None
 
     def __init__(self, buffer):
         LinkTag.lid += 1
         Gtk.TextTag.__init__(self, name=str(LinkTag.lid))
+        if LinkTag.linkcolor is None:
+            label = Gtk.Label(label="test")  # kept alive across the style read
+            LinkTag.linkcolor = get_link_color(label.get_style_context())
         tag_table = buffer.get_tag_table()
         self.set_property("foreground", self.linkcolor)
         # self.set_property('underline', Pango.Underline.SINGLE)


### PR DESCRIPTION
## Summary
**User impact:** On a machine with no graphical display — a headless server, or the automated test suite — Gramps aborted the instant one of its modules was loaded, before doing any work. The same fault also took down the entire core unit-test suite while it was still collecting tests.

Deferring one bit of colour setup until a link is actually drawn means merely loading the module no longer needs a display, so headless runs stop crashing.

No Mantis bug is filed for this crash — it was surfaced during headless unit-test discovery, so there is no tracker ticket to reference.

## What to look at
A module built a graphical element (reading a theme colour off a live widget) the instant it was imported, which is fatal when there is no display. Moving that work to the moment a link is actually rendered — where a display always exists — fixes it with no display probe and no behaviour change when a display is present. To confirm: importing the module in a display-less subprocess now exits cleanly (a new test does exactly this, for the module and for the transitive import chain that reaches it).

## Root cause
The body of `class LinkTag(Gtk.TextTag)` in `gramps/gui/widgets/grampletpane.py` computes the theme link colour **at import time**: it constructs a `Gtk.Label` and reads its style context (`grampletpane.py:221-222`). With no display Gtk escalates "Can't create a GtkStyleContext without a display connection" into a fatal `Gtk-ERROR`, which raises `SIGTRAP` and aborts the process. Any headless import of this module — directly, or transitively (`gramps.plugins.lib.libpersonview` → `gramps/gui/views/listview.py` → `pageview.py` → `grampletbar.py` → `grampletpane.py`) — therefore kills the interpreter; under `python3 -m unittest discover` it takes down the whole core unit suite during discovery.

## Fix
A `LinkTag` is only ever constructed while rendering links — i.e. always with a display — so compute the colour **lazily on first construction** (cached on the class) instead of in the class body. Importing the module then builds no widget, so it is safe headless; with a display the behaviour is unchanged (the colour is still computed once and reused). No display probe is introduced — the work that needs a display simply no longer runs at import time.

## Verification
- **Claim:** importing the module (directly or transitively) builds no Gtk widget, so it is safe with no display; with a display the link colour is still computed once and reused, leaving link rendering unchanged.
- **Checked:** on maintenance/gramps61 — `gramps/gui/widgets/grampletpane.py:221-222` (the class-body `Gtk.Label` + `get_link_color(get_style_context())` that aborts on headless import, moved into `__init__` and computed once on first use), `grampletpane.py:555,627` (the only `LinkTag(...)` call sites, both on link-rendering paths that run under a display, so deferring the computation changes nothing user-visible). Headless red→green: with the change reverted, importing the module in a display-less subprocess dies on `SIGTRAP`; with it, the import — and the whole `python3 -m unittest discover` run — completes.
- **Test:** new `gramps/gui/test/headless_import_test.py` spawns a child `python3 -c "import …"` with `DISPLAY`/`WAYLAND_DISPLAY` stripped and asserts the child exits `0`, for both the faulting module (`gramps.gui.widgets.grampletpane`) and the transitive chain the suite hit (`gramps.plugins.lib.libpersonview`). A `SIGTRAP` abort cannot be caught in-process, so the test uses a subprocess; red pre-fix (returncode -5 / 133), green post-fix. The test module imports no `gi`/`gramps.gui` symbol itself, so it runs under a plain headless `python3 -m unittest`.

Unrelated to draft PR #2354, which addresses a different headless-import frame (`PersistentTreeView` subclassing in `widgets/__init__.py`); this change is confined to `LinkTag` and does not touch `widgets/__init__.py`.


