### PR TITLE
Limit dashboard gramplet columns (Mantis ID 13864)

### DIFF
--- a/gramps/gui/grampletconfig.py
+++ b/gramps/gui/grampletconfig.py
@@ -1,0 +1,36 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026 Gramps project
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Helpers for gramplet view configuration.
+"""
+
+MAX_GRAMPLET_COLUMNS = 10
+
+
+def clamp_column_count(num):
+    """
+    Return a gramplet column count that is safe to build.
+
+    :param num: Requested column count.
+    :type num: int | str
+    :returns: The requested count constrained to the supported range.
+    :rtype: int
+    """
+    return min(max(int(num), 1), MAX_GRAMPLET_COLUMNS)

--- a/gramps/gui/test/grampletconfig_test.py
+++ b/gramps/gui/test/grampletconfig_test.py
@@ -1,0 +1,51 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026 Gramps project
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Tests for gramplet view configuration helpers.
+"""
+
+import unittest
+
+from gramps.gui.grampletconfig import MAX_GRAMPLET_COLUMNS, clamp_column_count
+
+
+class GrampletConfigTest(unittest.TestCase):
+    """
+    Test gramplet configuration value normalization.
+    """
+
+    def test_clamp_column_count_keeps_supported_values(self):
+        self.assertEqual(clamp_column_count(1), 1)
+        self.assertEqual(clamp_column_count(2), 2)
+        self.assertEqual(clamp_column_count(MAX_GRAMPLET_COLUMNS), MAX_GRAMPLET_COLUMNS)
+
+    def test_clamp_column_count_raises_low_values_to_one(self):
+        self.assertEqual(clamp_column_count(0), 1)
+        self.assertEqual(clamp_column_count(-5), 1)
+
+    def test_clamp_column_count_limits_large_values(self):
+        self.assertEqual(clamp_column_count(1000), MAX_GRAMPLET_COLUMNS)
+
+    def test_clamp_column_count_accepts_config_file_strings(self):
+        self.assertEqual(clamp_column_count("1000"), MAX_GRAMPLET_COLUMNS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gui/widgets/grampletpane.py
+++ b/gramps/gui/widgets/grampletpane.py
@@ -56,6 +56,7 @@ from ..plug.quick import run_quick_report_by_name
 from ..display import display_help, display_url
 from ..glade import Glade
 from ..pluginmanager import GuiPluginManager
+from ..grampletconfig import MAX_GRAMPLET_COLUMNS, clamp_column_count
 from .undoablebuffer import UndoableBuffer
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 
@@ -1016,7 +1017,7 @@ class GrampletPane(Gtk.ScrolledWindow):
         Gtk.ScrolledWindow.__init__(self)
         self.configfile = os.path.join(VERSION_DIR, "%s.ini" % configfile)
         # default for new user; may be overridden in config:
-        self.column_count = kwargs.get("column_count", 2)
+        self.column_count = clamp_column_count(kwargs.get("column_count", 2))
         # width of window, if sidebar; may be overridden in config:
         self.pane_position = kwargs.get("pane_position", -1)
         self.pane_orientation = kwargs.get("pane_orientation", "horizontal")
@@ -1196,7 +1197,9 @@ class GrampletPane(Gtk.ScrolledWindow):
             for sec in cp.sections():
                 if sec == "Gramplet View Options":
                     if "column_count" in cp.options(sec):
-                        self.column_count = int(cp.get(sec, "column_count"))
+                        self.column_count = clamp_column_count(
+                            cp.get(sec, "column_count")
+                        )
                     if "pane_position" in cp.options(sec):
                         self.pane_position = int(cp.get(sec, "pane_position"))
                     if "pane_orientation" in cp.options(sec):
@@ -1383,8 +1386,7 @@ class GrampletPane(Gtk.ScrolledWindow):
         return True
 
     def set_columns(self, num):
-        if num < 1:
-            num = 1
+        num = clamp_column_count(num)
         # clear the gramplets:
         self.clear_gramplets()
         # clear the columns:
@@ -1638,6 +1640,7 @@ class GrampletPane(Gtk.ScrolledWindow):
             "Gramplet View Options.column_count",
             self._config.set,
             config=self._config,
+            helptext=_("Enter a number from 1 to %d.") % MAX_GRAMPLET_COLUMNS,
         )
         return _("Gramplet Layout"), grid
 

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -329,6 +329,7 @@ gramps/gui/basesidebar.py
 gramps/gui/dbguielement.py
 gramps/gui/ddtargets.py
 gramps/gui/display.py
+gramps/gui/grampletconfig.py
 gramps/gui/glade.py
 gramps/gui/listmodel.py
 gramps/gui/managedwindow.py


### PR DESCRIPTION
## Summary
**User impact:** Setting the Dashboard to a very large number of gramplet columns — for example 1000 — could freeze Gramps or shut it down entirely. Even a far more modest setting of 20 columns already pushed newly added gramplets off-screen with odd spacing. There was nothing stopping a user from entering these values.

This caps the Dashboard column count at a practical range of 1 to 10 everywhere a value can be set, preventing both the crash and the unusable high-column layout.

Reported in Mantis [#13864](https://gramps-project.org/bugs/view.php?id=13864) (the crash at 1000 columns), with the related layout failure at 20 columns tracked in [#13865](https://gramps-project.org/bugs/view.php?id=13865).

## What to look at
The column count is now clamped to 1–10 at every point a value enters the pane: when the pane is created, when `gramplets.ini` is loaded, and when the configure dialog applies a new value; the configure field's tooltip states the valid range. To try it: open the Dashboard configure dialog and attempt to set the column count to 1000 (previously a freeze/crash) or to 20 (previously off-screen gramplets) — both now cap at 10.

## Root cause
The Dashboard gramplet layout accepted any positive integer for the number of
columns. Entering a very large value such as `1000` caused `GrampletPane` to
allocate that many GTK column boxes, which could freeze or terminate Gramps.

## Fix
Clamp the gramplet column count to a supported range of `1..10` at every point
where a value enters `GrampletPane`: when the pane is created, when
`gramplets.ini` is loaded, and when the configure dialog applies a new value.
`set_columns` now uses the same clamp, so it bounds the high end as well as the
existing low end. The configure field's tooltip states the valid range.

The clamp and its `MAX_GRAMPLET_COLUMNS` constant live in a small GTK-free module,
`gramps/gui/grampletconfig.py`. This mirrors the existing
`gramps/gui/viewmanagerutils.py` seam: `grampletpane.py` imports `gi`/GTK at module
load, so its logic cannot be imported under the headless test runner. Extracting the
pure value-normalization keeps the production code path and the unit test importing
the *same* function, without launching GTK.

The upper bound is intentionally below `20` because Mantis issue #13865 reports
that setting the Dashboard to 20 columns already causes added gramplets to appear
off-screen with odd spacing. In other words, issue 13864 is the severe
resource-exhaustion failure at `1000`, while issue 13865 shows the same
unbounded column setting entering unusable layout territory at a much lower
value. A practical cap of 10 prevents both the crash class and the known
20-column layout failure without introducing screen-size-dependent behavior in a
maintenance-branch fix.

## Verification
- **Claim:** every column count entering `GrampletPane` is clamped to the supported `1..10` range, bounding both the low and high ends.
- **Checked:** on maintenance/gramps61 — `gramps/gui/grampletconfig.py:24` (supported maximum defined once), `:27` (config and UI values clamped); `gramps/gui/widgets/grampletpane.py:1020` (constructor defaults clamped), `:1200` (stored `column_count` clamped), `:1389` (live configure changes clamped), `:1643` (UI tooltip states the range).
- **Test:** `gramps/gui/test/grampletconfig_test.py` covers the clamp contract: supported values pass through, sub-`1` values raise to `1`, large values (and config-file strings) cap at `MAX_GRAMPLET_COLUMNS`. It runs headless because the helper carries no GTK import. Run with `python3 -m unittest -v gramps.gui.test.grampletconfig_test` (and `python3 -m black --check --diff --fast --workers 1 --target-version py314 gramps/gui/grampletconfig.py gramps/gui/widgets/grampletpane.py gramps/gui/test/grampletconfig_test.py`).

Fixes [#13864](https://gramps-project.org/bugs/view.php?id=13864), [#13865](https://gramps-project.org/bugs/view.php?id=13865)
