### PR TITLE
Add (i) info button to date editor with calendar and syntax help

### DIFF
--- a/gramps/gen/lib/date.py
+++ b/gramps/gen/lib/date.py
@@ -1764,7 +1764,7 @@ class Date(BaseObject):
         if text:
             self.text = text
 
-        if modifier != Date.MOD_TEXTONLY:
+        if modifier != Date.MOD_TEXTONLY and not self.is_empty():
             sanity = Date(self)
             sanity.convert_calendar(self.calendar, known_valid=False)
             # convert_calendar resets slash and new year, restore these as needed

--- a/gramps/gen/utils/markdown/__init__.py
+++ b/gramps/gen/utils/markdown/__init__.py
@@ -1,0 +1,35 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025  Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+gramps.gen.utils.markdown
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+Pure-Python parser for the Gramps markdown dialect.
+
+Runtime GTK rendering is in gramps.gui.widgets.markdown_render.
+"""
+
+from .parse import parse_front_matter, parse_img_src, parse_markdown
+
+__all__ = [
+    "parse_front_matter",
+    "parse_markdown",
+    "parse_img_src",
+]

--- a/gramps/gen/utils/markdown/parse.py
+++ b/gramps/gen/utils/markdown/parse.py
@@ -1,0 +1,200 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025  Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+gramps.gen.utils.markdown.parse
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Pure-Python tokenizer for the Gramps markdown dialect.
+
+No GTK, no Gramps GUI dependencies.
+"""
+
+import re
+
+# -------------------------------------------------------------------------
+#
+# Regexes
+#
+# -------------------------------------------------------------------------
+
+_LINK_RE = re.compile(r"^-\s+(~?)\[([^\]]*)\]\(([^)]*)\)\s*$")
+_HEAD_RE = re.compile(r"^(#{1,6})\s+(.*)")
+_BLOCK_IMG_RE = re.compile(r"^!\[([^\]]*)\]\(([^)]*)\)\s*$")
+_ICON_RE = re.compile(r"^!\[([^\]]*)\]\(([^)]*)\)\s+(.+)")
+
+
+def _strip_quotes(s: str) -> str:
+    """Remove surrounding single or double quotes."""
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in ('"', "'"):
+        return s[1:-1]
+    return s
+
+
+def parse_front_matter(text: str) -> tuple[dict, str]:
+    """
+    Parse YAML-like front matter delimited by --- lines.
+
+    :returns: ``(config, body)`` where config is a dict of key/value pairs
+              and body is the remaining markdown text.
+    """
+    if not text.startswith("---\n"):
+        return {}, text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return {}, text
+    yaml_src = text[4:end]
+    body = text[end + 5 :]
+
+    config: dict = {}
+    lines = yaml_src.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if not line.strip() or line.strip().startswith("#"):
+            i += 1
+            continue
+        m = re.match(r"^(\w+):\s*(.*)", line)
+        if not m:
+            i += 1
+            continue
+        key, val = m.group(1), m.group(2).strip()
+        if val:
+            config[key] = _strip_quotes(val)
+            i += 1
+        else:
+            items: list = []
+            kv: dict = {}
+            i += 1
+            while i < len(lines) and lines[i] and lines[i][0] in " \t":
+                sub = lines[i].strip()
+                if sub.startswith("- "):
+                    items.append(sub[2:].strip())
+                elif ":" in sub:
+                    k, _, v = sub.partition(":")
+                    kv[k.strip()] = _strip_quotes(v.strip())
+                i += 1
+            config[key] = kv if kv else items
+    return config, body
+
+
+def parse_img_src(src: str) -> tuple[str, int | None, str]:
+    """
+    Parse image src into ``(path, width, align)``.
+
+    Handles::
+
+        gramps:icon:name:size      -> (src, None, "left")
+        gramps:image:file|w|a     -> ("gramps:image:file", w, a)
+        plain/path|w|a             -> ("plain/path", w, a)
+    """
+    if src.startswith("gramps:icon:"):
+        return src, None, "left"
+    parts = src.split("|")
+    path = parts[0]
+    width = int(parts[1]) if len(parts) > 1 and parts[1] else None
+    align = parts[2] if len(parts) > 2 and parts[2] else "left"
+    return path, width, align
+
+
+def parse_markdown(text: str) -> list[dict]:
+    """
+    Parse a markdown body into a list of block tokens.
+
+    Token shapes::
+
+        {'type': 'heading',     'level': int, 'text': str, 'icon': str|None}
+        {'type': 'paragraph',   'text': str}
+        {'type': 'block_image', 'path': str, 'width': int|None, 'align': str}
+        {'type': 'icon_para',   'icon': str, 'text': str}
+        {'type': 'link',        'text': str, 'url': str, 'translate': bool}
+    """
+    blocks: list[dict] = []
+    para_lines: list[str] = []
+
+    def flush_para() -> None:
+        if para_lines:
+            blocks.append({"type": "paragraph", "text": " ".join(para_lines)})
+            para_lines.clear()
+
+    for line in text.splitlines():
+        stripped = line.strip()
+
+        if not stripped:
+            flush_para()
+            continue
+
+        m_head = _HEAD_RE.match(stripped)
+        if m_head:
+            flush_para()
+            level = len(m_head.group(1))
+            head_text = m_head.group(2).strip()
+            icon = None
+            m_icon = _ICON_RE.match(head_text)
+            if m_icon:
+                icon = m_icon.group(2).strip()
+                head_text = m_icon.group(3).strip()
+            blocks.append(
+                {"type": "heading", "level": level, "text": head_text, "icon": icon}
+            )
+            continue
+
+        m_link = _LINK_RE.match(stripped)
+        if m_link:
+            flush_para()
+            blocks.append(
+                {
+                    "type": "link",
+                    "text": m_link.group(2),
+                    "url": m_link.group(3),
+                    "translate": m_link.group(1) != "~",
+                }
+            )
+            continue
+
+        m_bimg = _BLOCK_IMG_RE.match(stripped)
+        if m_bimg:
+            flush_para()
+            path, width, align = parse_img_src(m_bimg.group(2).strip())
+            blocks.append(
+                {
+                    "type": "block_image",
+                    "path": path,
+                    "width": width,
+                    "align": align,
+                }
+            )
+            continue
+
+        m_icon = _ICON_RE.match(stripped)
+        if m_icon:
+            flush_para()
+            blocks.append(
+                {
+                    "type": "icon_para",
+                    "icon": m_icon.group(2).strip(),
+                    "text": m_icon.group(3).strip(),
+                }
+            )
+            continue
+
+        para_lines.append(stripped)
+
+    flush_para()
+    return blocks

--- a/gramps/gui/editors/editdate.py
+++ b/gramps/gui/editors/editdate.py
@@ -584,28 +584,30 @@ class EditDate(ManagedWindow):
         return [
             {
                 "title": _("Calendar"),
-                "body": _(
-                    "Choose the calendar system: **Gregorian**, **Julian**, "
-                    "**Hebrew**, **French Republican**, **Persian**, **Islamic**, "
-                    "or **Swedish**. "
-                    "The selector is disabled when the date type is "
-                    "**Free text**, when **Dual dated** is active, or when "
-                    "the date contains a validation error (shown in the "
-                    "status bar at the bottom of this dialog)."
-                ),
+                # fmt: off
+                # Translators: this string may contain markdown formatting; preserve them
+                "body": _("Choose the calendar system: **Gregorian**, **Julian**, "
+                          "**Hebrew**, **French Republican**, **Persian**, **Islamic**, "
+                          "or **Swedish**. "
+                          "The selector is disabled when the date type is "
+                          "**Free text**, when **Dual dated** is active, or when "
+                          "the date contains a validation error (shown in the "
+                          "status bar at the bottom of this dialog)."),
+                # fmt: on
             },
             {
                 "title": _("Dual-dated dates"),
-                "body": _(
-                    "Slash dates such as `Jan 23, 1735/6` mark a historic transition "
-                    "between New Year conventions (e.g., March 25 vs. January 1). "
-                    "Enter a slash between years to create one: `1721/2`, `1719/20`, "
-                    "`1799/800`. Dual-dated dates use the Julian calendar. "
-                    "An alternate New Year day can be added in parentheses after "
-                    "the calendar name: `Jan 20, 1750 (Julian,Mar25)` or "
-                    "`Feb 23, 1710/1 (Mar25)`. Valid New Year codes: "
-                    "`Jan1`, `Mar1`, `Mar25`, `Sep1`."
-                ),
+                # fmt: off
+                # Translators: this string may contain markdown formatting; preserve them
+                "body": _("Slash dates such as `Jan 23, 1735/6` mark a historic transition "
+                          "between New Year conventions (e.g., March 25 vs. January 1). "
+                          "Enter a slash between years to create one: `1721/2`, `1719/20`, "
+                          "`1799/800`. Dual-dated dates use the Julian calendar. "
+                          "An alternate New Year day can be added in parentheses after "
+                          "the calendar name: `Jan 20, 1750 (Julian,Mar25)` or "
+                          "`Feb 23, 1710/1 (Mar25)`. Valid New Year codes: "
+                          "`Jan1`, `Mar1`, `Mar25`, `Sep1`."),
+                # fmt: on
             },
             {
                 "title": _("Date entry syntax for this locale"),

--- a/gramps/gui/editors/editdate.py
+++ b/gramps/gui/editors/editdate.py
@@ -64,6 +64,7 @@ from gramps.gen.const import URL_MANUAL_SECT1
 from ..display import display_help
 from ..managedwindow import ManagedWindow
 from ..glade import Glade
+from ..widgets.markdown_render import render_md, setup_tags
 
 LOG = logging.getLogger(".EditDate")
 _ = glocale.translation.sgettext
@@ -583,10 +584,11 @@ class EditDate(ManagedWindow):
             {
                 "title": _("Calendar"),
                 "body": _(
-                    "Choose the calendar system: Gregorian, Julian, Hebrew, "
-                    "French Republican, Persian, Islamic, or Swedish. "
+                    "Choose the calendar system: **Gregorian**, **Julian**, "
+                    "**Hebrew**, **French Republican**, **Persian**, **Islamic**, "
+                    "or **Swedish**. "
                     "The selector is disabled when the date type is "
-                    '"Free text", when "Dual dated" is active, or when '
+                    "**Free text**, when **Dual dated** is active, or when "
                     "the date contains a validation error (shown in the "
                     "status bar at the bottom of this dialog)."
                 ),
@@ -594,14 +596,14 @@ class EditDate(ManagedWindow):
             {
                 "title": _("Dual-dated dates"),
                 "body": _(
-                    'Slash dates such as "Jan 23, 1735/6" mark a historic transition '
+                    "Slash dates such as `Jan 23, 1735/6` mark a historic transition "
                     "between New Year conventions (e.g., March 25 vs. January 1). "
-                    "Enter a slash between years to create one: 1721/2, 1719/20, "
-                    "1799/800. Dual-dated dates use the Julian calendar. "
+                    "Enter a slash between years to create one: `1721/2`, `1719/20`, "
+                    "`1799/800`. Dual-dated dates use the Julian calendar. "
                     "An alternate New Year day can be added in parentheses after "
-                    'the calendar name: "Jan 20, 1750 (Julian,Mar25)" or '
-                    '"Feb 23, 1710/1 (Mar25)". Valid New Year codes: '
-                    "Jan1, Mar1, Mar25, Sep1."
+                    "the calendar name: `Jan 20, 1750 (Julian,Mar25)` or "
+                    "`Feb 23, 1710/1 (Mar25)`. Valid New Year codes: "
+                    "`Jan1`, `Mar1`, `Mar25`, `Sep1`."
                 ),
             },
             {
@@ -704,11 +706,16 @@ class EditDate(ManagedWindow):
             vbox.pack_start(lbl, False, False, 0)
 
             if "body" in topic:
-                lbl = Gtk.Label(label=topic["body"])
-                lbl.set_line_wrap(True)
-                lbl.set_xalign(0)
-                lbl.set_max_width_chars(60)
-                vbox.pack_start(lbl, False, False, 0)
+                buf = Gtk.TextBuffer()
+                setup_tags(buf)
+                links: list = []
+                render_md(topic["body"], buf, links)
+                tv = Gtk.TextView(buffer=buf)
+                tv.set_editable(False)
+                tv.set_cursor_visible(False)
+                tv.set_wrap_mode(Gtk.WrapMode.WORD)
+                tv.set_size_request(450, -1)
+                vbox.pack_start(tv, False, False, 0)
 
             if "examples" in topic:
                 store = Gtk.ListStore(str, str)

--- a/gramps/gui/editors/editdate.py
+++ b/gramps/gui/editors/editdate.py
@@ -145,6 +145,9 @@ class EditDate(ManagedWindow):
         self.align_newyear_ui_with_calendar(cal)
         self.calendar_box.connect("changed", self.switch_calendar)
 
+        self.info_button = self.top.get_object("info_button")
+        self.info_button.connect("clicked", self.cb_show_date_syntax)
+
         self.quality_box = self.top.get_object("quality_box")
         for item_number, item in enumerate(QUAL_TEXT):
             self.quality_box.append_text(item[1])
@@ -571,3 +574,107 @@ class EditDate(ManagedWindow):
         LOG.debug(
             "<<<switch_calendar: {0} changed, {1} -> {2}".format(obj, old_cal, new_cal)
         )
+
+    def _build_date_examples(self) -> list[tuple[str, str]]:
+        """Build list of (description, example) pairs for the current locale displayer."""
+
+        def make(
+            yr: int,
+            mon: int = 0,
+            day: int = 0,
+            mod: int = Date.MOD_NONE,
+            qual: int = Date.QUAL_NONE,
+            cal: int = Date.CAL_GREGORIAN,
+            yr2: int = 0,
+            mon2: int = 0,
+            day2: int = 0,
+        ) -> Date:
+            """Create a Date object with the given parameters."""
+            d = Date()
+            if mod in (Date.MOD_RANGE, Date.MOD_SPAN):
+                value = (day, mon, yr, False, day2, mon2, yr2, False)
+            else:
+                value = (day, mon, yr, False)
+            d.set(
+                quality=qual,
+                modifier=mod,
+                calendar=cal,
+                value=value,
+                text="",
+                newyear=Date.NEWYEAR_JAN1,
+            )
+            return d
+
+        text_date = Date()
+        text_date.set(
+            quality=Date.QUAL_NONE,
+            modifier=Date.MOD_TEXTONLY,
+            calendar=Date.CAL_GREGORIAN,
+            value=Date.EMPTY,
+            text=_("sometime in the 1800s"),
+            newyear=Date.NEWYEAR_JAN1,
+        )
+
+        rows: list[tuple[str, Date]] = [
+            (_("Year only"), make(1800)),
+            (_("Month and year"), make(1800, mon=3)),
+            (_("Full date"), make(1800, mon=3, day=15)),
+            (_("Before"), make(1800, mod=Date.MOD_BEFORE)),
+            (_("After"), make(1800, mod=Date.MOD_AFTER)),
+            (_("About/circa"), make(1800, mod=Date.MOD_ABOUT)),
+            (_("Estimated"), make(1800, qual=Date.QUAL_ESTIMATED)),
+            (_("Calculated"), make(1800, qual=Date.QUAL_CALCULATED)),
+            (
+                _("Estimated, before"),
+                make(1800, mod=Date.MOD_BEFORE, qual=Date.QUAL_ESTIMATED),
+            ),
+            (
+                _("Calculated, after"),
+                make(1800, mod=Date.MOD_AFTER, qual=Date.QUAL_CALCULATED),
+            ),
+            (_("Span (from/to)"), make(1800, mod=Date.MOD_SPAN, yr2=1810)),
+            (_("Range (between/and)"), make(1800, mod=Date.MOD_RANGE, yr2=1810)),
+            (_("Julian calendar"), make(1800, mon=2, day=10, cal=Date.CAL_JULIAN)),
+            (_("Hebrew calendar"), make(5780, mon=1, day=1, cal=Date.CAL_HEBREW)),
+            (_("French Republican"), make(10, mon=3, day=1, cal=Date.CAL_FRENCH)),
+            (_("Persian calendar"), make(1400, mon=1, cal=Date.CAL_PERSIAN)),
+            (_("Islamic calendar"), make(1400, mon=1, cal=Date.CAL_ISLAMIC)),
+            (_("Swedish calendar"), make(1712, mon=3, cal=Date.CAL_SWEDISH)),
+            (_("Text only"), text_date),
+        ]
+        return [(desc, displayer.display(d)) for desc, d in rows]
+
+    def cb_show_date_syntax(self, obj: Gtk.Button) -> None:
+        """Show a popover with date entry syntax examples for the current locale."""
+        popover = Gtk.Popover()
+        popover.set_relative_to(self.info_button)
+
+        store = Gtk.ListStore(str, str)
+        for description, example in self._build_date_examples():
+            store.append([description, example])
+
+        view = Gtk.TreeView(model=store)
+        view.set_headers_visible(True)
+        view.set_grid_lines(Gtk.TreeViewGridLines.HORIZONTAL)
+
+        renderer1 = Gtk.CellRendererText()
+        renderer1.set_padding(6, 2)
+        col1 = Gtk.TreeViewColumn(_("What to express"), renderer1, text=0)
+        col1.set_expand(True)
+        view.append_column(col1)
+
+        renderer2 = Gtk.CellRendererText()
+        renderer2.set_padding(6, 2)
+        col2 = Gtk.TreeViewColumn(_("Example"), renderer2, text=1)
+        col2.set_expand(True)
+        view.append_column(col2)
+
+        scroll = Gtk.ScrolledWindow()
+        scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scroll.set_min_content_height(300)
+        scroll.set_min_content_width(450)
+        scroll.add(view)
+
+        popover.add(scroll)
+        popover.show_all()
+        popover.popup()

--- a/gramps/gui/editors/editdate.py
+++ b/gramps/gui/editors/editdate.py
@@ -578,7 +578,8 @@ class EditDate(ManagedWindow):
             "<<<switch_calendar: {0} changed, {1} -> {2}".format(obj, old_cal, new_cal)
         )
 
-    def get_help_topics(self) -> list[dict]:
+    @classmethod
+    def get_help_topics(cls) -> list[dict]:
         """Return help topics describing date entry syntax for this locale."""
         return [
             {
@@ -608,11 +609,12 @@ class EditDate(ManagedWindow):
             },
             {
                 "title": _("Date entry syntax for this locale"),
-                "examples": self._build_date_examples(),
+                "examples": cls._build_date_examples(),
             },
         ]
 
-    def _build_date_examples(self) -> list[tuple[str, str]]:
+    @staticmethod
+    def _build_date_examples() -> list[tuple[str, str]]:
         """Build list of (description, example) pairs for the current locale displayer."""
 
         def make(

--- a/gramps/gui/editors/editdate.py
+++ b/gramps/gui/editors/editdate.py
@@ -593,6 +593,10 @@ class EditDate(ManagedWindow):
         ) -> Date:
             """Create a Date object with the given parameters."""
             d = Date()
+            value: (
+                tuple[int, int, int, bool, int, int, int, bool]
+                | tuple[int, int, int, bool]
+            )
             if mod in (Date.MOD_RANGE, Date.MOD_SPAN):
                 value = (day, mon, yr, False, day2, mon2, yr2, False)
             else:

--- a/gramps/gui/editors/editdate.py
+++ b/gramps/gui/editors/editdate.py
@@ -585,7 +585,7 @@ class EditDate(ManagedWindow):
             {
                 "title": _("Calendar"),
                 # fmt: off
-                # Translators: this string may contain markdown formatting; preserve them
+                # Translators: this string may contain markdown formatting; preserve it
                 "body": _("Choose the calendar system: **Gregorian**, **Julian**, "
                           "**Hebrew**, **French Republican**, **Persian**, **Islamic**, "
                           "or **Swedish**. "
@@ -598,7 +598,7 @@ class EditDate(ManagedWindow):
             {
                 "title": _("Dual-dated dates"),
                 # fmt: off
-                # Translators: this string may contain markdown formatting; preserve them
+                # Translators: this string may contain markdown formatting; preserve it
                 "body": _("Slash dates such as `Jan 23, 1735/6` mark a historic transition "
                           "between New Year conventions (e.g., March 25 vs. January 1). "
                           "Enter a slash between years to create one: `1721/2`, `1719/20`, "

--- a/gramps/gui/editors/editdate.py
+++ b/gramps/gui/editors/editdate.py
@@ -277,6 +277,8 @@ class EditDate(ManagedWindow):
     def show_on_calendar(self, calendar, date):
         if self.calendar_box.get_active() != Date.CAL_GREGORIAN:
             return
+        if date.is_empty():
+            return
         date = date.to_calendar("gregorian")
         year = date.get_year()
         if year < 0:  # Gtk.Calendar only works for positive years
@@ -649,6 +651,59 @@ class EditDate(ManagedWindow):
         popover = Gtk.Popover()
         popover.set_relative_to(self.info_button)
 
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        vbox.set_margin_top(12)
+        vbox.set_margin_bottom(12)
+        vbox.set_margin_start(12)
+        vbox.set_margin_end(12)
+
+        def add_section(heading: str, body: str) -> None:
+            """Add a bold heading and wrapped body text to the popover."""
+            lbl = Gtk.Label()
+            lbl.set_markup("<b>" + heading + "</b>")
+            lbl.set_xalign(0)
+            vbox.pack_start(lbl, False, False, 0)
+            lbl = Gtk.Label(label=body)
+            lbl.set_line_wrap(True)
+            lbl.set_xalign(0)
+            lbl.set_max_width_chars(60)
+            vbox.pack_start(lbl, False, False, 0)
+
+        add_section(
+            _("Calendar"),
+            _(
+                "Choose the calendar system: Gregorian, Julian, Hebrew, "
+                "French Republican, Persian, Islamic, or Swedish. "
+                "The selector is disabled when the date type is "
+                '"Free text", when "Dual dated" is active, or when '
+                "the date contains a validation error (shown in the "
+                "status bar at the bottom of this dialog)."
+            ),
+        )
+
+        vbox.pack_start(Gtk.Separator(), False, False, 4)
+
+        add_section(
+            _("Dual-dated dates"),
+            _(
+                'Slash dates such as "Jan 23, 1735/6" mark a historic transition '
+                "between New Year conventions (e.g., March 25 vs. January 1). "
+                "Enter a slash between years to create one: 1721/2, 1719/20, "
+                "1799/800. Dual-dated dates use the Julian calendar. "
+                "An alternate New Year day can be added in parentheses after "
+                'the calendar name: "Jan 20, 1750 (Julian,Mar25)" or '
+                '"Feb 23, 1710/1 (Mar25)". Valid New Year codes: '
+                "Jan1, Mar1, Mar25, Sep1."
+            ),
+        )
+
+        vbox.pack_start(Gtk.Separator(), False, False, 4)
+
+        lbl = Gtk.Label()
+        lbl.set_markup("<b>" + _("Date entry syntax for this locale") + "</b>")
+        lbl.set_xalign(0)
+        vbox.pack_start(lbl, False, False, 0)
+
         store = Gtk.ListStore(str, str)
         for description, example in self._build_date_examples():
             store.append([description, example])
@@ -675,6 +730,8 @@ class EditDate(ManagedWindow):
         scroll.set_min_content_width(450)
         scroll.add(view)
 
-        popover.add(scroll)
+        vbox.pack_start(scroll, True, True, 0)
+
+        popover.add(vbox)
         popover.show_all()
         popover.popup()

--- a/gramps/gui/editors/editdate.py
+++ b/gramps/gui/editors/editdate.py
@@ -577,6 +577,39 @@ class EditDate(ManagedWindow):
             "<<<switch_calendar: {0} changed, {1} -> {2}".format(obj, old_cal, new_cal)
         )
 
+    def get_help_topics(self) -> list[dict]:
+        """Return help topics describing date entry syntax for this locale."""
+        return [
+            {
+                "title": _("Calendar"),
+                "body": _(
+                    "Choose the calendar system: Gregorian, Julian, Hebrew, "
+                    "French Republican, Persian, Islamic, or Swedish. "
+                    "The selector is disabled when the date type is "
+                    '"Free text", when "Dual dated" is active, or when '
+                    "the date contains a validation error (shown in the "
+                    "status bar at the bottom of this dialog)."
+                ),
+            },
+            {
+                "title": _("Dual-dated dates"),
+                "body": _(
+                    'Slash dates such as "Jan 23, 1735/6" mark a historic transition '
+                    "between New Year conventions (e.g., March 25 vs. January 1). "
+                    "Enter a slash between years to create one: 1721/2, 1719/20, "
+                    "1799/800. Dual-dated dates use the Julian calendar. "
+                    "An alternate New Year day can be added in parentheses after "
+                    'the calendar name: "Jan 20, 1750 (Julian,Mar25)" or '
+                    '"Feb 23, 1710/1 (Mar25)". Valid New Year codes: '
+                    "Jan1, Mar1, Mar25, Sep1."
+                ),
+            },
+            {
+                "title": _("Date entry syntax for this locale"),
+                "examples": self._build_date_examples(),
+            },
+        ]
+
     def _build_date_examples(self) -> list[tuple[str, str]]:
         """Build list of (description, example) pairs for the current locale displayer."""
 
@@ -651,7 +684,7 @@ class EditDate(ManagedWindow):
         return [(desc, displayer.display(d)) for desc, d in rows]
 
     def cb_show_date_syntax(self, obj: Gtk.Button) -> None:
-        """Show a popover with date entry syntax examples for the current locale."""
+        """Show a popover rendering the help topics for the current locale."""
         popover = Gtk.Popover()
         popover.set_relative_to(self.info_button)
 
@@ -661,80 +694,50 @@ class EditDate(ManagedWindow):
         vbox.set_margin_start(12)
         vbox.set_margin_end(12)
 
-        def add_section(heading: str, body: str) -> None:
-            """Add a bold heading and wrapped body text to the popover."""
+        for i, topic in enumerate(self.get_help_topics()):
+            if i > 0:
+                vbox.pack_start(Gtk.Separator(), False, False, 4)
+
             lbl = Gtk.Label()
-            lbl.set_markup("<b>" + heading + "</b>")
+            lbl.set_markup("<b>" + topic["title"] + "</b>")
             lbl.set_xalign(0)
             vbox.pack_start(lbl, False, False, 0)
-            lbl = Gtk.Label(label=body)
-            lbl.set_line_wrap(True)
-            lbl.set_xalign(0)
-            lbl.set_max_width_chars(60)
-            vbox.pack_start(lbl, False, False, 0)
 
-        add_section(
-            _("Calendar"),
-            _(
-                "Choose the calendar system: Gregorian, Julian, Hebrew, "
-                "French Republican, Persian, Islamic, or Swedish. "
-                "The selector is disabled when the date type is "
-                '"Free text", when "Dual dated" is active, or when '
-                "the date contains a validation error (shown in the "
-                "status bar at the bottom of this dialog)."
-            ),
-        )
+            if "body" in topic:
+                lbl = Gtk.Label(label=topic["body"])
+                lbl.set_line_wrap(True)
+                lbl.set_xalign(0)
+                lbl.set_max_width_chars(60)
+                vbox.pack_start(lbl, False, False, 0)
 
-        vbox.pack_start(Gtk.Separator(), False, False, 4)
+            if "examples" in topic:
+                store = Gtk.ListStore(str, str)
+                for description, example in topic["examples"]:
+                    store.append([description, example])
 
-        add_section(
-            _("Dual-dated dates"),
-            _(
-                'Slash dates such as "Jan 23, 1735/6" mark a historic transition '
-                "between New Year conventions (e.g., March 25 vs. January 1). "
-                "Enter a slash between years to create one: 1721/2, 1719/20, "
-                "1799/800. Dual-dated dates use the Julian calendar. "
-                "An alternate New Year day can be added in parentheses after "
-                'the calendar name: "Jan 20, 1750 (Julian,Mar25)" or '
-                '"Feb 23, 1710/1 (Mar25)". Valid New Year codes: '
-                "Jan1, Mar1, Mar25, Sep1."
-            ),
-        )
+                view = Gtk.TreeView(model=store)
+                view.set_headers_visible(True)
+                view.set_grid_lines(Gtk.TreeViewGridLines.HORIZONTAL)
 
-        vbox.pack_start(Gtk.Separator(), False, False, 4)
+                renderer1 = Gtk.CellRendererText()
+                renderer1.set_padding(6, 2)
+                col1 = Gtk.TreeViewColumn(_("What to express"), renderer1, text=0)
+                col1.set_expand(True)
+                view.append_column(col1)
 
-        lbl = Gtk.Label()
-        lbl.set_markup("<b>" + _("Date entry syntax for this locale") + "</b>")
-        lbl.set_xalign(0)
-        vbox.pack_start(lbl, False, False, 0)
+                renderer2 = Gtk.CellRendererText()
+                renderer2.set_padding(6, 2)
+                col2 = Gtk.TreeViewColumn(_("Example"), renderer2, text=1)
+                col2.set_expand(True)
+                view.append_column(col2)
 
-        store = Gtk.ListStore(str, str)
-        for description, example in self._build_date_examples():
-            store.append([description, example])
+                scroll = Gtk.ScrolledWindow()
+                scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+                scroll.set_min_content_height(300)
+                scroll.set_min_content_width(450)
+                scroll.add(view)
 
-        view = Gtk.TreeView(model=store)
-        view.set_headers_visible(True)
-        view.set_grid_lines(Gtk.TreeViewGridLines.HORIZONTAL)
-
-        renderer1 = Gtk.CellRendererText()
-        renderer1.set_padding(6, 2)
-        col1 = Gtk.TreeViewColumn(_("What to express"), renderer1, text=0)
-        col1.set_expand(True)
-        view.append_column(col1)
-
-        renderer2 = Gtk.CellRendererText()
-        renderer2.set_padding(6, 2)
-        col2 = Gtk.TreeViewColumn(_("Example"), renderer2, text=1)
-        col2.set_expand(True)
-        view.append_column(col2)
-
-        scroll = Gtk.ScrolledWindow()
-        scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
-        scroll.set_min_content_height(300)
-        scroll.set_min_content_width(450)
-        scroll.add(view)
-
-        vbox.pack_start(scroll, True, True, 0)
+                vbox.pack_start(scroll, True, True, 0)
 
         popover.add(vbox)
         popover.show_all()

--- a/gramps/gui/glade/editdate.glade
+++ b/gramps/gui/glade/editdate.glade
@@ -129,6 +129,28 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <child>
+                      <object class="GtkButton" id="info_button">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="relief">none</property>
+                        <property name="tooltip-text" translatable="yes">Show date entry syntax examples</property>
+                        <child>
+                          <object class="GtkImage">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="icon-name">dialog-information</property>
+                            <property name="icon-size">1</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
                       <object class="GtkLabel" id="label404">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
@@ -142,7 +164,7 @@
                         <property name="expand">False</property>
                         <property name="fill">True</property>
                         <property name="padding">6</property>
-                        <property name="position">0</property>
+                        <property name="position">1</property>
                       </packing>
                     </child>
                     <child>
@@ -160,28 +182,6 @@
                       <packing>
                         <property name="expand">True</property>
                         <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="info_button">
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="receives-default">False</property>
-                        <property name="tooltip-text" translatable="yes">Show date entry syntax examples</property>
-                        <property name="relief">none</property>
-                        <child>
-                          <object class="GtkImage">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="icon-name">dialog-information</property>
-                            <property name="icon-size">1</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
                         <property name="position">2</property>
                       </packing>
                     </child>

--- a/gramps/gui/glade/editdate.glade
+++ b/gramps/gui/glade/editdate.glade
@@ -163,6 +163,28 @@
                         <property name="position">1</property>
                       </packing>
                     </child>
+                    <child>
+                      <object class="GtkButton" id="info_button">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="tooltip-text" translatable="yes">Show date entry syntax examples</property>
+                        <property name="relief">none</property>
+                        <child>
+                          <object class="GtkImage">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="icon-name">dialog-information</property>
+                            <property name="icon-size">1</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/gramps/gui/glade/editdate.glade
+++ b/gramps/gui/glade/editdate.glade
@@ -621,9 +621,6 @@
             <property name="position">1</property>
           </packing>
         </child>
-        <child>
-          <placeholder/>
-        </child>
       </object>
     </child>
     <action-widgets>

--- a/gramps/gui/grampsgui.py
+++ b/gramps/gui/grampsgui.py
@@ -28,6 +28,7 @@
 # -------------------------------------------------------------------------
 import sys
 import os
+import gettext
 import logging
 
 LOG = logging.getLogger(".grampsgui")
@@ -492,6 +493,22 @@ if glocale.no_gettext_support:
 # -------------------------------------------------------------------------
 
 
+def _gtk_translations_found():
+    """
+    Return True if GTK translations exist in any standard locale directory.
+
+    Python's gettext.find() defaults to the Python prefix's share/locale,
+    which may not contain GTK translations when running from a virtualenv or
+    conda environment.  We also search XDG_DATA_DIRS and Ubuntu's
+    locale-langpack directory so that system-installed GTK translations are
+    found regardless of which Python is used.
+    """
+    xdg_dirs = os.environ.get("XDG_DATA_DIRS", "/usr/local/share:/usr/share").split(":")
+    locale_dirs = [os.path.join(d, "locale") for d in xdg_dirs]
+    locale_dirs.append("/usr/share/locale-langpack")
+    return any(gettext.find(GTK_GETTEXT_DOMAIN, localedir=d) for d in locale_dirs)
+
+
 def _display_gtk_gettext_message(parent=None):
     """
     Display a GTK-translations-missing message to the user.
@@ -591,7 +608,7 @@ class Gramps:
             lin()
             and "SNAP" not in os.environ
             and glocale.lang != "C"
-            and not gettext.find(GTK_GETTEXT_DOMAIN)
+            and not _gtk_translations_found()
         ):
             _display_gtk_gettext_message(parent=self._vm.window)
 

--- a/gramps/gui/managedwindow.py
+++ b/gramps/gui/managedwindow.py
@@ -551,6 +551,18 @@ class ManagedWindow:
     def build_window_key(self, obj):
         return id(obj)
 
+    def get_help_topics(self) -> list[dict]:
+        """
+        Return help topics for this window.
+
+        Each entry is a dict with a ``"title"`` key plus one of:
+        - ``"body"``: a translated prose string
+        - ``"examples"``: a list of ``(label, value)`` string pairs
+
+        Override in subclasses to provide window-specific help content.
+        """
+        return []
+
     def define_glade(self, top_module, glade_file=None, also_load=[]):
         if glade_file is None:
             raise TypeError("ManagedWindow.define_glade: no glade file")

--- a/gramps/gui/managedwindow.py
+++ b/gramps/gui/managedwindow.py
@@ -551,7 +551,8 @@ class ManagedWindow:
     def build_window_key(self, obj):
         return id(obj)
 
-    def get_help_topics(self) -> list[dict]:
+    @classmethod
+    def get_help_topics(cls) -> list[dict]:
         """
         Return help topics for this window.
 
@@ -560,6 +561,8 @@ class ManagedWindow:
         - ``"examples"``: a list of ``(label, value)`` string pairs
 
         Override in subclasses to provide window-specific help content.
+        This is a classmethod so topics can be indexed without instantiating
+        the window.
         """
         return []
 

--- a/gramps/gui/widgets/markdown_render.py
+++ b/gramps/gui/widgets/markdown_render.py
@@ -1,0 +1,471 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025  Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+gramps.gui.widgets.markdown_render
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Runtime Markdown renderer for Gramps GTK widgets.
+
+Renders the Gramps markdown dialect into a Gtk.TextBuffer, with support
+for images, inline formatting, and gramps: URI scheme links.
+
+Public API::
+
+    render_md(text, buf, links, dbstate=None, uistate=None, vars=None)
+    load_md(plugin_dir, basename)
+    setup_tags(buf)
+"""
+
+# -------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import os
+import re
+from typing import Any
+
+# -------------------------------------------------------------------------
+#
+# GTK/Gnome modules
+#
+# -------------------------------------------------------------------------
+from gi.repository import GdkPixbuf, Gtk, Pango
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.const import IMAGE_DIR
+from gramps.gen.utils.markdown import parse_front_matter, parse_markdown
+
+_INLINE_RE = re.compile(r"(\*\*(.+?)\*\*|\*(.+?)\*|`(.+?)`)")
+
+
+# -------------------------------------------------------------------------
+#
+# Image loading
+#
+# -------------------------------------------------------------------------
+
+
+def _load_pixbuf(path: str, width: int | None = None) -> GdkPixbuf.Pixbuf | None:
+    """
+    Load and optionally scale a pixbuf.
+
+    Handles URI schemes:
+    - ``gramps:icon:name:size`` — GTK theme icon by name and size
+    - ``gramps:image:filename`` — file relative to IMAGE_DIR
+    - plain path — file relative to IMAGE_DIR
+    """
+    if path.startswith("gramps:icon:"):
+        parts = path.split(":")
+        name = parts[2]
+        size = int(parts[3]) if len(parts) > 3 else 22
+        try:
+            pixbuf = Gtk.IconTheme.get_default().load_icon(name, size, 0)
+        except Exception:
+            return None
+        if width is not None and pixbuf is not None and width != size:
+            orig_h = pixbuf.get_height()
+            orig_w = pixbuf.get_width()
+            new_h = max(1, int(orig_h * width / orig_w)) if orig_w else size
+            pixbuf = pixbuf.scale_simple(width, new_h, GdkPixbuf.InterpType.BILINEAR)
+        return pixbuf
+    if path.startswith("gramps:image:"):
+        filepath = path[len("gramps:image:") :]
+    else:
+        filepath = path
+    if not os.path.isabs(filepath):
+        filepath = os.path.join(IMAGE_DIR, filepath)
+    if not os.path.exists(filepath):
+        return None
+    try:
+        pixbuf = GdkPixbuf.Pixbuf.new_from_file(filepath)
+    except Exception:
+        return None
+    if width is not None and pixbuf.get_width() > 0:
+        orig_w = pixbuf.get_width()
+        orig_h = pixbuf.get_height()
+        new_h = max(1, int(orig_h * width / orig_w))
+        pixbuf = pixbuf.scale_simple(width, new_h, GdkPixbuf.InterpType.BILINEAR)
+    return pixbuf
+
+
+def _ins_image(
+    buf: Gtk.TextBuffer, path: str, width: int | None = None, align: str = "left"
+) -> None:
+    """Insert a scaled pixbuf into buf at the current end position."""
+    pixbuf = _load_pixbuf(path, width)
+    if pixbuf is None:
+        return
+    start_offset = buf.get_char_count()
+    buf.insert_pixbuf(buf.get_end_iter(), pixbuf)
+    if align != "left":
+        buf.apply_tag_by_name(
+            "align_" + align,
+            buf.get_iter_at_offset(start_offset),
+            buf.get_end_iter(),
+        )
+
+
+# -------------------------------------------------------------------------
+#
+# Link insertion
+#
+# -------------------------------------------------------------------------
+
+
+def _ins_link(
+    buf: Gtk.TextBuffer,
+    links: list,
+    text: str,
+    url: str,
+    tag: str = "link",
+) -> None:
+    """Insert text as a clickable link, appending (start, end, url) to links."""
+    start_offset = buf.get_char_count()
+    buf.insert(buf.get_end_iter(), text)
+    end_offset = buf.get_char_count()
+    buf.apply_tag_by_name(
+        tag,
+        buf.get_iter_at_offset(start_offset),
+        buf.get_iter_at_offset(end_offset),
+    )
+    links.append((start_offset, end_offset, url))
+
+
+# -------------------------------------------------------------------------
+#
+# Inline formatting
+#
+# -------------------------------------------------------------------------
+
+
+def _render_inline(buf: Gtk.TextBuffer, text: str) -> None:
+    """Parse **bold**, *italic*, and `code` in text and insert into buf with tags."""
+    pos = 0
+    for m in _INLINE_RE.finditer(text):
+        if m.start() > pos:
+            buf.insert(buf.get_end_iter(), text[pos : m.start()])
+        if m.group(2) is not None:
+            inner, tag = m.group(2), "bold"
+        elif m.group(3) is not None:
+            inner, tag = m.group(3), "italic"
+        else:
+            inner, tag = m.group(4), "code"
+        start_offset = buf.get_char_count()
+        buf.insert(buf.get_end_iter(), inner)
+        buf.apply_tag_by_name(
+            tag,
+            buf.get_iter_at_offset(start_offset),
+            buf.get_end_iter(),
+        )
+        pos = m.end()
+    if pos < len(text):
+        buf.insert(buf.get_end_iter(), text[pos:])
+
+
+# -------------------------------------------------------------------------
+#
+# URL helpers
+#
+# -------------------------------------------------------------------------
+
+
+def wiki(page: str, manual: bool = False) -> str:
+    """Build a URL to a Gramps wiki page."""
+    from gramps.gen.const import URL_MANUAL_PAGE, URL_WIKISTRING
+    from gramps.gui.display import EXTENSION
+
+    url = URL_WIKISTRING
+    if manual:
+        url += URL_MANUAL_PAGE
+    url += page + EXTENSION
+    return url
+
+
+def url_to_value(url: str, vars: dict | None = None) -> str:
+    """
+    Resolve a markdown URL spec to a string at runtime.
+
+    Handles ``wiki:``, ``wiki_manual:``, ``{VARNAME}`` substitution,
+    and literal URLs.
+    """
+    if url.startswith("wiki_manual:"):
+        return wiki(url[len("wiki_manual:") :], manual=True)
+    if url.startswith("wiki:"):
+        page = url[len("wiki:") :]
+        if page.startswith("{") and page.endswith("}"):
+            page = (vars or {}).get(page[1:-1], page)
+        return wiki(page)
+    if "{" in url:
+        parts = re.split(r"\{(\w+)\}", url)
+        result = ""
+        for idx, part in enumerate(parts):
+            if idx % 2 == 0:
+                result += part
+            else:
+                result += str((vars or {}).get(part, "{" + part + "}"))
+        return result
+    return url
+
+
+# -------------------------------------------------------------------------
+#
+# Gramps: link dispatcher
+#
+# -------------------------------------------------------------------------
+
+
+def handle_gramps_link(url: str, dbstate: Any, uistate: Any) -> None:
+    """Dispatch a gramps: scheme URL to the appropriate Gramps action."""
+    parts = url.split(":")
+    if len(parts) < 3:
+        return
+    scheme = parts[1]
+
+    if scheme == "view":
+        _view_map = {
+            "people": "People",
+            "families": "Families",
+            "events": "Events",
+            "places": "Places",
+            "sources": "Sources",
+            "citations": "Citations",
+            "repositories": "Repositories",
+            "media": "Media",
+            "notes": "Notes",
+            "geography": "Geography",
+            "charts": "Charts",
+            "dashboard": "Dashboard",
+        }
+        view_name = _view_map.get(parts[2])
+        if view_name:
+            uistate.viewmanager.goto_page(view_name, None)
+        return
+
+    if scheme not in ("edit", "nav") or len(parts) < 4:
+        return
+    obj_type, gramps_id = parts[2], parts[3]
+    db = dbstate.db
+    _getters = {
+        "Person": db.get_person_from_gramps_id,
+        "Family": db.get_family_from_gramps_id,
+        "Event": db.get_event_from_gramps_id,
+        "Place": db.get_place_from_gramps_id,
+        "Source": db.get_source_from_gramps_id,
+        "Citation": db.get_citation_from_gramps_id,
+        "Repository": db.get_repository_from_gramps_id,
+        "Media": db.get_media_from_gramps_id,
+        "Note": db.get_note_from_gramps_id,
+    }
+    getter = _getters.get(obj_type)
+    if getter is None:
+        return
+    obj = getter(gramps_id)
+    if obj is None:
+        return
+
+    if scheme == "nav":
+        uistate.set_active(obj.get_handle(), obj_type)
+        return
+
+    from gramps.gui.editors import (
+        EditCitation,
+        EditEvent,
+        EditFamily,
+        EditMedia,
+        EditNote,
+        EditPerson,
+        EditPlace,
+        EditRepository,
+        EditSource,
+    )
+
+    _editors = {
+        "Person": EditPerson,
+        "Family": EditFamily,
+        "Event": EditEvent,
+        "Place": EditPlace,
+        "Source": EditSource,
+        "Citation": EditCitation,
+        "Repository": EditRepository,
+        "Media": EditMedia,
+        "Note": EditNote,
+    }
+    editor_class = _editors.get(obj_type)
+    if editor_class:
+        editor_class(dbstate, uistate, [], obj)
+
+
+# -------------------------------------------------------------------------
+#
+# Tag setup
+#
+# -------------------------------------------------------------------------
+
+
+def setup_tags(buf: Gtk.TextBuffer) -> None:
+    """Create all standard text tags on buf (idempotent — skips existing tags)."""
+    table = buf.get_tag_table()
+
+    def _ensure(name: str, **kwargs: object) -> None:
+        if table.lookup(name) is None:
+            buf.create_tag(name, **kwargs)
+
+    _ensure("bold", weight=Pango.Weight.BOLD)
+    _ensure("italic", style=Pango.Style.ITALIC)
+    _ensure(
+        "code",
+        family="Monospace",
+        background="#f0f0f0",
+    )
+    _ensure("h1", weight=Pango.Weight.BOLD, scale=1.728)
+    _ensure("h2", weight=Pango.Weight.BOLD, scale=1.440)
+    _ensure("h3", weight=Pango.Weight.BOLD, scale=1.200)
+    _ensure("h4", weight=Pango.Weight.BOLD)
+    _ensure("h5", weight=Pango.Weight.BOLD)
+    _ensure("h6", weight=Pango.Weight.BOLD)
+    try:
+        _lbl = Gtk.Label()
+        _rgba = _lbl.get_style_context().get_color(Gtk.StateFlags.LINK)
+        link_color = "#{:02x}{:02x}{:02x}".format(
+            int(_rgba.red * 255),
+            int(_rgba.green * 255),
+            int(_rgba.blue * 255),
+        )
+    except Exception:
+        link_color = "blue"
+    _ensure("link", foreground=link_color, underline=Pango.Underline.SINGLE)
+    _ensure("gramps_link", foreground="purple", underline=Pango.Underline.SINGLE)
+    _ensure("align_center", justification=Gtk.Justification.CENTER)
+    _ensure("align_right", justification=Gtk.Justification.RIGHT)
+
+
+# -------------------------------------------------------------------------
+#
+# Locale-aware .md loader
+#
+# -------------------------------------------------------------------------
+
+
+def load_md(plugin_dir: str, basename: str) -> str:
+    """
+    Load the best locale-matched .md file for basename.
+
+    Search order::
+
+        {basename}.{lang_full}.md  (e.g., welcomegramplet.fr_FR.md)
+        {basename}.{lang}.md       (e.g., welcomegramplet.fr.md)
+        {basename}.md              (English fallback)
+    """
+    lang = glocale.lang
+    lang_full = lang.split(".")[0]
+    lang_short = lang_full.split("_")[0]
+
+    for name in [
+        f"{basename}.{lang_full}.md",
+        f"{basename}.{lang_short}.md",
+        f"{basename}.md",
+    ]:
+        path = os.path.join(plugin_dir, name)
+        if os.path.exists(path):
+            with open(path, encoding="utf-8") as fh:
+                return fh.read()
+
+    raise FileNotFoundError(f"No .md file found for {basename!r} in {plugin_dir!r}")
+
+
+# -------------------------------------------------------------------------
+#
+# Main renderer
+#
+# -------------------------------------------------------------------------
+
+
+def render_md(
+    text: str,
+    buf: Gtk.TextBuffer,
+    links: list,
+    dbstate: Any = None,
+    uistate: Any = None,
+    vars: dict | None = None,
+) -> None:
+    """
+    Parse and render a markdown string into buf.
+
+    Tags must already exist on buf — call :func:`setup_tags` first.
+
+    :param text: Markdown source.
+    :param buf: Gtk.TextBuffer to render into (cleared before rendering).
+    :param links: List to which ``(start_offset, end_offset, url)`` tuples
+                  are appended for each link.
+    :param dbstate: Gramps DbState — required for gramps:edit/nav links.
+    :param uistate: Gramps UiState — required for gramps:edit/nav/view links.
+    :param vars: Dict of variable name to value for ``{VARNAME}`` URL
+                 substitution.
+    """
+    _config, body = parse_front_matter(text)
+    all_vars = dict(vars or {})
+
+    blocks = parse_markdown(body)
+    buf.set_text("")
+
+    for block in blocks:
+        btype = block["type"]
+
+        if btype == "heading":
+            level = block.get("level", 2)
+            tag = f"h{level}"
+            icon = block.get("icon")
+            if icon:
+                _ins_image(buf, icon)
+                buf.insert(buf.get_end_iter(), " ")
+            start = buf.get_char_count()
+            buf.insert(buf.get_end_iter(), block["text"])
+            buf.apply_tag_by_name(
+                tag, buf.get_iter_at_offset(start), buf.get_end_iter()
+            )
+            buf.insert(buf.get_end_iter(), "\n\n")
+
+        elif btype == "paragraph":
+            _render_inline(buf, block["text"])
+            buf.insert(buf.get_end_iter(), "\n\n")
+
+        elif btype == "block_image":
+            _ins_image(buf, block["path"], width=block["width"], align=block["align"])
+            buf.insert(buf.get_end_iter(), "\n\n")
+
+        elif btype == "icon_para":
+            _ins_image(buf, block["icon"])
+            buf.insert(buf.get_end_iter(), " ")
+            _render_inline(buf, block["text"])
+            buf.insert(buf.get_end_iter(), "\n\n")
+
+        elif btype == "link":
+            resolved_url = url_to_value(block["url"], all_vars)
+            is_gramps = block["url"].startswith("gramps:")
+            link_tag = "gramps_link" if is_gramps else "link"
+            buf.insert(buf.get_end_iter(), "  • ")
+            _ins_link(buf, links, block["text"], resolved_url, link_tag)
+            buf.insert(buf.get_end_iter(), "\n\n")

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -307,6 +307,11 @@ gramps/gen/utils/docgen/__init__.py
 gramps/gen/utils/docgen/csvtab.py
 gramps/gen/utils/docgen/tabbeddoc.py
 #
+# gen.utils.markdown
+#
+gramps/gen/utils/markdown/__init__.py
+gramps/gen/utils/markdown/parse.py
+#
 # gen.utils.test
 #
 gramps/gen/utils/test/alive_test.py
@@ -470,6 +475,7 @@ gramps/gui/widgets/linkbox.py
 gramps/gui/widgets/menuitem.py
 gramps/gui/widgets/multitreeview.py
 gramps/gui/widgets/placeentry.py
+gramps/gui/widgets/markdown_render.py
 gramps/gui/widgets/selectionwidget.py
 gramps/gui/widgets/shadebox.py
 gramps/gui/widgets/shortlistcomboentry.py


### PR DESCRIPTION
## Summary

- Adds a flat `(i)` information button to the upper-left of the Calendar row in the Edit Date dialog.
- Clicking it opens a popover that explains:
  - **Calendar** — what the calendar selector does and when it is disabled (Free text mode, Dual-dated active, or a validation error)
  - **Dual-dated dates** — what slash-year notation means and how to enter it (e.g. `1735/6`, alternate New Year codes)
  - **Date entry syntax for this locale** — the existing per-locale two-column table of formats and live examples
- Fixes a bug where the calendar selector was always disabled when the dialog first opened (a spurious `DateError` from `Date.set()` running a round-trip sanity check on an empty `(0,0,0,False)` date value). (made a separate PR)
- Fixes `show_on_calendar()` to bail early for empty dates, preventing a spurious GTK Calendar `day-selected` signal. (made a separate PR)
- Fixes GTK translation detection in `grampsgui.py` to search `XDG_DATA_DIRS` and `/usr/share/locale-langpack`, so `language-pack-gnome-*` packages installed on Ubuntu are found when running from a virtualenv or conda environment. (made a separate PR)

## Motivation

The motivation for this PR is two-fold:

1. Explain some esoteric date-related things that are hard to remember
2. Provide examples of how to enter dates in a particular locale

In English:

<img width="859" height="692" alt="image" src="https://github.com/user-attachments/assets/3e4a6d6f-6615-4d9a-8577-e85ec3918cc9" />

In French (the text has not been translated yet):

<img width="876" height="703" alt="image" src="https://github.com/user-attachments/assets/518391d4-7f25-402b-b0a3-6c450498e231" />

I hope to add additional :information_source: buttons with short helpful advice in various places in Gramps.

## Test plan

- [ ] Open the Edit Date dialog and confirm the calendar selector is enabled (not greyed out) on first open.
- [ ] Click the `(i)` button and confirm the popover shows Calendar, Dual-dated, and syntax sections.
- [ ] Set date type to "Free text" and confirm the calendar selector becomes disabled; the popover text explains why.
- [ ] Check "Dual dated" and confirm the calendar selector becomes disabled; the popover explains this too.
- [ ] Enter an invalid date and confirm the calendar selector disables with an error in the status bar.
- [ ] Switch calendar to Hebrew/Julian/etc. and confirm the syntax table updates for that locale.
- [ ] On Ubuntu with `language-pack-gnome-en` installed, confirm no "GTK translations missing" warning on startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)