### PR TITLE
Add Visual Studio Code config to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ ehthumbs.db
 
 # coverage
 .coverage
+
+# Visual Studio Code
+.vscode/*


### PR DESCRIPTION
Add Visual Studio Code's configuration folder to gitignore, allowing developers to have local files which don't get added to commits.

For now the entire folder is ignored, but it would make sense to provide a list of recommended extensions, launch configurations, etc. and include those files in the repo.

