### PR TITLE
Skip DISPLAY check test locally if GDK_BACKEND=-

### DIFF
--- a/gramps/gen/test/constfunc_test.py
+++ b/gramps/gen/test/constfunc_test.py
@@ -20,6 +20,7 @@
 
 """Unittest for constfunc.py"""
 
+import os
 import unittest
 from .. import constfunc
 
@@ -32,6 +33,10 @@ class Test_has_display(unittest.TestCase):
         self.display_nonempty = ("DISPLAY" in env) and bool(env["DISPLAY"])
 
     @unittest.skipUnless(constfunc.lin(), "Written for Linux only...")
+    @unittest.skipIf(
+        os.environ.get("GDK_BACKEND") == "-",
+        "GDK_BACKEND=- overrides normal display detection",
+    )
     def test_consistent_with_DISPLAY_env(self):
         self.assertEqual(
             self.has,


### PR DESCRIPTION
Unit test `test_consistent_with_DISPLAY_env` fails on Ubuntu 24.04 when `GDK_BACKEND=-` is set, and passes when it isn't.

This doesn't happen on GitHub in Gramps CI environment and the difference is that locally DISPLAY is set causing the test to fail, whereas on GitHub Gramps CI, DISPLAY is not set, allowing the test to pass.

To work around this, this test is skipped when GDK_BACKEND=- because that deliberately overrides display detection.