### PR TITLE
Improved Manage Family Trees behavior when deleting trees: preserve sort column and better next item selection

### DIFF
--- a/gramps/gui/dbman.py
+++ b/gramps/gui/dbman.py
@@ -157,9 +157,18 @@ class DbManager(CLIDbManager, ManagedWindow):
         CLIDbManager.ICON_OPEN: "document-open",
     }
 
-    BUSY_CURSOR = Gdk.Cursor.new_for_display(
-        Gdk.Display.get_default(), Gdk.CursorType.WATCH
-    )
+    _busy_cursor: "Gdk.Cursor | None" = None
+
+    @classmethod
+    def _get_busy_cursor(cls) -> "Gdk.Cursor | None":
+        """Return the busy cursor, creating it lazily on first use."""
+        if cls._busy_cursor is None:
+            display = Gdk.Display.get_default()
+            if display is not None:
+                cls._busy_cursor = Gdk.Cursor.new_for_display(
+                    display, Gdk.CursorType.WATCH
+                )
+        return cls._busy_cursor
 
     def __init__(self, uistate, dbstate, viewmanager, parent=None):
         """
@@ -1034,7 +1043,7 @@ class DbManager(CLIDbManager, ManagedWindow):
         message
         """
         self.msg.set_label(msg)
-        self.top.get_window().set_cursor(self.BUSY_CURSOR)
+        self.top.get_window().set_cursor(self._get_busy_cursor())
         while Gtk.events_pending():
             Gtk.main_iteration()
 

--- a/gramps/gui/dbman.py
+++ b/gramps/gui/dbman.py
@@ -243,6 +243,27 @@ class DbManager(CLIDbManager, ManagedWindow):
             self.selection.select_path(tree_path)
             self.dblist.scroll_to_cell(tree_path, None, 1, 0.5, 0)
 
+    def _select_next_after_deletion(self, next_item_name):
+        """
+        Select the item that would have been next after deletion.
+        
+        Args:
+            next_item_name: The name of the item that should be selected
+        """
+        if self.model is None or not next_item_name:
+            return
+            
+        # Find the item with the matching name in the rebuilt model
+        iter = self.model.get_iter_first()
+        while iter:
+            name = self.model.get_value(iter, NAME_COL)
+            if name == next_item_name:
+                path = self.model.get_path(iter)
+                self.selection.select_path(path)
+                self.dblist.scroll_to_cell(path, None, 1, 0.5, 0)
+                break
+            iter = self.model.iter_next(iter)
+
     def __connect_signals(self):
         """
         Connects the signals to the buttons on the interface.
@@ -796,6 +817,18 @@ class DbManager(CLIDbManager, ManagedWindow):
         path = store.get_path(node)
         node = self.model.get_iter(path)
         filename = self.model.get_value(node, FILE_COL)
+        
+        # Remember what should be selected next (the item after the deleted one)
+        next_iter = self.model.iter_next(node)
+        next_item_name = None
+        if next_iter is not None:
+            next_item_name = self.model.get_value(next_iter, NAME_COL)
+        else:
+            # If no next item, try previous item
+            prev_iter = store.iter_previous(node)
+            if prev_iter is not None:
+                next_item_name = self.model.get_value(prev_iter, NAME_COL)
+        
         try:
             with open(filename, "r", encoding="utf-8") as name_file:
                 file_name_to_delete = name_file.read()
@@ -809,7 +842,7 @@ class DbManager(CLIDbManager, ManagedWindow):
             ErrorDialog(_("Could not delete Family Tree"), str(msg), parent=self.top)
         # rebuild the display
         self.__populate()
-        self._select_default()
+        self._select_next_after_deletion(next_item_name)
 
     def __really_delete_version(self):
         """

--- a/gramps/gui/dbman.py
+++ b/gramps/gui/dbman.py
@@ -36,6 +36,7 @@ import subprocess
 from urllib.parse import urlparse
 import logging
 import re
+import threading
 
 # -------------------------------------------------------------------------
 #
@@ -158,16 +159,19 @@ class DbManager(CLIDbManager, ManagedWindow):
     }
 
     _busy_cursor: "Gdk.Cursor | None" = None
+    _busy_cursor_lock: threading.Lock = threading.Lock()
 
     @classmethod
     def _get_busy_cursor(cls) -> "Gdk.Cursor | None":
         """Return the busy cursor, creating it lazily on first use."""
         if cls._busy_cursor is None:
-            display = Gdk.Display.get_default()
-            if display is not None:
-                cls._busy_cursor = Gdk.Cursor.new_for_display(
-                    display, Gdk.CursorType.WATCH
-                )
+            with cls._busy_cursor_lock:
+                if cls._busy_cursor is None:
+                    display = Gdk.Display.get_default()
+                    if display is not None:
+                        cls._busy_cursor = Gdk.Cursor.new_for_display(
+                            display, Gdk.CursorType.WATCH
+                        )
         return cls._busy_cursor
 
     def __init__(self, uistate, dbstate, viewmanager, parent=None):

--- a/gramps/gui/dbman.py
+++ b/gramps/gui/dbman.py
@@ -246,13 +246,13 @@ class DbManager(CLIDbManager, ManagedWindow):
     def _select_next_after_deletion(self, next_item_name):
         """
         Select the item that would have been next after deletion.
-        
+
         Args:
             next_item_name: The name of the item that should be selected
         """
         if self.model is None or not next_item_name:
             return
-            
+
         # Find the item with the matching name in the rebuilt model
         iter = self.model.get_iter_first()
         while iter:
@@ -480,7 +480,7 @@ class DbManager(CLIDbManager, ManagedWindow):
         current_sort_column, current_sort_order = None, None
         if self.model is not None:
             current_sort_column, current_sort_order = self.model.get_sort_column_id()
-        
+
         self.model = Gtk.TreeStore(str, str, str, str, int, bool, str, str)
 
         # use current names to set up the model
@@ -511,7 +511,7 @@ class DbManager(CLIDbManager, ManagedWindow):
                 self.model.append(node, data)
         if self._current_node is None:
             self._current_node = last_accessed_node
-        
+
         # Restore the previous sort order, or default to NAME_COL ascending if no previous sort
         if current_sort_column is not None and current_sort_order is not None:
             self.model.set_sort_column_id(current_sort_column, current_sort_order)
@@ -817,7 +817,7 @@ class DbManager(CLIDbManager, ManagedWindow):
         path = store.get_path(node)
         node = self.model.get_iter(path)
         filename = self.model.get_value(node, FILE_COL)
-        
+
         # Remember what should be selected next (the item after the deleted one)
         next_iter = self.model.iter_next(node)
         next_item_name = None
@@ -828,7 +828,7 @@ class DbManager(CLIDbManager, ManagedWindow):
             prev_iter = store.iter_previous(node)
             if prev_iter is not None:
                 next_item_name = self.model.get_value(prev_iter, NAME_COL)
-        
+
         try:
             with open(filename, "r", encoding="utf-8") as name_file:
                 file_name_to_delete = name_file.read()

--- a/gramps/gui/dbman.py
+++ b/gramps/gui/dbman.py
@@ -243,26 +243,26 @@ class DbManager(CLIDbManager, ManagedWindow):
             self.selection.select_path(tree_path)
             self.dblist.scroll_to_cell(tree_path, None, 1, 0.5, 0)
 
-    def _select_next_after_deletion(self, next_item_name):
+    def _select_next_after_deletion(self, next_item_name: str | None) -> None:
         """
         Select the item that would have been next after deletion.
 
-        Args:
-            next_item_name: The name of the item that should be selected
+        :param next_item_name: The name of the item that should be selected.
+        :type next_item_name: str | None
         """
         if self.model is None or not next_item_name:
             return
 
         # Find the item with the matching name in the rebuilt model
-        iter = self.model.get_iter_first()
-        while iter:
-            name = self.model.get_value(iter, NAME_COL)
+        tree_iter = self.model.get_iter_first()
+        while tree_iter:
+            name = self.model.get_value(tree_iter, NAME_COL)
             if name == next_item_name:
-                path = self.model.get_path(iter)
+                path = self.model.get_path(tree_iter)
                 self.selection.select_path(path)
                 self.dblist.scroll_to_cell(path, None, 1, 0.5, 0)
                 break
-            iter = self.model.iter_next(iter)
+            tree_iter = self.model.iter_next(tree_iter)
 
     def __connect_signals(self):
         """

--- a/gramps/gui/dbman.py
+++ b/gramps/gui/dbman.py
@@ -455,6 +455,11 @@ class DbManager(CLIDbManager, ManagedWindow):
         """
         Builds the display model.
         """
+        # Store current sort order before rebuilding model
+        current_sort_column, current_sort_order = None, None
+        if self.model is not None:
+            current_sort_column, current_sort_order = self.model.get_sort_column_id()
+        
         self.model = Gtk.TreeStore(str, str, str, str, int, bool, str, str)
 
         # use current names to set up the model
@@ -485,7 +490,12 @@ class DbManager(CLIDbManager, ManagedWindow):
                 self.model.append(node, data)
         if self._current_node is None:
             self._current_node = last_accessed_node
-        self.model.set_sort_column_id(NAME_COL, Gtk.SortType.ASCENDING)
+        
+        # Restore the previous sort order, or default to NAME_COL ascending if no previous sort
+        if current_sort_column is not None and current_sort_order is not None:
+            self.model.set_sort_column_id(current_sort_column, current_sort_order)
+        else:
+            self.model.set_sort_column_id(NAME_COL, Gtk.SortType.ASCENDING)
         self.dblist.set_model(self.model)
 
     def existing_name(self, name, skippath=None):

--- a/gramps/gui/dbman.py
+++ b/gramps/gui/dbman.py
@@ -825,7 +825,7 @@ class DbManager(CLIDbManager, ManagedWindow):
             next_item_name = self.model.get_value(next_iter, NAME_COL)
         else:
             # If no next item, try previous item
-            prev_iter = store.iter_previous(node)
+            prev_iter = self.model.iter_previous(node)
             if prev_iter is not None:
                 next_item_name = self.model.get_value(prev_iter, NAME_COL)
 

--- a/gramps/gui/ddtargets.py
+++ b/gramps/gui/ddtargets.py
@@ -50,6 +50,7 @@ drag_dest_set(Gtk.DestDefaults.ALL,
 #
 # -------------------------------------------------------------------------
 import logging
+import threading
 
 log = logging.getLogger(".DdTargets")
 
@@ -72,6 +73,7 @@ class _DdType:
 
         self.drag_type = drag_type
         self._atom_drag_type = None
+        self._atom_drag_type_lock = threading.Lock()
         self.target_flags = target_flags
         self.app_id = app_id or self._calculate_id()
         container.insert(self)
@@ -80,7 +82,9 @@ class _DdType:
     def atom_drag_type(self):
         """Return the Gdk atom for this drag type, creating it lazily on first use."""
         if self._atom_drag_type is None:
-            self._atom_drag_type = Gdk.atom_intern(self.drag_type, False)
+            with self._atom_drag_type_lock:
+                if self._atom_drag_type is None:
+                    self._atom_drag_type = Gdk.atom_intern(self.drag_type, False)
         return self._atom_drag_type
 
     def _calculate_id(self):

--- a/gramps/gui/ddtargets.py
+++ b/gramps/gui/ddtargets.py
@@ -71,10 +71,17 @@ class _DdType:
         """
 
         self.drag_type = drag_type
-        self.atom_drag_type = Gdk.atom_intern(drag_type, False)
+        self._atom_drag_type = None
         self.target_flags = target_flags
         self.app_id = app_id or self._calculate_id()
         container.insert(self)
+
+    @property
+    def atom_drag_type(self):
+        """Return the Gdk atom for this drag type, creating it lazily on first use."""
+        if self._atom_drag_type is None:
+            self._atom_drag_type = Gdk.atom_intern(self.drag_type, False)
+        return self._atom_drag_type
 
     def _calculate_id(self):
         """Return the next available app_id."""

--- a/gramps/gui/displaystate.py
+++ b/gramps/gui/displaystate.py
@@ -457,9 +457,18 @@ class DisplayState(Callback):
         "Note": _("No active note"),
     }
 
-    BUSY_CURSOR = Gdk.Cursor.new_for_display(
-        Gdk.Display.get_default(), Gdk.CursorType.WATCH
-    )
+    _busy_cursor: "Gdk.Cursor | None" = None
+
+    @classmethod
+    def _get_busy_cursor(cls) -> "Gdk.Cursor | None":
+        """Return the busy cursor, creating it lazily on first use."""
+        if cls._busy_cursor is None:
+            display = Gdk.Display.get_default()
+            if display is not None:
+                cls._busy_cursor = Gdk.Cursor.new_for_display(
+                    display, Gdk.CursorType.WATCH
+                )
+        return cls._busy_cursor
 
     def __init__(self, window, status, uimanager, viewmanager=None):
         self.busy = False
@@ -679,7 +688,7 @@ class DisplayState(Callback):
         if self.window.get_window():
             if value:
                 self.cursor = self.window.get_window().get_cursor()
-                self.window.get_window().set_cursor(self.BUSY_CURSOR)
+                self.window.get_window().set_cursor(self._get_busy_cursor())
             else:
                 self.window.get_window().set_cursor(self.cursor)
                 if self.window.get_window().is_visible():

--- a/gramps/gui/displaystate.py
+++ b/gramps/gui/displaystate.py
@@ -28,6 +28,7 @@
 import os
 from io import StringIO
 import html
+import threading
 
 # -------------------------------------------------------------------------
 #
@@ -458,16 +459,19 @@ class DisplayState(Callback):
     }
 
     _busy_cursor: "Gdk.Cursor | None" = None
+    _busy_cursor_lock: threading.Lock = threading.Lock()
 
     @classmethod
     def _get_busy_cursor(cls) -> "Gdk.Cursor | None":
         """Return the busy cursor, creating it lazily on first use."""
         if cls._busy_cursor is None:
-            display = Gdk.Display.get_default()
-            if display is not None:
-                cls._busy_cursor = Gdk.Cursor.new_for_display(
-                    display, Gdk.CursorType.WATCH
-                )
+            with cls._busy_cursor_lock:
+                if cls._busy_cursor is None:
+                    display = Gdk.Display.get_default()
+                    if display is not None:
+                        cls._busy_cursor = Gdk.Cursor.new_for_display(
+                            display, Gdk.CursorType.WATCH
+                        )
         return cls._busy_cursor
 
     def __init__(self, window, status, uimanager, viewmanager=None):

--- a/gramps/gui/test/dbman_selection_test.py
+++ b/gramps/gui/test/dbman_selection_test.py
@@ -1,7 +1,6 @@
 #
 # Gramps - a GTK+/GNOME based genealogy program
 #
-# Copyright (C) 2026  GitHub Copilot
 # Copyright (C) 2026  Himanshu Gohel
 #
 # This program is free software; you can redistribute it and/or modify

--- a/gramps/gui/test/dbman_selection_test.py
+++ b/gramps/gui/test/dbman_selection_test.py
@@ -21,7 +21,6 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-
 # Patch Gdk.Cursor.new_for_display before importing DbManager, because
 # DbManager defines BUSY_CURSOR as a class attribute using
 # Gdk.Cursor.new_for_display(Gdk.Display.get_default(), ...). When no

--- a/gramps/gui/test/dbman_selection_test.py
+++ b/gramps/gui/test/dbman_selection_test.py
@@ -20,8 +20,17 @@
 
 import unittest
 from unittest.mock import MagicMock, patch
-from gi.repository import Gtk
-from gramps.gui.dbman import DbManager, NAME_COL
+
+
+# Patch Gdk.Cursor.new_for_display before importing DbManager, because
+# DbManager defines BUSY_CURSOR as a class attribute using
+# Gdk.Cursor.new_for_display(Gdk.Display.get_default(), ...). When no
+# display is available (e.g. headless/CI), get_default() returns None and
+# new_for_display raises TypeError. This patch prevents the crash at import
+# time.
+with patch("gi.repository.Gdk.Cursor.new_for_display", return_value=MagicMock()):
+    from gi.repository import Gtk
+    from gramps.gui.dbman import DbManager, NAME_COL
 
 
 class TestDbManSelection(unittest.TestCase):

--- a/gramps/gui/test/dbman_selection_test.py
+++ b/gramps/gui/test/dbman_selection_test.py
@@ -18,23 +18,18 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+import gi
 import unittest
 from unittest.mock import MagicMock, patch
 
-# Patch Gdk.Cursor.new_for_display before importing DbManager, because
-# DbManager defines BUSY_CURSOR as a class attribute using
-# Gdk.Cursor.new_for_display(Gdk.Display.get_default(), ...). When no
-# display is available (e.g. headless/CI), get_default() returns None and
-# new_for_display raises TypeError. This patch prevents the crash at import
-# time.
-with patch("gi.repository.Gdk.Cursor.new_for_display", return_value=MagicMock()):
-    from gi.repository import Gtk
-    from gramps.gui.dbman import DbManager, NAME_COL
+gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")
+from gi.repository import Gtk
+from gramps.gui.dbman import DbManager, NAME_COL
 
 
 class TestDbManSelection(unittest.TestCase):
     def setUp(self):
-        # Mocking the dependencies of DbManager to avoid initializing the full GUI
         self.uistate = MagicMock()
         self.uistate.gwm = MagicMock()
         self.uistate.gwm.get_item_from_id.return_value = None
@@ -43,13 +38,15 @@ class TestDbManSelection(unittest.TestCase):
         self.dbstate = MagicMock()
         self.viewmanager = MagicMock()
 
-        # Patch Glade and PersistentTreeView to avoid GTK errors during init
         with (
             patch("gramps.gui.dbman.Glade"),
             patch("gramps.gui.dbman.PersistentTreeView"),
             patch("gramps.gui.dbman.User"),
             patch("gramps.gui.dbman.ManagedWindow.setup_configs"),
             patch("gramps.gui.dbman.DbManager._select_default"),
+            patch.object(DbManager, "_DbManager__connect_signals"),
+            patch.object(DbManager, "_DbManager__build_interface"),
+            patch("gramps.gui.dbman.DbManager._populate_model"),
         ):
             self.dbman = DbManager(self.uistate, self.dbstate, self.viewmanager)
 

--- a/gramps/gui/test/test_dbman_selection.py
+++ b/gramps/gui/test/test_dbman_selection.py
@@ -1,0 +1,99 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  GitHub Copilot
+# Copyright (C) 2026  Himanshu Gohel
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+import unittest
+from unittest.mock import MagicMock, patch
+from gi.repository import Gtk
+from gramps.gui.dbman import DbManager, NAME_COL
+
+class TestDbManSelection(unittest.TestCase):
+    def setUp(self):
+        # Mocking the dependencies of DbManager to avoid initializing the full GUI
+        self.uistate = MagicMock()
+        self.uistate.gwm = MagicMock()
+        self.uistate.gwm.get_item_from_id.return_value = None
+        self.uistate.gwm.add_item.return_value = []
+        self.uistate.pulse_progressbar = MagicMock()
+        self.dbstate = MagicMock()
+        self.viewmanager = MagicMock()
+        
+        # Patch Glade and PersistentTreeView to avoid GTK errors during init
+        with patch('gramps.gui.dbman.Glade'), \
+             patch('gramps.gui.dbman.PersistentTreeView'), \
+             patch('gramps.gui.dbman.User'), \
+             patch('gramps.gui.dbman.ManagedWindow.setup_configs'), \
+             patch('gramps.gui.dbman.DbManager._select_default'):
+            self.dbman = DbManager(self.uistate, self.dbstate, self.viewmanager)
+            
+        # Mock the model and selection
+        self.dbman.model = MagicMock(spec=Gtk.TreeStore)
+        self.dbman.selection = MagicMock()
+        self.dbman.selection.get_selected.return_value = (None, None)
+        self.dbman.dblist = MagicMock()
+
+    def test_select_next_after_deletion_happy_path(self):
+        """
+        Test that the correct item is selected when a successor exists.
+        """
+        # Setup model: Item A, Item B, Item C
+        # We simulate the model's behavior with a list of values
+        mock_iters = [MagicMock(), MagicMock(), MagicMock()]
+        self.dbman.model.get_iter_first.return_value = mock_iters[0]
+        self.dbman.model.iter_next.side_effect = [mock_iters[1], mock_iters[2], None]
+        
+        # Mock get_value for NAME_COL
+        self.dbman.model.get_value.side_effect = lambda it, col: {
+            mock_iters[0]: "Tree A",
+            mock_iters[1]: "Tree B",
+            mock_iters[2]: "Tree C"
+        }[it] if col == NAME_COL else None
+        
+        # Mock get_path with deterministic strings
+        path_map = {
+            mock_iters[0]: "path_a",
+            mock_iters[1]: "path_b",
+            mock_iters[2]: "path_c",
+        }
+        self.dbman.model.get_path.side_effect = lambda it: path_map[it]
+
+        # Act: Select "Tree B"
+        self.dbman._select_next_after_deletion("Tree B")
+
+        # Assert
+        self.dbman.selection.select_path.assert_called_with("path_b")
+
+    def test_select_next_after_deletion_only_item(self):
+        """
+        Test that nothing is selected when next_item_name is None.
+        """
+        self.dbman._select_next_after_deletion(None)
+        self.dbman.selection.select_path.assert_not_called()
+
+    def test_select_next_after_deletion_model_none(self):
+        """
+        Test that the method returns gracefully when self.model is None.
+        """
+        self.dbman.model = None
+        self.dbman._select_next_after_deletion("Some Tree")
+        self.dbman.selection.select_path.assert_not_called()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gui/test/test_dbman_selection.py
+++ b/gramps/gui/test/test_dbman_selection.py
@@ -24,6 +24,7 @@ from unittest.mock import MagicMock, patch
 from gi.repository import Gtk
 from gramps.gui.dbman import DbManager, NAME_COL
 
+
 class TestDbManSelection(unittest.TestCase):
     def setUp(self):
         # Mocking the dependencies of DbManager to avoid initializing the full GUI
@@ -34,15 +35,17 @@ class TestDbManSelection(unittest.TestCase):
         self.uistate.pulse_progressbar = MagicMock()
         self.dbstate = MagicMock()
         self.viewmanager = MagicMock()
-        
+
         # Patch Glade and PersistentTreeView to avoid GTK errors during init
-        with patch('gramps.gui.dbman.Glade'), \
-             patch('gramps.gui.dbman.PersistentTreeView'), \
-             patch('gramps.gui.dbman.User'), \
-             patch('gramps.gui.dbman.ManagedWindow.setup_configs'), \
-             patch('gramps.gui.dbman.DbManager._select_default'):
+        with (
+            patch("gramps.gui.dbman.Glade"),
+            patch("gramps.gui.dbman.PersistentTreeView"),
+            patch("gramps.gui.dbman.User"),
+            patch("gramps.gui.dbman.ManagedWindow.setup_configs"),
+            patch("gramps.gui.dbman.DbManager._select_default"),
+        ):
             self.dbman = DbManager(self.uistate, self.dbstate, self.viewmanager)
-            
+
         # Mock the model and selection
         self.dbman.model = MagicMock(spec=Gtk.TreeStore)
         self.dbman.selection = MagicMock()
@@ -58,14 +61,16 @@ class TestDbManSelection(unittest.TestCase):
         mock_iters = [MagicMock(), MagicMock(), MagicMock()]
         self.dbman.model.get_iter_first.return_value = mock_iters[0]
         self.dbman.model.iter_next.side_effect = [mock_iters[1], mock_iters[2], None]
-        
+
         # Mock get_value for NAME_COL
-        self.dbman.model.get_value.side_effect = lambda it, col: {
-            mock_iters[0]: "Tree A",
-            mock_iters[1]: "Tree B",
-            mock_iters[2]: "Tree C"
-        }[it] if col == NAME_COL else None
-        
+        self.dbman.model.get_value.side_effect = lambda it, col: (
+            {mock_iters[0]: "Tree A", mock_iters[1]: "Tree B", mock_iters[2]: "Tree C"}[
+                it
+            ]
+            if col == NAME_COL
+            else None
+        )
+
         # Mock get_path with deterministic strings
         path_map = {
             mock_iters[0]: "path_a",
@@ -94,6 +99,7 @@ class TestDbManSelection(unittest.TestCase):
         self.dbman.model = None
         self.dbman._select_next_after_deletion("Some Tree")
         self.dbman.selection.select_path.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/gramps/plugins/tool/removeunused.py
+++ b/gramps/plugins/tool/removeunused.py
@@ -63,9 +63,18 @@ class RemoveUnused(tool.Tool, ManagedWindow, UpdateCallback):
     OBJ_TYPE_COL = 3
     OBJ_HANDLE_COL = 4
 
-    BUSY_CURSOR = Gdk.Cursor.new_for_display(
-        Gdk.Display.get_default(), Gdk.CursorType.WATCH
-    )
+    _busy_cursor: "Gdk.Cursor | None" = None
+
+    @classmethod
+    def _get_busy_cursor(cls) -> "Gdk.Cursor | None":
+        """Return the busy cursor, creating it lazily on first use."""
+        if cls._busy_cursor is None:
+            display = Gdk.Display.get_default()
+            if display is not None:
+                cls._busy_cursor = Gdk.Cursor.new_for_display(
+                    display, Gdk.CursorType.WATCH
+                )
+        return cls._busy_cursor
 
     def __init__(self, dbstate, user, options_class, name, callback=None):
         uistate = user.uistate
@@ -270,7 +279,7 @@ class RemoveUnused(tool.Tool, ManagedWindow, UpdateCallback):
 
         self.uistate.set_busy_cursor(True)
         self.uistate.progress.show()
-        self.window.get_window().set_cursor(self.BUSY_CURSOR)
+        self.window.get_window().set_cursor(self._get_busy_cursor())
 
         self.real_model.clear()
         self.collect_unused()

--- a/gramps/plugins/view/pedigreeview.py
+++ b/gramps/plugins/view/pedigreeview.py
@@ -555,9 +555,18 @@ class PedigreeView(NavigationView):
         ("interface.pedview-show-unknown-people", True),
     )
 
-    FLEUR_CURSOR = Gdk.Cursor.new_for_display(
-        Gdk.Display.get_default(), Gdk.CursorType.FLEUR
-    )
+    _fleur_cursor: "Gdk.Cursor | None" = None
+
+    @classmethod
+    def _get_fleur_cursor(cls) -> "Gdk.Cursor | None":
+        """Return the fleur (drag) cursor, creating it lazily on first use."""
+        if cls._fleur_cursor is None:
+            display = Gdk.Display.get_default()
+            if display is not None:
+                cls._fleur_cursor = Gdk.Cursor.new_for_display(
+                    display, Gdk.CursorType.FLEUR
+                )
+        return cls._fleur_cursor
 
     def __init__(self, pdata, dbstate, uistate, nav_group=0):
         NavigationView.__init__(
@@ -1556,7 +1565,7 @@ class PedigreeView(NavigationView):
         or call option menu.
         """
         if event.button == 1 and event.type == Gdk.EventType.BUTTON_PRESS:
-            widget.get_window().set_cursor(self.FLEUR_CURSOR)
+            widget.get_window().set_cursor(self._get_fleur_cursor())
             self._last_x = event.x
             self._last_y = event.y
             self._in_move = True


### PR DESCRIPTION
This is a rebase of #2154 by @hgohel, with the test updated to run under `GDK_BACKEND=-` (headless CI). All credit for the feature goes to @hgohel.

---

Manage Family Trees list unexpectedly (1) reverts the sort column selection to Name when a tree is deleted from the list and (2) always selects the most recently accessed tree as the current selection after a tree is deleted, rather than the next/previous item.

There are two commits in this PR for easy review:
1. Preserve sort order when the list is rebuilt after a tree is deleted.
2. Remember the item that was next after a deleted item (or previous if there's no next), and select that after the list is rebuilt.

## Testing

With sort order set to name, last accessed etc., repeat each step below and verify that the selection after delete is reasonable (next item, previous item, or none if there are no more items):

- delete item at top of list
- delete item at bottom of list
- delete item in middle of list

To run the three new unit tests:

```
env GDK_BACKEND=- python3 -m unittest gramps.gui.test.dbman_selection_test.TestDbManSelection
```

**Note:** this branch is rebased on top of #2363, which fixes GTK cursor and drag-target atoms being initialized at import time (required for headless test execution). Once #2363 merges, the diff here will reduce to just the sort/selection changes.

Fixes #12187.

AI Usage: KwaiKAT's KAT-Coder-Pro V1 used within Cline host to fix the bugs, with manual tweaking before commit. Further changes and unit tests by GitHub Copilot. Rebase and headless test fix by Claude Code.