### PR TITLE
Fix calendar selector disabled on open in Edit Date dialog

### DIFF
--- a/gramps/gen/lib/date.py
+++ b/gramps/gen/lib/date.py
@@ -1827,7 +1827,7 @@ class Date(BaseObject):
         if text:
             self.text = text
 
-        if modifier != Date.MOD_TEXTONLY:
+        if modifier != Date.MOD_TEXTONLY and not self.is_empty():
             sanity = Date(self)
             sanity.convert_calendar(self.calendar, known_valid=False)
             # convert_calendar resets slash and new year, restore these as needed

--- a/gramps/gui/editors/editdate.py
+++ b/gramps/gui/editors/editdate.py
@@ -274,6 +274,8 @@ class EditDate(ManagedWindow):
     def show_on_calendar(self, calendar, date):
         if self.calendar_box.get_active() != Date.CAL_GREGORIAN:
             return
+        if date.is_empty():
+            return
         date = date.to_calendar("gregorian")
         year = date.get_year()
         if year < 0:  # Gtk.Calendar only works for positive years


### PR DESCRIPTION
## Summary

When the Edit Date dialog opens with an empty date, the calendar selector
(Gregorian, Julian, Hebrew, …) was always disabled on first open.

**Root cause:** `Date.set()` runs a round-trip calendar sanity check on the
date value it just stored. When the date is empty — the uninitialised
`(0, 0, 0, False)` tuple — the check raised a `DateError` ("Invalid day/month
0"), which the dialog caught and used to disable the calendar selector.
Toggling "Dual dated" on and off cleared the error and re-enabled it, which
is what made the bug hard to spot.

**Fixes:**

- `gramps/gen/lib/date.py` — skip the sanity check in `Date.set()` when the
  date is empty (`and not self.is_empty()`).
- `gramps/gui/editors/editdate.py` — bail early in `show_on_calendar()` for
  empty dates so no spurious GTK Calendar `day-selected` signal is emitted.

## Test plan

- [ ] Open the Edit Date dialog on a person with no existing date — confirm the
  calendar selector is enabled immediately (was greyed out before this fix).
- [ ] Open the dialog on an existing date — confirm the selector is still enabled
  and set to the correct calendar.
- [ ] Set date type to "Free text" — confirm the selector becomes disabled (that
  code path is unchanged).
- [ ] Check "Dual dated" — confirm the selector becomes disabled (unchanged).
- [ ] Enter an invalid date — confirm the selector disables and the status bar
  shows an error (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)