### PR TITLE
Enhance Ancestor and Descend Trees to use color based on gender, life status and marriage type

### DIFF
--- a/gramps/gen/plug/report/utils.py
+++ b/gramps/gen/plug/report/utils.py
@@ -6,7 +6,7 @@
 # Copyright (C) 2008       James Friedmann <jfriedmannj@gmail.com>
 # Copyright (C) 2010       Jakim Friant
 # Copyright (C) 2015-2016  Paul Franklin
-# Copyright (C) 2025       Dave Khuon
+# Copyright (C) 2025-2026  Dave Khuon
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -47,10 +47,73 @@ from ...utils.file import media_path_full
 from ...utils.symbols import Symbols
 from ..docgen import IndexMark, INDEX_TYPE_ALP
 
+# just to borrow these constants from Person, Family, and for marriage_type
+from ...config import config
+from ...lib import Person, Family, FamilyRelType
+from ...utils.alive import probably_alive
+
+_G_FEMALE, _G_MALE, _G_UNKNOWN, _G_OTHER = (
+    Person.FEMALE,
+    Person.MALE,
+    Person.UNKNOWN,
+    Person.OTHER,
+)
+
+_G_ALIVE = True
+_G_DEAD = False
+
+_F_MARRIED, _F_UNMARRIED, _F_CIVIL_UNION, _F_UNKNOWN = (
+    FamilyRelType.MARRIED,
+    FamilyRelType.UNMARRIED,
+    FamilyRelType.CIVIL_UNION,
+    FamilyRelType.UNKNOWN,
+)
+
 
 # _T_ is a gramps-defined keyword -- see po/update_po.py and po/genpot.sh
 def _T_(value, context=""):  # enable deferred translations
     return "%s\x04%s" % (context, value) if context else value
+
+
+def get_rgb_color(color_name):
+    # Converts a hex string (e.g., "#FFFFFF" or "FFFFFF") to an RGB tuple.
+    hex_color = config.get(color_name)[0].lstrip("#")
+    try:
+        # convert each hex to integer
+        return tuple(int(hex_color[i : i + 2], 16) for i in (0, 2, 4))
+    except (ValueError, IndexError):
+        return (0, 0, 0)  # use default if error occurs
+
+
+# -------------------------------------------------------------------------
+#  Fetch current color preferences from configuration at runtime of report
+# -------------------------------------------------------------------------
+def get_report_gender_colors():
+    return {
+        (_G_FEMALE, _G_ALIVE): [get_rgb_color("colors.female-alive"), "_FEMALE_ALIVE"],
+        (_G_MALE, _G_ALIVE): [get_rgb_color("colors.male-alive"), "_MALE_ALIVE"],
+        (_G_UNKNOWN, _G_ALIVE): [
+            get_rgb_color("colors.unknown-alive"),
+            "_UNKNOWN_ALIVE",
+        ],
+        (_G_OTHER, _G_ALIVE): [get_rgb_color("colors.other-alive"), "_OTHER_ALIVE"],
+        (_G_FEMALE, _G_DEAD): [get_rgb_color("colors.female-dead"), "_FEMALE_DEAD"],
+        (_G_MALE, _G_DEAD): [get_rgb_color("colors.male-dead"), "_MALE_DEAD"],
+        (_G_UNKNOWN, _G_DEAD): [get_rgb_color("colors.unknown-dead"), "_UNKNOWN_DEAD"],
+        (_G_OTHER, _G_DEAD): [get_rgb_color("colors.other-dead"), "_OTHER_DEAD"],
+    }
+
+
+def get_report_family_colors():
+    return {
+        _F_MARRIED: [get_rgb_color("colors.family-married"), "_MARRIED"],
+        _F_UNMARRIED: [get_rgb_color("colors.family-unmarried"), "_UNMARRIED"],
+        _F_CIVIL_UNION: [
+            get_rgb_color("colors.family-civil-union"),
+            "_CIVIL_UNION",
+        ],
+        _F_UNKNOWN: [get_rgb_color("colors.family-unknown"), "_UNKNOWN"],
+    }
 
 
 SYMBOLS = Symbols()
@@ -437,3 +500,98 @@ def get_family_filters(database, family, include_single=True, name_format=None):
 def get_gender_symbol(person):
     """generate gender symbol"""
     return SYMBOLS.get_symbol_for_string(person.gender)
+
+
+# -------------------------------------------------------------------------
+#
+# Generate all possible genders for the given style
+# and its graph and return their name set
+#
+# -------------------------------------------------------------------------
+def generate_gender_color_styles(
+    style, base_draw_name, graph_style, report_gender_colors
+):
+    for (gender, life_status), (gen_color, gen_suffix) in report_gender_colors.items():
+        graph_style.set_fill_color(gen_color)
+        graph_style.set_description(
+            _("The style for the person box for %s.") % gen_suffix
+        )
+        box_name = base_draw_name + gen_suffix
+        style.add_draw_style(box_name, graph_style)
+
+
+# -------------------------------------------------------------------------
+#
+# Get color box name based on the person's gender
+#
+# -------------------------------------------------------------------------
+
+
+def get_gender_color_box_name(person, db, base_draw_name, report_gender_colors):
+    """select gender box name"""
+    try:
+        gender = person.gender
+    except AttributeError:
+        gender = _G_UNKNOWN
+
+    try:
+        is_alive = get_life_status(person, db)
+        gen_color, gen_suffix = report_gender_colors[(gender, is_alive)]
+    except KeyError:
+        gen_color, gen_suffix = report_gender_colors[
+            (gender, _G_DEAD)
+        ]  # default values
+    return base_draw_name + gen_suffix
+
+
+def get_life_status(person, db):
+    is_alive = bool(probably_alive(person, db))
+    return is_alive
+
+
+# -------------------------------------------------------------------------
+#
+# Generate the color family for the given style
+# and its graph and return its name
+#
+# -------------------------------------------------------------------------
+def generate_family_color_style(
+    style, base_draw_name, graph_style, report_family_colors
+):
+    for marr_status, (marr_color, marr_suffix) in report_family_colors.items():
+        graph_style.set_fill_color(marr_color)
+        graph_style.set_description(
+            _("The style for the family box for %s.") % marr_suffix
+        )
+        box_name = base_draw_name + marr_suffix
+        style.add_draw_style(box_name, graph_style)
+
+
+# -------------------------------------------------------------------------
+#
+# Get color box name based on the person's gender
+#
+# -------------------------------------------------------------------------
+
+
+def get_family_color_box_name(family_handle, db, base_draw_name, report_family_colors):
+    """select family box name"""
+    try:
+        marr_type = get_marriage_type(family_handle, db)
+        marr_color, marr_suffix = report_family_colors[marr_type]
+    except KeyError:
+        marr_color, marr_suffix = report_family_colors[_F_UNKNOWN]  # default values
+    return base_draw_name + marr_suffix
+
+
+def get_marriage_type(family_handle, db):
+    # get family from handle
+    family = db.get_family_from_handle(family_handle)
+    if not family:
+        # I guess _F_UNKNOWN is the most appropriate, among all others
+        return _F_UNKNOWN
+    try:
+        # Return marriage type: _F_MARRIED, _F_UNMARRIED, _F_CIVIL_UNION
+        return int(family.type)
+    except Exception:
+        return _F_UNKNOWN

--- a/gramps/plugins/drawreport/ancestortree.py
+++ b/gramps/plugins/drawreport/ancestortree.py
@@ -5,6 +5,7 @@
 # Copyright (C) 2010       Jakim Friant
 # Copyright (C) 2014       Paul Franklin
 # Copyright (C) 2010-2015  Craig J. Anderson
+# Copyright (C) 2025-2026  Dave Khuon
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -87,15 +88,23 @@ class PersonBox(BoxBase):
     Calculates information about the box that will print on a page
     """
 
-    def __init__(self, level):
+    def __init__(self, level, database):
         BoxBase.__init__(self)
         self.boxstr = "AC2-box"
         # self.level = (level[0]-1, level[1])
         self.level = level
+        self.database = database
         self.idx = 0
+        self.report_gender_colors = GUIConnect().get_gender_colors()
 
     def __lt__(self, other):
         return self.level[LVL_Y] < other.level[LVL_Y]
+
+    def set_person_color(self, person):
+        """Set box color based on person's gender and alive status."""
+        self.boxstr = utils.get_gender_color_box_name(
+            person, self.database, "AC2-box", self.report_gender_colors
+        )
 
     def display(self):
         BoxBase.display(self)
@@ -115,14 +124,21 @@ class FamilyBox(BoxBase):
     Calculates information about the box that will print on a page
     """
 
-    def __init__(self, level):
+    def __init__(self, level, database):
         BoxBase.__init__(self)
         self.boxstr = "AC2-fam-box"
         # self.level = (level[0]-1, level[1])
         self.level = level
+        self.database = database
+        self.report_family_colors = GUIConnect().get_family_colors()
 
     def __lt__(self, other):
         return self.level[LVL_Y] < other.level[LVL_Y]
+
+    def set_family_color(self, family_handle):
+        self.boxstr = utils.get_family_color_box_name(
+            family_handle, self.database, "AC2-fam-box", self.report_family_colors
+        )
 
 
 # ------------------------------------------------------------------------
@@ -247,6 +263,9 @@ class MakeAncestorTree(AscendPerson):
         self.inlc_marr = _gui.inc_marr()
         self.inc_sib = _gui.inc_sib()
         self.compress_tree = _gui.compress_tree()
+
+        self.fill_box_color = _gui.get_val("fill_box_color")
+
         self.center_family = None
         self.lines = [None] * (_gui.maxgen() + 1)
         if _gui.get_val("show_idx"):
@@ -262,7 +281,7 @@ class MakeAncestorTree(AscendPerson):
         """Makes a person box and add that person into the Canvas."""
 
         # print str(index) + " add_person " + str(indi_handle)
-        myself = PersonBox((index[0] - 1,) + index[1:])
+        myself = PersonBox((index[0] - 1,) + index[1:], self.database)
 
         if index[LVL_GEN] == 1:  # Center Person
             self.center_family = fams_handle
@@ -277,10 +296,11 @@ class MakeAncestorTree(AscendPerson):
             genIdx = self.start_idx * (2 ** (index[LVL_GEN] - 1))
             genOff = index[LVL_INDX] - (2 ** (index[LVL_GEN] - 1))
             myself.idx = genIdx + genOff
+
+        person = None
         if indi_handle is not None:  # None is legal for an empty box
-            myself.add_mark(
-                self.database, self.database.get_person_from_handle(indi_handle)
-            )
+            person = self.database.get_person_from_handle(indi_handle)
+            myself.add_mark(self.database, person)
 
         self.canvas.add_box(myself)
 
@@ -296,6 +316,9 @@ class MakeAncestorTree(AscendPerson):
                 line = self.lines[indx - 1].line_to
             line.add_to(myself)
 
+        if self.fill_box_color and person:
+            myself.set_person_color(person)
+
         return myself
 
     def add_person_again(self, index, indi_handle, fams_handle):
@@ -307,12 +330,15 @@ class MakeAncestorTree(AscendPerson):
         if not self.inlc_marr:
             return
 
-        myself = FamilyBox((index[0] - 1,) + index[1:])
+        myself = FamilyBox((index[0] - 1,) + index[1:], self.database)
 
         # calculate the text.
         myself.text = self.calc_items.calc_marriage(indi_handle, fams_handle)
 
         self.canvas.add_box(myself)
+
+        if self.fill_box_color:
+            myself.set_family_color(fams_handle)
 
     def y_index(self, x_level, index):
         """Calculate the column or generation that this person is in.
@@ -530,7 +556,7 @@ class MakeReport:
 class GUIConnect:
     """This is a BORG object.  There is ONLY one.
     This give some common routines that EVERYONE can use like
-      get the value from a GUI variable
+    get the value from a GUI variable
     """
 
     __shared_state: dict[str, Any] = {}
@@ -539,18 +565,28 @@ class GUIConnect:
         self.__dict__ = self.__shared_state
 
     def set__opts(self, options, locale, name_displayer):
-        """Set only once as we are BORG."""
-        self.__opts = options
+        # This is now the Full Options object, not just .menu
+        self._opts = options
         self.locale = locale
         self.n_d = name_displayer
 
     def get_val(self, val):
         """Get a GUI value."""
-        value = self.__opts.get_option_by_name(val)
+        # Look for the option inside the .menu attribute of self._opts
+        value = self._opts.menu.get_option_by_name(val)
         if value:
             return value.get_value()
         else:
-            False
+            return False
+
+    # to bridge the gap between the GUI and the rest of the code, we have these two functions
+    def get_gender_colors(self):
+        """Retrieve the colors stored in the options instance."""
+        return self._opts.report_gender_colors
+
+    def get_family_colors(self):
+        """Retrieve the family colors stored in the options instance."""
+        return self._opts.report_family_colors
 
     def title_class(self, doc):
         """Return a class that holds the proper title based off of the
@@ -633,7 +669,8 @@ class AncestorTree(Report):
         database = self.database
 
         self.connect = GUIConnect()
-        self.connect.set__opts(self.options.menu, self._locale, self._nd)
+        # CHANGE THIS LINE: pass self.options instead of self.options.menu
+        self.connect.set__opts(self.options, self._locale, self._nd)
 
         # Set up the canvas that we will print on.
         style_sheet = self.doc.get_style_sheet()
@@ -826,6 +863,11 @@ class AncestorTreeOptions(MenuReportOptions):
         self.__pid = None
         self.box_Y_sf = None
         self.box_shadow_sf = None
+
+        # THE ONLY PLACE utils is called for these colors:
+        self.report_gender_colors = utils.get_report_gender_colors()
+        self.report_family_colors = utils.get_report_family_colors()
+
         MenuReportOptions.__init__(self, name, dbase)
 
     def get_subject(self):
@@ -881,6 +923,17 @@ class AncestorTreeOptions(MenuReportOptions):
         self.start_idx = NumberOption(_("Start Index"), 1, 1, 50)
         self.start_idx.set_help(_("The start index"))
         menu.add_option(category_name, "start_idx", self.start_idx)
+
+        fill_box_color = BooleanOption(
+            _("Fill color in the person and marriage boxes"), True
+        )
+        fill_box_color.set_help(
+            _(
+                "Whether to fill color in the person and marriage boxes."
+                "  You may change the color scheme by creating a new style."
+            )
+        )
+        menu.add_option(category_name, "fill_box_color", fill_box_color)
 
         # better to 'Show siblings of\nthe center person
         # Spouse_disp = EnumeratedListOption(_("Show spouses of\nthe center "
@@ -1143,11 +1196,21 @@ class AncestorTreeOptions(MenuReportOptions):
         graph_style.set_fill_color((255, 255, 255))
         default_style.add_draw_style("AC2-box", graph_style)
 
+        # generate color box based on gender
+        utils.generate_gender_color_styles(
+            default_style, "AC2-box", graph_style, self.report_gender_colors
+        )
+
         graph_style = GraphicsStyle()
         graph_style.set_paragraph_style("AC2-Normal")
         # graph_style.set_shadow(0, PT2CM(9))  # shadow set by text size
         graph_style.set_fill_color((255, 255, 255))
         default_style.add_draw_style("AC2-fam-box", graph_style)
+
+        # generate color box based for family
+        utils.generate_family_color_style(
+            default_style, "AC2-fam-box", graph_style, self.report_family_colors
+        )
 
         graph_style = GraphicsStyle()
         graph_style.set_paragraph_style("AC2-Note")

--- a/gramps/plugins/drawreport/descendtree.py
+++ b/gramps/plugins/drawreport/descendtree.py
@@ -6,6 +6,7 @@
 # Copyright (C) 2010       Jakim Friant
 # Copyright (C) 2009-2010  Craig J. Anderson
 # Copyright (C) 2014       Paul Franklin
+# Copyright (C) 2025-2026  Dave Khuon
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,10 +22,7 @@
 # with this program; if not, see <https://www.gnu.org/licenses/>.
 #
 
-"""
-Reports/Graphical Reports/Familial Tree
-Reports/Graphical Reports/Personal Tree
-"""
+"""Reports/Graphical Reports/Familial Tree"""
 
 from __future__ import annotations
 from typing import Any
@@ -92,6 +90,11 @@ class DescendantBoxBase(BoxBase):
         self.linked_box = None
         self.father = None
 
+        # Get colors from the Borg instead of calling utils again
+        gui = GuiConnect()
+        self.report_gender_colors = gui.get_gender_colors()
+        self.report_family_colors = gui.get_family_colors()
+
     def calc_text(self, database, person, family):
         """A single place to calculate box text"""
 
@@ -105,13 +108,20 @@ class PersonBox(DescendantBoxBase):
     Calculates information about the box that will print on a page
     """
 
-    def __init__(self, level, boldable=0):
+    def __init__(self, level, database, boldable=0):
         DescendantBoxBase.__init__(self, "CG2-box")
         self.level = level
+        self.database = database
 
     def set_bold(self):
         """update me to a bolded box"""
         self.boxstr = "CG2b-box"
+
+    def set_person_color(self, person, base_name):
+        """Set box color based on person's gender and alive status."""
+        self.boxstr = utils.get_gender_color_box_name(
+            person, self.database, base_name, self.report_gender_colors
+        )
 
 
 class FamilyBox(DescendantBoxBase):
@@ -119,9 +129,15 @@ class FamilyBox(DescendantBoxBase):
     Calculates information about the box that will print on a page
     """
 
-    def __init__(self, level):
+    def __init__(self, level, database):
         DescendantBoxBase.__init__(self, "CG2-fam-box")
         self.level = level
+        self.database = database
+
+    def set_family_color(self, family_handle):
+        self.boxstr = utils.get_family_color_box_name(
+            family_handle, self.database, "CG2-fam-box", self.report_family_colors
+        )
 
 
 class PlaceHolderBox(BoxBase):
@@ -428,6 +444,8 @@ class RecurseDown:
             self.inlc_marr = False
         self.spouse_indent = gui.get_val("ind_spouse")
 
+        self.fill_box_color = gui.get_val("fill_box_color")
+
         # is the option even available?
         self.bold_direct = gui.get_val("bolddirect")
         # can we bold direct descendants?
@@ -441,10 +459,10 @@ class RecurseDown:
     def add_to_col(self, box):
         """
         Add the box to a column on the canvas.  we will do these things:
-          set the .linked_box attrib for the boxs in this col
-          get the height and width of this box and set it no the column
-          also we set the .x_cm to any s_level (indentation) here
-            we will calculate the real .x_cm later (with indentation)
+        set the .linked_box attrib for the boxs in this col
+        get the height and width of this box and set it no the column
+        also we set the .x_cm to any s_level (indentation) here
+        we will calculate the real .x_cm later (with indentation)
         """
 
         level = box.level[0]
@@ -460,6 +478,7 @@ class RecurseDown:
             # calculate the .y_cm for this box.
             box.y_cm = last_box.y_cm
             box.y_cm += last_box.height
+
             if last_box.boxstr in ["CG2-box", "CG2b-box"]:
                 box.y_cm += self.canvas.report_opts.box_shadow
 
@@ -492,7 +511,7 @@ class RecurseDown:
 
     def add_person_box(self, level, indi_handle, fams_handle, father):
         """Makes a person box and add that person into the Canvas."""
-        myself = PersonBox(level)
+        myself = PersonBox(level, self.database)
         myself.father = father
 
         if myself.level[1] == 0 and self.bold_direct and self.bold_now:
@@ -514,21 +533,24 @@ class RecurseDown:
         # calculate the text.
         myself.calc_text(self.database, indi_handle, fams_handle)
 
+        person = None
         if indi_handle:
-            myself.add_mark(
-                self.database, self.database.get_person_from_handle(indi_handle)
-            )
+            person = self.database.get_person_from_handle(indi_handle)
+            myself.add_mark(self.database, person)
 
         self.add_to_col(myself)
 
         self.canvas.add_box(myself)
 
+        if self.fill_box_color and person:
+            base_name = myself.boxstr  # use value based on prev boldness assessment
+            myself.set_person_color(person, base_name)
+
         return myself
 
     def add_marriage_box(self, level, indi_handle, fams_handle, father):
         """Makes a marriage box and add that person into the Canvas."""
-        myself = FamilyBox(level)
-
+        myself = FamilyBox(level, self.database)
         # if father is not None:
         #    myself.father = father
         # calculate the text.
@@ -538,6 +560,8 @@ class RecurseDown:
 
         self.canvas.add_box(myself)
 
+        if self.fill_box_color:
+            myself.set_family_color(fams_handle)
         return myself
 
     def recurse(self, person_handle, x_level, s_level, father):
@@ -623,6 +647,7 @@ class RecurseDown:
                     # spouse_handle = utils.find_spouse(person,family)
                     self.recurse(spouse_handle, x_level, s_level + 1, spouse)
 
+        # for level 1, restore the original bold_now
         if s_level == 1:
             self.bold_now = tmp_bold
 
@@ -1250,7 +1275,7 @@ class MakeReport:
 class GuiConnect:
     """This is a BORG object.  There is ONLY one.
     This give some common routines that EVERYONE can use like
-      get the value from a GUI variable
+    get the value from a GUI variable
     """
 
     __shared_state: dict[str, Any] = {}
@@ -1259,18 +1284,27 @@ class GuiConnect:
         self.__dict__ = self.__shared_state
 
     def set__opts(self, options, which, locale, name_displayer):
-        self._opts = options
+        self._opts = options  # This is now the Full Options object, not just .menu
         self._which_report = which.split(",")[0]
         self._locale = locale
         self._nd = name_displayer
 
     def get_val(self, val):
         """Get a GUI value."""
-        value = self._opts.get_option_by_name(val)
+        # Look for the option inside the .menu attribute of self._opts
+        value = self._opts.menu.get_option_by_name(val)
         if value:
             return value.get_value()
         else:
-            False
+            return False
+
+    def get_gender_colors(self):
+        """Access the colors stored on the Options instance."""
+        return self._opts.report_gender_colors
+
+    def get_family_colors(self):
+        """Access the colors stored on the Options instance."""
+        return self._opts.report_family_colors
 
     def Title_class(self, database, doc):
         Title_type = self.get_val("report_title")
@@ -1364,9 +1398,7 @@ class DescendTree(Report):
         database = self.database
 
         self.Connect = GuiConnect()
-        self.Connect.set__opts(
-            self.options.menu, self.options.name, self._locale, self._nd
-        )
+        self.Connect.set__opts(self.options, self.options.name, self._locale, self._nd)
 
         style_sheet = self.doc.get_style_sheet()
         font_normal = style_sheet.get_paragraph_style("CG2-Normal").get_font()
@@ -1624,6 +1656,17 @@ class DescendTreeOptions(MenuReportOptions):
         indspouce.set_help(_("Whether to indent the spouses in the tree."))
         menu.add_option(category_name, "ind_spouse", indspouce)
 
+        fill_box_color = BooleanOption(
+            _("Fill color in the person and marriage boxes"), True
+        )
+        fill_box_color.set_help(
+            _(
+                "Whether to fill color in the person and marriage boxes."
+                "  You may change the color scheme by creating a new style."
+            )
+        )
+        menu.add_option(category_name, "fill_box_color", fill_box_color)
+
         ##################
         category_name = _("Report Options")
 
@@ -1812,6 +1855,10 @@ class DescendTreeOptions(MenuReportOptions):
     def make_default_style(self, default_style):
         """Make the default output style for the Descendant Tree."""
 
+        # Store these on 'self' so GuiConnect can find them later
+        self.report_gender_colors = utils.get_report_gender_colors()
+        self.report_family_colors = utils.get_report_family_colors()
+
         ## Paragraph Styles:
         font = FontStyle()
         font.set_size(16)
@@ -1864,6 +1911,11 @@ class DescendTreeOptions(MenuReportOptions):
         graph_style.set_description(_("The style for the marriage box."))
         default_style.add_draw_style("CG2-fam-box", graph_style)
 
+        # generate color box based on family
+        utils.generate_family_color_style(
+            default_style, "CG2-fam-box", graph_style, self.report_family_colors
+        )
+
         graph_style = GraphicsStyle()
         graph_style.set_paragraph_style("CG2-Normal")
         graph_style.set_shadow(1, box_shadow)
@@ -1871,12 +1923,22 @@ class DescendTreeOptions(MenuReportOptions):
         graph_style.set_description(_("The style for the spouse box."))
         default_style.add_draw_style("CG2-box", graph_style)
 
+        # generate normal color box based on gender
+        utils.generate_gender_color_styles(
+            default_style, "CG2-box", graph_style, self.report_gender_colors
+        )
+
         graph_style = GraphicsStyle()
         graph_style.set_paragraph_style("CG2-Bold")
         graph_style.set_shadow(1, box_shadow)
         graph_style.set_fill_color((255, 255, 255))
         graph_style.set_description(_("The style for the direct descendant box."))
         default_style.add_draw_style("CG2b-box", graph_style)
+
+        # generate bolded color box based on gender
+        utils.generate_gender_color_styles(
+            default_style, "CG2b-box", graph_style, self.report_gender_colors
+        )
 
         graph_style = GraphicsStyle()
         graph_style.set_paragraph_style("CG2-Note")


### PR DESCRIPTION
This PR supersedes both PR 1873 (partial), and PR 2300 (full features), to simplify review, and overcome my mess with stacking branches.  Both old PR# have been de-activated "with prejudice" (=closed).

This PR will make both the Ancestor and Descend Trees use appropriate color for person and marriage based on the gender, life status, and marriage type.  The main logics are in the shared gen/plug/report/utils.py.