### PR TITLE
gui(addon): guard refresh delivery from closed window crash

### DIFF
--- a/gramps/gen/plug/_addonrefresh.py
+++ b/gramps/gen/plug/_addonrefresh.py
@@ -1,0 +1,89 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025  The Gramps project
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Liveness gate for the Addon Manager background refresh.
+
+The Addon Manager fetches its listing off the GUI thread. When a project's
+listing file is missing (e.g. an old ``gramps51`` path, or any URL where
+``addons-<lang>.json`` 404s), that fetch is both slow and failing: every
+language's listing is tried and times out in turn. If the Addon Manager
+window is closed while such a refresh is still in flight, the result that
+arrives later must be *dropped*. Delivering it would call back into the
+destroyed window and leave a dangling pointer in the Gtk draw cycle, which
+crashes Gramps (Mantis 13174).
+
+:class:`AddonRefreshDispatch` is the gate that decides whether a fetched
+result may still be applied. It holds no GUI references, so it can be unit
+tested headless while the real Addon Manager routes its refresh delivery
+through it.
+"""
+
+
+# -------------------------------------------------------------------------
+#
+# AddonRefreshDispatch
+#
+# -------------------------------------------------------------------------
+class AddonRefreshDispatch:
+    """
+    Gate the delivery of one background addon-refresh result.
+
+    A refresh creates a dispatch and hands :meth:`deliver` to the worker
+    thread as its completion callback. When the requesting window is torn
+    down (or a newer refresh supersedes this one), :meth:`cancel` is called;
+    any result that arrives afterwards is then dropped instead of being
+    applied to a destroyed window.
+
+    :param apply_result: callable invoked with the fetched addon list when,
+        and only when, the dispatch is still alive at delivery time.
+    """
+
+    def __init__(self, apply_result):
+        self._apply_result = apply_result
+        self._alive = True
+
+    @property
+    def alive(self):
+        """True until :meth:`cancel` is called."""
+        return self._alive
+
+    def cancel(self):
+        """
+        Mark the requesting window as torn down.
+
+        After this, :meth:`deliver` drops its result instead of applying it,
+        so a late-arriving (possibly failed) refresh cannot touch a window
+        that no longer exists.
+        """
+        self._alive = False
+
+    def deliver(self, addon_list):
+        """
+        Apply a fetched result iff the dispatch is still alive.
+
+        :param addon_list: the addon list returned by the background fetch
+            (an empty list for a missing/404 listing).
+        :returns: True if the result was applied, False if it was dropped
+            because the window had been closed during the refresh.
+        """
+        if not self._alive:
+            return False
+        self._apply_result(addon_list)
+        return True

--- a/gramps/gen/plug/test/utils_test.py
+++ b/gramps/gen/plug/test/utils_test.py
@@ -1,0 +1,96 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025  The Gramps project
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Regression tests for the Addon Manager refresh against a missing listing
+(Mantis 13174).
+
+These are headless, GUI-import-free: the dangling-window crash is reproduced
+through the same liveness gate the real Addon Manager refresh routes its
+delivery through (:class:`AddonRefreshDispatch`), so no ``gi`` / ``gramps.gui``
+import is needed.
+"""
+
+import os
+import tempfile
+import unittest
+
+from gramps.gen.plug.utils import get_addons
+from gramps.gen.plug._addonrefresh import AddonRefreshDispatch
+
+
+class MissingListingFetchTest(unittest.TestCase):
+    """The fetch surfaces a missing listing as a handled empty result."""
+
+    def test_missing_listing_returns_empty_without_raising(self):
+        """A project whose listing .json is absent yields [] (no exception)."""
+        empty_dir = tempfile.mkdtemp()  # no listings/ subdir -> every lookup 404s
+        url = "file://" + empty_dir
+        result = get_addons("TestProject", url)
+        self.assertEqual(result, [])
+
+
+class AddonRefreshDispatchTest(unittest.TestCase):
+    """
+    The dispatch gate that stops a late refresh result from touching a
+    destroyed window (the dangling-window crash, Mantis 13174).
+    """
+
+    def setUp(self):
+        self.delivered = []
+
+    def _apply(self, addon_list):
+        self.delivered.append(addon_list)
+
+    def test_live_dispatch_delivers(self):
+        """A result delivered while the window is open is applied."""
+        dispatch = AddonRefreshDispatch(self._apply)
+        self.assertTrue(dispatch.alive)
+        applied = dispatch.deliver(["addon"])
+        self.assertTrue(applied)
+        self.assertEqual(self.delivered, [["addon"]])
+
+    def test_cancelled_dispatch_drops_late_result(self):
+        """
+        A result that arrives after the window was closed is dropped.
+
+        This is the dangling-window guard: without it, deliver would call back
+        into the destroyed Addon Manager window during the Gtk draw cycle.
+        """
+        dispatch = AddonRefreshDispatch(self._apply)
+        dispatch.cancel()  # window closed mid-refresh
+        self.assertFalse(dispatch.alive)
+        applied = dispatch.deliver([])  # the slow/failed 404 refresh completes
+        self.assertFalse(applied)
+        self.assertEqual(self.delivered, [])
+
+    def test_subsequent_valid_refresh_still_works(self):
+        """After a cancelled (failed) refresh, a fresh refresh delivers."""
+        stale = AddonRefreshDispatch(self._apply)
+        stale.cancel()
+        stale.deliver([])  # dropped
+        # A new refresh creates a new dispatch which delivers normally.
+        fresh = AddonRefreshDispatch(self._apply)
+        applied = fresh.deliver(["addon"])
+        self.assertTrue(applied)
+        self.assertEqual(self.delivered, [["addon"]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gui/plug/_windows.py
+++ b/gramps/gui/plug/_windows.py
@@ -90,6 +90,7 @@ from gramps.gen.config import config
 from ..widgets.progressdialog import LongOpStatus, ProgressMonitor, GtkProgressDialog
 
 from gramps.gen.plug.utils import get_all_addons, available_updates
+from gramps.gen.plug._addonrefresh import AddonRefreshDispatch
 from ..display import display_help, display_url
 from gramps.gui.widgets import BasicLabel, SimpleButton
 from gramps.gen.utils.requirements import Requirements
@@ -384,6 +385,9 @@ class AddonManager(ManagedWindow):
     def __init__(self, dbstate, uistate, track):
         self.dbstate = dbstate
         self.title = _("Addon Manager")
+        # Gate for the background refresh result (Mantis 13174). Set before
+        # the window is built so close() can always cancel a pending refresh.
+        self._dispatch = None
         ManagedWindow.__init__(self, uistate, [], self)
 
         self.__pmgr = GuiPluginManager.get_instance()
@@ -543,8 +547,29 @@ class AddonManager(ManagedWindow):
 
         self.__placeholder(_("Loading..."))
 
-        thread = GetAddons(self.load_addons)
+        # A failing refresh (e.g. a project whose listing .json 404s) runs for
+        # a long time off the GUI thread. If the window is closed meanwhile,
+        # the result that arrives later must be dropped: delivering it would
+        # call back into the destroyed window and leave a dangling pointer in
+        # the Gtk draw cycle (Mantis 13174). Route delivery through a liveness
+        # gate, superseding any still-in-flight previous refresh.
+        if self._dispatch is not None:
+            self._dispatch.cancel()
+        self._dispatch = AddonRefreshDispatch(self.load_addons)
+
+        thread = GetAddons(self._dispatch.deliver)
         thread.start()
+
+    def close(self, *args):
+        """
+        Drop any in-flight refresh result, then close the window.
+
+        Cancelling the dispatch ensures a slow/failed refresh that completes
+        after teardown cannot touch the destroyed window (Mantis 13174).
+        """
+        if self._dispatch is not None:
+            self._dispatch.cancel()
+        ManagedWindow.close(self, *args)
 
     def update_addon(self, addon_id):
         """

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -213,6 +213,7 @@ gramps/gen/mime/__init__.py
 # gen plug API
 #
 gramps/gen/plug/__init__.py
+gramps/gen/plug/_addonrefresh.py
 gramps/gen/plug/_docgenplugin.py
 gramps/gen/plug/_export.py
 gramps/gen/plug/_import.py
@@ -275,6 +276,7 @@ gramps/gen/plug/report/_reportbase.py
 #
 gramps/gen/plug/test/__init__.py
 gramps/gen/plug/test/_manager_symlinks_test.py
+gramps/gen/plug/test/utils_test.py
 #
 # gen proxy API
 #


### PR DESCRIPTION
## Summary
**User impact:** If you close the Add-on Manager window while it is still fetching its list of add-ons, Gramps could crash to the desktop. This is especially likely when a project's add-on list is missing, because each language's list then takes about ten seconds to time out — plenty of time for an impatient user to close the window before the slow, failing result arrives.

This makes any result that arrives after the window has been closed simply get dropped, so it can never reach the destroyed window; a later valid refresh still populates the list normally.

Reported in Mantis [#13174](https://gramps-project.org/bugs/view.php?id=13174).

## What to look at
The refresh runs on a background thread; the fix adds a small liveness gate so a result delivered after the window is torn down is discarded instead of drawn into it. To reproduce the crash pre-fix: open the Add-on Manager, trigger a refresh against a project whose listing is missing/404 (each language times out in turn), and close the dialog while the refresh is still in flight — the late result calls back into the destroyed window and crashes Gramps. Post-fix the late result is dropped and a fresh refresh works.

## Root cause
When the Addon Manager refreshes against a project whose listing file is missing
or returns 404, the fetch is both slow (each language's listing times out in turn
after ~10 seconds) and failing (HTTP 404). The refresh runs off the GUI thread via
`GetAddons` thread (gramps/gui/plug/_windows.py:116). If the user closes the
Addon Manager dialog while the refresh is still in flight, the queued result that
arrives later invokes `load_addons` (via `GLib.idle_add`, _windows.py:130-132)
and calls back into the destroyed window, leaving a dangling pointer in the Gtk
draw cycle—crashing Gramps to desktop.

## Fix
Extract `AddonRefreshDispatch` (new gramps/gen/plug/_addonrefresh.py), a
plain-Python liveness gate that marks when the requesting window is torn down and
drops any result that arrives after teardown. Wire the gate into the refresh path:

- gramps/gui/plug/_windows.py:
  - Line 93: import `AddonRefreshDispatch` from the new gate module
  - Line 390: initialize `self._dispatch = None` early in `__init__` so `close()`
    can always cancel a pending refresh
  - Line 556-560: `refresh()` cancels any in-flight previous dispatch, creates a
    fresh one, and hands `dispatch.deliver` (not the bare `self.load_addons`) to
    `GetAddons`
  - Line 563-572: new `close()` override cancels the dispatch before calling
    `ManagedWindow.close()`

Now a result that arrives after the window is destroyed is dropped—`load_addons`
never touches the closed window. A subsequent valid refresh creates a new live
dispatch and populates normally (success criterion: "a subsequent valid refresh
still works").

## Verification
- **Claim:** a result arriving after the window is torn down is dropped and never touches the closed window; a subsequent valid refresh still delivers normally.
- **Checked:** on maintenance/gramps61 — the headless unit tests in `gramps/gen/plug/test/utils_test.py` verify: `MissingListingFetchTest::test_missing_listing_returns_empty_without_raising` — `get_addons()` against a missing listing returns `[]` without raising (the "handled" half of the success criterion; green pre- and post-fix, a regression guard on the already-correct fetch path); `AddonRefreshDispatchTest::test_live_dispatch_delivers` — a result delivered while the dispatch is alive is applied; `AddonRefreshDispatchTest::test_cancelled_dispatch_drops_late_result` — the dangling-window guard: a result arriving after `cancel()` is dropped, not applied; `AddonRefreshDispatchTest::test_subsequent_valid_refresh_still_works` — after a cancelled (failed) refresh, a fresh dispatch delivers normally.
- **Test:** `gramps/gen/plug/test/utils_test.py` (lines 139-194). The extracted gate is plain Python with no GUI imports, so it is driven headless. The three `AddonRefreshDispatch` tests form the red→green regression path: with the production change reverted, `_addonrefresh.py` is gone, so the test module fails to import — the protective mechanism is absent (red-without-fix, green-with-fix). Honest limitation: the GUI wiring (refresh creating the dispatch, close cancelling it) lives in `_windows.py` and cannot be imported headless, so the unit test does not detect a revert of only the wiring while the module stays; that last mile — the actual destroyed-window draw — is reachable only through an AT-SPI interface test, listed as advisory follow-up in gramps-testbed.

Fixes [#13174](https://gramps-project.org/bugs/view.php?id=13174)
