### PR TITLE
Silence noisy traceback in FamilySearch tree test

### DIFF
--- a/gramps/gen/fs/test/tree_test.py
+++ b/gramps/gen/fs/test/tree_test.py
@@ -219,9 +219,10 @@ class TestAddPersons(unittest.TestCase):
                 raise RuntimeError("network failure")
             return (fsid, mock_response, {"persons": [{"id": fsid}]})
 
-        with patch.object(self.tree, "_fetch_raw", side_effect=fake_fetch_raw):
-            with patch("gramps.gen.fs.tree.deserialize.deserialize_json"):
-                self.tree.add_persons(["FS-030", "FS-031"])
+        with patch("gramps.gen.fs.tree.LOG"):
+            with patch.object(self.tree, "_fetch_raw", side_effect=fake_fetch_raw):
+                with patch("gramps.gen.fs.tree.deserialize.deserialize_json"):
+                    self.tree.add_persons(["FS-030", "FS-031"])
 
         # FS-030 succeeded and should be in _persons
         self.assertIn("FS-030", self.tree._persons)


### PR DESCRIPTION
## Summary

- `test_add_persons_one_fetch_raises_other_still_imported` intentionally raises a `RuntimeError` to simulate a network failure, but didn't patch `LOG`
- This caused `LOG.warning(..., exc_info=True)` inside `add_persons` to emit a full traceback to stderr on every test run
- Fix: wrap the `add_persons` call with `patch("gramps.gen.fs.tree.LOG")`, matching the pattern already used by the companion test `test_add_persons_fetch_exception_is_logged_not_raised`

## Test plan

- [x] Run `python3 -m unittest gramps.gen.fs.test.tree_test -v` — all 12 tests pass with no traceback output

🤖 Generated with [Claude Code](https://claude.com/claude-code)