### PR TITLE
Fix CSV import: resolve place IDs in event place columns

### DIFF
--- a/gramps/plugins/importer/importcsv.py
+++ b/gramps/plugins/importer/importcsv.py
@@ -1265,6 +1265,11 @@ class CSVParser:
         if place_name.startswith("[") and place_name.endswith("]"):
             place = self.lookup("place", place_name)
             return (0, place)
+        # Try as a local CSV place ID for consistency with enclosed_by handling
+        # in _parse_place, which also accepts bare numeric IDs via lookup().
+        place = self.lookup("place", place_name)
+        if place is not None:
+            return (0, place)
         LOG.debug("get_or_create_place: looking for: %s", place_name)
         for place_handle in self.db.iter_place_handles():
             place = self.db.get_place_from_handle(place_handle)


### PR DESCRIPTION
## Summary

When a CSV file defines a places section with local numeric IDs, those IDs are stored in an internal `placeref` dict. However, `get_or_create_place()` — called for event place columns like `birthplace`, `deathplace`, and marriage `place` — only searched by title and never checked `placeref`. Bare numeric IDs in those columns were imported as new places named `"4"`, `"6"`, etc., instead of resolving to the already-imported place.

The fix makes `get_or_create_place()` call `lookup()` before falling back to the title search. This is consistent with how `_parse_place()` already handles the `enclosed_by` column, which calls `lookup()` directly and accepts bare numeric IDs without any special syntax.

User report: https://gramps.discourse.group/t/csv-import-error-places-and-persons-events/9593

## Test plan

- [ ] Import a CSV with a places section using numeric IDs, and a persons section referencing those IDs in birthplace/deathplace columns — verify no spurious places are created
- [ ] Import a CSV using place names (not IDs) in event place columns — verify existing behaviour unchanged
- [ ] Import a CSV using `[P0042]` bracket notation in event place columns — verify existing behaviour unchanged