### PR TITLE
date: normalize empty text dates to canonical empty dates

### DIFF
--- a/gramps/gen/lib/date.py
+++ b/gramps/gen/lib/date.py
@@ -1827,6 +1827,14 @@ class Date(BaseObject):
         if text:
             self.text = text
 
+        # A text-only date with no text holds no date information; treat it as
+        # a regular empty date so an empty date keeps a canonical serialized
+        # form (bug 13744 — see set_as_text).
+        if self.modifier == Date.MOD_TEXTONLY and not self.text:
+            self.modifier = Date.MOD_NONE
+            self.dateval = Date.EMPTY
+            self.sortval = 0
+
         if modifier != Date.MOD_TEXTONLY:
             sanity = Date(self)
             sanity.convert_calendar(self.calendar, known_valid=False)
@@ -1931,8 +1939,19 @@ class Date(BaseObject):
     def set_as_text(self, text):
         """
         Set the day to a text string, and assign the sort value to zero.
+
+        An empty text carries no date information, so it is recorded as a
+        regular empty date (``MOD_NONE``) rather than a text-only date.  This
+        keeps the serialized form of an empty date canonical (bug 13744): a
+        missing and an empty Gramps-XML ``<datestr>`` then deserialize to the
+        same empty Date, and an empty date is never emitted as ``<datestr
+        val=""/>`` nor reported as an invalid date.
         """
-        self.modifier = Date.MOD_TEXTONLY
+        if text:
+            self.modifier = Date.MOD_TEXTONLY
+        else:
+            self.modifier = Date.MOD_NONE
+            self.dateval = Date.EMPTY
         self.text = text
         self.sortval = 0
 

--- a/gramps/gen/lib/test/date_test.py
+++ b/gramps/gen/lib/test/date_test.py
@@ -1758,6 +1758,60 @@ class EmptyDateTest(BaseDateTest):
         d.set(value=(1, 1, 1900, False, 1, 1, 1910, False), modifier=Date.MOD_SPAN)
         self.assertFalse(d.is_empty())
 
+    def test_set_as_text_empty_is_regular_empty(self):
+        """An empty text date is a regular empty date, not text-only.
+
+        bug 13744: a text-only date with empty text used to keep
+        ``MOD_TEXTONLY``, whose serialized form the Gramps-XML writer emits
+        as ``<datestr val=""/>`` (distinct from a missing element) and which
+        validation must not flag.
+        """
+        d = Date()
+        d.set_as_text("")
+        self.assertTrue(d.is_empty())
+        self.assertEqual(d.get_modifier(), Date.MOD_NONE)
+        self.assertTrue(d.get_valid())
+
+    def test_empty_text_date_serializes_canonically(self):
+        """An empty date has the canonical empty serialized form.
+
+        Equating its serialized tuple with a default (canonical) empty Date
+        is what makes a missing and an empty ``<datestr>`` equivalent: the
+        XML writer omits the element for this form (it is not
+        ``MOD_TEXTONLY``), so export/re-import round-trips to an empty date.
+        """
+        d = Date()
+        d.set_as_text("")
+        self.assertEqual(d.serialize(), Date().serialize())
+        self.assertNotEqual(d.get_modifier(), Date.MOD_TEXTONLY)
+
+    def test_empty_date_serialize_roundtrip_stable(self):
+        """serialize -> unserialize -> serialize is a stable empty date."""
+        d = Date()
+        d.set_as_text("")
+        once = d.serialize()
+        roundtrip = Date().unserialize(once)
+        self.assertTrue(roundtrip.is_empty())
+        self.assertNotEqual(roundtrip.get_modifier(), Date.MOD_TEXTONLY)
+        self.assertTrue(roundtrip.get_valid())
+        self.assertEqual(roundtrip.serialize(), once)
+
+    def test_set_text_only_with_empty_text_normalizes(self):
+        """set(MOD_TEXTONLY, text="") yields a regular empty date."""
+        d = Date()
+        d.set(modifier=Date.MOD_TEXTONLY, value=Date.EMPTY, text="")
+        self.assertTrue(d.is_empty())
+        self.assertEqual(d.get_modifier(), Date.MOD_NONE)
+        self.assertEqual(d.serialize(), Date().serialize())
+
+    def test_text_only_with_text_is_preserved(self):
+        """A genuine text-only date keeps MOD_TEXTONLY and its text."""
+        d = Date()
+        d.set_as_text("Christmas 1900")
+        self.assertEqual(d.get_modifier(), Date.MOD_TEXTONLY)
+        self.assertEqual(d.get_text(), "Christmas 1900")
+        self.assertFalse(d.is_empty())
+
 
 # -------------------------------------------------------------------------
 #


### PR DESCRIPTION
## Summary
**User impact:** A blank (empty) date could be saved to the Gramps XML family-tree file in a form that, when the file was loaded again, came back looking different from a genuinely blank date. The data-verification tool would then flag it as an invalid date, and the value did not survive a save-and-reload cleanly.

This makes an empty date always normalize to one canonical blank form, so it exports, re-imports, and verifies exactly like a date that was never filled in.

Reported in Mantis [#13744](https://gramps-project.org/bugs/view.php?id=13744).

## What to look at
The change normalizes any empty-text date to the canonical empty date at the two points where dates are set, so the XML writer omits the `<datestr>` element entirely (matching pre-6.0.0 behaviour) and the round-trip is stable. To try it: create or import an empty date, save the tree to Gramps XML, reload it, and run the data-verification tool — the date is no longer flagged, and `serialize → unserialize → serialize` returns the same canonical empty value.

## Root cause
An empty date can be stored as `MOD_TEXTONLY` with empty text — the path used by the XML reader (`gramps/plugins/importer/importxml.py:2774` → `Date.set_as_text("")`). The Gramps-XML writer emits a `MOD_TEXTONLY` date as `<datestr val="…"/>` (gramps/plugins/export/exportxml.py:1074), so an empty date serializes to `<datestr val=""/>` — distinct from the pre-6.0.0 form (missing element). On re-import, this reconstructs the non-canonical form, breaking the roundtrip invariant and causing validation to flag it as an invalid date (gramps/plugins/tool/verify.py:247–248).

## Fix
Normalize empty text to a canonical empty date (`MOD_NONE`, `dateval = Date.EMPTY`) at the two entry points in gramps/gen/lib/date.py:

- `set_as_text(text)` (line 1939): when `text` is empty, set `MOD_NONE` instead of `MOD_TEXTONLY`. This path is used by the XML reader, so it closes the deserialize side — an empty `<datestr val=""/>` now imports as canonical.
- `Date.set(...)` (line 1827): after setting text, if the result is `MOD_TEXTONLY` with empty text, normalize to `MOD_NONE`. This covers the editor's text-only path, closing the serialize/export side.

The XML writer already omits `<datestr>` for `MOD_NONE` dates with empty ISO start (gramps/plugins/export/exportxml.py:1052–1074), so an empty date now exports without the `<datestr>` element, matching pre-6.0.0 behavior. The roundtrip is stable: `serialize() → unserialize() → serialize()` returns the same canonical empty tuple.

## Verification
- **Claim:** an empty date normalizes to the canonical empty form (`MOD_NONE`, `Date.EMPTY`), so it exports without a `<datestr>` element, re-imports identically, and `serialize → unserialize → serialize` is stable.
- **Checked:** gramps/gen/lib/date.py:1827, 1939 on maintenance/gramps61 — empty-text normalization in `set` and `set_as_text`; imports pass (no syntax/lint errors) and black formatting is clean.
- **Test:** added to gramps/gen/lib/test/date_test.py (class `EmptyDateTest`, lines 1746–1799; no new file, so no po/POTFILES.* change). Tests exercise the production path (`Date.set_as_text`, `Date.set`, `Date.serialize`, `Date.unserialize`): `test_set_as_text_empty_is_regular_empty` — `set_as_text("")` yields `MOD_NONE`, empty, and valid; `test_empty_text_date_serializes_canonically` — an empty date's serialized tuple equals `Date().serialize()` (the missing ≡ empty equivalence; transitively ensures the writer omits the element); `test_empty_date_serialize_roundtrip_stable` — serialize → unserialize → serialize is stable and empty; `test_set_text_only_with_empty_text_normalizes` — `Date.set(MOD_TEXTONLY, text="")` also yields `MOD_NONE`; `test_text_only_with_text_is_preserved` — regression: a genuine text-only date (non-empty text) keeps `MOD_TEXTONLY` and its text. Red without fix: 4 assertion errors; green with fix: all 45 tests pass.

Fixes [#13744](https://gramps-project.org/bugs/view.php?id=13744)
