### PR TITLE
Prevent race condition between JSON and blob metadata

### DIFF
--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -811,16 +811,15 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
             # Note: downgrade check only works from v5.1.2 and later on sqlite
             self.has_changed = 1  # to make sure genderstats gets saved
             if self.use_json_data():
-                # Write JSON first so concurrent readers always find valid
-                # json_data (avoids NULL json_data race window).
                 self.set_serializer("json")
                 self._set_all_metadata()
-            self.set_serializer("blob")
-            self._set_all_metadata()
-            if self.use_json_data():
-                # Restore the JSON serializer; the schema uses json_data columns
-                # and subsequent commits must target that column.
+                # Write blob second, then restore JSON as the active serializer.
+                self.set_serializer("blob")
+                self._set_all_metadata()
                 self.set_serializer("json")
+            else:
+                self.set_serializer("blob")
+                self._set_all_metadata()
             self.has_changed = 0  # number of commits
 
         self.db_is_open = True

--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -817,6 +817,10 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
                 self._set_all_metadata()
             self.set_serializer("blob")
             self._set_all_metadata()
+            if self.use_json_data():
+                # Restore the JSON serializer; the schema uses json_data columns
+                # and subsequent commits must target that column.
+                self.set_serializer("json")
             self.has_changed = 0  # number of commits
 
         self.db_is_open = True

--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -809,12 +809,14 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
             # for new db we always need blob metadata to allow prior Gramps versions
             # to make it to the downgrade version check
             # Note: downgrade check only works from v5.1.2 and later on sqlite
-            self.set_serializer("blob")
             self.has_changed = 1  # to make sure genderstats gets saved
-            self._set_all_metadata()
             if self.use_json_data():
+                # Write JSON first so concurrent readers always find valid
+                # json_data (avoids NULL json_data race window).
                 self.set_serializer("json")
                 self._set_all_metadata()
+            self.set_serializer("blob")
+            self._set_all_metadata()
             self.has_changed = 0  # number of commits
 
         self.db_is_open = True


### PR DESCRIPTION
It turned out that my fix https://github.com/gramps-project/gramps/pull/2029 was not complete: when two concurrent processes access the data simultaneously, a reace condition can occur that leads to a database in a broken state, with partially populated JSON column. See https://github.com/gramps-project/gramps-web-api/issues/880, in particular this analysis: https://github.com/gramps-project/gramps-web-api/issues/880#issuecomment-4711947501.

It would be great if this could be included in the next 6.0 maintenance release. Thanks!