### PR TITLE
Skip legacy-bsddb import tests when no backend is loadable

### DIFF
--- a/gramps/plugins/test/_bsddb_avail.py
+++ b/gramps/plugins/test/_bsddb_avail.py
@@ -1,0 +1,53 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026 Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Test-harness helper: probe whether the bsddb database backend is loadable.
+
+The legacy-bsddb import tests in :mod:`gramps.plugins.test.imports_test` must
+*skip* — not *fail* — when the bsddb backend cannot be loaded, on every
+platform rather than only on Windows.  This helper answers the exact question
+the plugin loader asks at ``gramps/plugins/db/bsddb/bsddb.py`` lines 32-35:
+is :mod:`berkeleydb` (the maintained successor) importable, or failing that
+:mod:`bsddb3` (deprecated since Python 3.6)?  If neither is, the backend is
+unavailable and ``make_database("bsddb")`` would raise.
+"""
+
+
+def bsddb_backend_available():
+    """Return ``True`` iff the bsddb backend is loadable on this platform.
+
+    Mirrors the loader's probe order at ``gramps/plugins/db/bsddb/bsddb.py``
+    lines 32-35 (try ``berkeleydb`` then ``bsddb3``) so the test harness's
+    notion of "bsddb is available" matches what ``make_database("bsddb")``
+    will actually find.  Any import error — a missing package or a failed
+    shared library — counts as unavailable, exactly as the loader tolerates.
+    """
+    try:
+        from berkeleydb.db import DB  # noqa: F401
+
+        return True
+    except Exception:
+        pass
+    try:
+        from bsddb3.db import DB  # noqa: F401
+
+        return True
+    except Exception:
+        pass
+    return False

--- a/gramps/plugins/test/imports_test.py
+++ b/gramps/plugins/test/imports_test.py
@@ -64,6 +64,16 @@ from gramps.gen.db.exceptions import (
     DbConnectionError,
 )
 
+try:
+    from gramps.plugins.test._bsddb_avail import bsddb_backend_available
+except ImportError:  # pragma: no cover - defensive fallback
+
+    def bsddb_backend_available():
+        # If the availability prober cannot be imported, do not skip: let the
+        # real backend load attempt surface any problem rather than mask it.
+        return True
+
+
 # logger = logging.getLogger(__name__)
 
 # the following defines where to find test error diffs and import result XML files
@@ -241,9 +251,15 @@ def db_load(zipfn, self):
             else:
                 dbid = "bsddb"
 
-            # skip if the bsddb backend is not available
-            if dbid == "bsddb" and win():
-                self.skipTest("bsddb not supported on Windows")
+            # skip if the bsddb backend is not loadable on this platform
+            # (mirrors the loader's probe at
+            # gramps/plugins/db/bsddb/bsddb.py:32-35 — neither berkeleydb nor
+            # bsddb3 importable means make_database("bsddb") would raise)
+            if dbid == "bsddb" and not bsddb_backend_available():
+                self.skipTest(
+                    "bsddb backend not loadable on this platform "
+                    "(neither berkeleydb nor bsddb3 is installed)"
+                )
 
             db = make_database(dbid)
             db.disable_signals()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -624,6 +624,7 @@ gramps/plugins/sidebar/expandersidebar.py
 #
 # plugins/test directory
 #
+gramps/plugins/test/_bsddb_avail.py
 gramps/plugins/test/db_undo_and_signals_test.py
 gramps/plugins/test/exports_test.py
 gramps/plugins/test/imports_test.py


### PR DESCRIPTION
## Summary
**User impact:** On a computer where Gramps is installed without the older BerkeleyDB database support — the normal situation on many Linux systems (for example Ubuntu 24.04) — running the project's own test suite reports outright failures for a handful of tests it should simply skip. A perfectly healthy install looks broken to anyone checking it.

This makes those tests skip whenever the database backend genuinely cannot be loaded on the running machine, instead of reporting failures — exactly as they already do on Windows.

Reported in Mantis [#13260](https://gramps-project.org/bugs/view.php?id=13260) ([Linux Mint] "Exception: can't load database backend: 'bsddb'") as the underlying backend-unavailability issue. This PR fixes the *test-suite* symptom — backend-less installs reporting failures that should be skips — not the runtime install error itself, so it uses the non-closing `Bug #13260` trailer rather than `Fixes`. Reported upstream in gramps#2314.

## What to look at
The whole change is one guard: the five legacy-bsddb import tests should skip — not fail — when neither BerkeleyDB backend is importable. To try it, on a default SQLite checkout with no backend installed, run `GRAMPS_RESOURCES=. python3 -m unittest gramps.plugins.test.imports_test`: the five tests now report `skipped` instead of `FAILED`, and wherever a backend *is* installed the tests run unchanged.

## Root cause
On a default SQLite install where neither `berkeleydb` nor `bsddb3` is importable
(the common Linux case, e.g. Ubuntu 24.04), the five legacy-bsddb import tests fall
through to `make_database("bsddb")` at `gramps/plugins/test/imports_test.py:248`,
which raises `can't load database backend: 'bsddb'`; the catch-all at
`gramps/plugins/test/imports_test.py:266-275` reconverts that into an assertion
failure. The existing skip guard fires only under `win()`
(`gramps/plugins/test/imports_test.py:245-246`, added in
`29a0bedaa03eae52cb2e678f9a1a22121a0a7fc5`), so the backend-less Linux case reports
`FAILED` instead of skipping.

## Fix
Replace the Windows-only guard with a real backend-loadability probe, so the tests
skip whenever the backend is genuinely unavailable on the running platform — exactly
as they already do on Windows — and run unchanged wherever a backend is installed.

- New `gramps/plugins/test/_bsddb_avail.py:38-59` — `bsddb_backend_available()`,
  a test-harness helper whose probe order (try `berkeleydb`, then `bsddb3`,
  anything else → unavailable) mirrors the plugin loader at
  `gramps/plugins/db/bsddb/bsddb.py:32-35`.
- `gramps/plugins/test/imports_test.py:245-246` — the `dbid == "bsddb" and win()`
  guard becomes `dbid == "bsddb" and not bsddb_backend_available()`, with a skip
  message naming the real reason.
- `gramps/plugins/test/imports_test.py:59-65` — the helper is imported defensively
  (a `try/except ImportError` fallback returns `True`, i.e. do not skip), so a
  missing prober never masks a real load failure. No `win()` / OS check is
  reintroduced anywhere.

The `except SkipTest: raise` re-raise (`gramps/plugins/test/imports_test.py:263-265`,
also from `29a0bedaa03eae52cb2e678f9a1a22121a0a7fc5`) is what propagates the skip out
of `db_load`'s catch-all and is left untouched. The `while True` upgrade loop, the
catch-all exception block, the sqlite (`dbid != "bsddb"`) path, and
`gramps/plugins/db/bsddb/` are all unchanged.

## Verification
- **Claim:** the five legacy-bsddb import tests skip whenever the backend is genuinely unavailable on the running platform, and run unchanged wherever a backend is installed.
- **Checked:** `gramps/plugins/test/imports_test.py:245-246` on maintenance/gramps61 — confirmed the pre-fix guard was `win()`-only, so a non-Windows host with no backend never reached the skip; `:248` — the `make_database(dbid)` the "available" branch still falls through to, unchanged, so an installed backend runs the real import/compare as before; `:266-275` — the catch-all that turned the loader exception into `AssertionError: Cannot open database … can't load database backend: 'bsddb'` pre-fix; `gramps/plugins/db/bsddb/bsddb.py:32-35` — the loader's `berkeleydb`→`bsddb3` probe the new helper mirrors, keeping "available" in lockstep with what `make_database("bsddb")` actually finds.
- **Test:** no new test file — the regression evidence is the existing `gramps/plugins/test/imports_test.py` tests flipping from failures to skips. On a backend-less Linux checkout (`GRAMPS_RESOURCES=. python3 -m unittest gramps.plugins.test.imports_test`): representative `test_imp_5_1_2bsd_zip` goes pre-fix `FAILED … can't load database backend: 'bsddb'` → post-fix `skipped 'bsddb backend not loadable on this platform (neither berkeleydb nor bsddb3 is installed)'`; whole suite pre-fix `FAILED (failures=5, …)` → post-fix `OK (skipped=…)`. The "backend installed" half is non-regressive by construction: the diff changes only the guard condition and message, and on non-Windows the original `win()` guard was already `False`, so the run-the-real-import path is byte-identical to today's behaviour.

Bug [#13260](https://gramps-project.org/bugs/view.php?id=13260)
