### PR TITLE
Fix GTK translation detection missing Ubuntu locale-langpack paths

### DIFF
--- a/gramps/gui/grampsgui.py
+++ b/gramps/gui/grampsgui.py
@@ -28,6 +28,7 @@
 # -------------------------------------------------------------------------
 import sys
 import os
+import gettext
 import logging
 
 LOG = logging.getLogger(".grampsgui")
@@ -492,6 +493,22 @@ if glocale.no_gettext_support:
 # -------------------------------------------------------------------------
 
 
+def _gtk_translations_found() -> bool:
+    """
+    Return True if GTK translations exist in any standard locale directory.
+
+    Python's gettext.find() defaults to the Python prefix's share/locale,
+    which may not contain GTK translations when running from a virtualenv or
+    conda environment.  We also search XDG_DATA_DIRS and Ubuntu's
+    locale-langpack directory so that system-installed GTK translations are
+    found regardless of which Python is used.
+    """
+    xdg_dirs = os.environ.get("XDG_DATA_DIRS", "/usr/local/share:/usr/share").split(":")
+    locale_dirs = [os.path.join(d, "locale") for d in xdg_dirs]
+    locale_dirs.append("/usr/share/locale-langpack")
+    return any(gettext.find(GTK_GETTEXT_DOMAIN, localedir=d) for d in locale_dirs)
+
+
 def _display_gtk_gettext_message(parent=None):
     """
     Display a GTK-translations-missing message to the user.
@@ -578,7 +595,6 @@ class Gramps:
         from .viewmanager import ViewManager
         from gramps.cli.arghandler import ArgHandler
         from .tipofday import TipOfDay
-        import gettext
 
         # Append image directory to the theme search path
         theme = Gtk.IconTheme.get_default()
@@ -591,7 +607,7 @@ class Gramps:
             lin()
             and "SNAP" not in os.environ
             and glocale.lang != "C"
-            and not gettext.find(GTK_GETTEXT_DOMAIN)
+            and not _gtk_translations_found()
         ):
             _display_gtk_gettext_message(parent=self._vm.window)
 


### PR DESCRIPTION
## Summary

On Ubuntu, GTK translations installed via `language-pack-gnome-*` live in
`/usr/share/locale-langpack`, not in the Python prefix's `share/locale`.
When running Gramps from a virtualenv or conda environment,
`gettext.find('gtk30')` searches only the Python prefix and returns `None`,
causing a spurious **"GTK translations missing"** warning dialog even when
the translations are correctly installed.

Replace the single `gettext.find(GTK_GETTEXT_DOMAIN)` call in
`grampsgui.py` with a `_gtk_translations_found()` helper that searches:
- every directory in `XDG_DATA_DIRS` (the standard freedesktop path list)
- `/usr/share/locale-langpack` (Ubuntu-specific fallback)

This silences the false-positive warning for users who have GTK
translations installed via the normal Ubuntu package manager.

## Test plan

- [ ] On Ubuntu with `language-pack-gnome-en` (or any language pack)
  installed, run Gramps from source (`python3 Gramps.py`) and confirm
  no "GTK translations missing" warning appears on startup.
- [ ] Remove all `language-pack-gnome-*` packages and confirm the warning
  still appears correctly.
- [ ] Confirm the fix has no effect on non-Linux platforms (the warning is
  already guarded by `lin()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)