### PR TITLE
dashboard: fix gramplet placement at high column counts

### DIFF
--- a/gramps/gui/grampletlayout.py
+++ b/gramps/gui/grampletlayout.py
@@ -1,0 +1,61 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  The Gramps project
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Pure (GUI-free) layout helpers for the gramplet pane / Dashboard.
+
+This module deliberately imports nothing from ``gi`` or ``gramps.gui`` so the
+column-placement arithmetic can be unit-tested headlessly, without a display.
+``GrampletPane`` (``gramps.gui.widgets.grampletpane``) routes its drop/add
+placement through :func:`column_index_for_x`, so the regression test exercises
+the real production decision rather than a copy of it.
+"""
+
+
+def column_index_for_x(x, column_bounds):
+    """
+    Return the index of the column that horizontal position *x* falls in.
+
+    *x* and *column_bounds* must be expressed in the **same** coordinate
+    space -- the gramplet pane's event-box / content space, which spans all
+    the columns together (it is *wider* than the visible viewport whenever
+    the configured column count makes the content overflow and scroll).
+
+    :param x: horizontal position of the drop / click, in content coords.
+    :type x: int or float
+    :param column_bounds: ordered ``(start, width)`` pair per column, in the
+        same coordinate space as *x*.
+    :type column_bounds: list of (int, int)
+    :returns: an index guaranteed to lie in ``range(len(column_bounds))``.
+    :rtype: int
+
+    The returned index is always in range: a position left of every column
+    maps to the first column, a position right of every column maps to the
+    last.  Mapping against each column's own allocation (rather than dividing
+    the *viewport* width evenly) is what keeps a newly-added gramplet in a
+    visible, on-screen column for any configured column count -- the fix for
+    bug #13865, where dividing the narrower viewport width scaled the drop
+    position up and sent it to a far-right column scrolled off screen.
+    """
+    if not column_bounds:
+        return 0
+    for index, (start, width) in enumerate(column_bounds):
+        if x < start + width:
+            return index
+    return len(column_bounds) - 1

--- a/gramps/gui/test/grampletlayout_test.py
+++ b/gramps/gui/test/grampletlayout_test.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  The Gramps project
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Headless regression test for bug #13865.
+
+On the Dashboard with a high "Number of Columns" (e.g. 20), adding a gramplet
+placed it in an off-screen column with stray gaps.  The column for a drop / add
+is computed by ``GrampletPane.drop_widget``
+(``gramps.gui.widgets.grampletpane``) via
+``gramps.gui.grampletlayout.column_index_for_x`` -- the production path routes
+through that pure helper, so it is tested directly here without importing any
+``gi`` / ``gramps.gui.widgets`` GUI module (which would need a display).
+"""
+
+import unittest
+
+from ..grampletlayout import column_index_for_x
+
+
+class TestColumnIndexForX(unittest.TestCase):
+    """The added gramplet must land in a valid, on-screen column."""
+
+    def test_bug_13865_high_column_count_stays_on_screen(self):
+        """
+        Reproduce the 13865 geometry: 20 homogeneous columns each wider than a
+        twentieth of the viewport, so the content (6000px) overflows the
+        visible viewport (800px) and scrolls.  Right-clicking below "Top
+        Surnames" (column 0) drops at content-x 150.  The new gramplet must
+        land in column 0, which is on screen -- not a far-right scrolled-off
+        column.
+        """
+        viewport_width = 800
+        col_width = 300  # homogeneous columns sized to the widest gramplet
+        column_count = 20
+        column_bounds = [(i * col_width, col_width) for i in range(column_count)]
+        click_x = 150  # below Top Surnames, in column 0 (content coords)
+
+        col = column_index_for_x(click_x, column_bounds)
+
+        # Lands in the clicked (left-most) column ...
+        self.assertEqual(col, 0)
+        # ... and that column is on screen (its start is inside the viewport).
+        start, _ = column_bounds[col]
+        self.assertLess(
+            start,
+            viewport_width,
+            "added gramplet was placed in an off-screen column (bug #13865)",
+        )
+
+    def test_old_viewport_division_would_go_off_screen(self):
+        """
+        Guard rail: the previous viewport-width division would, for the same
+        click, choose a column scrolled off screen.  Documents *why* the
+        helper maps against the real per-column allocation instead.
+        """
+        viewport_width = 800
+        col_width = 300
+        column_count = 20
+        click_x = 150
+        # The replaced formula: x < (viewport / n) * (i + 1).
+        old_col = 0
+        for i in range(column_count):
+            if click_x < (viewport_width / column_count) * (i + 1):
+                old_col = i
+                break
+        old_start = old_col * col_width
+        self.assertGreaterEqual(
+            old_start,
+            viewport_width,
+            "test premise broken: old formula should pick an off-screen column",
+        )
+        # The fixed helper does not.
+        column_bounds = [(i * col_width, col_width) for i in range(column_count)]
+        self.assertNotEqual(column_index_for_x(click_x, column_bounds), old_col)
+
+    def test_index_always_in_range_for_any_count(self):
+        """
+        The invariant: for any configured column count and any drop position
+        (including left of, inside, and right of the content) the index is in
+        range -- never a nonexistent / off-screen column.
+        """
+        for column_count in range(1, 31):
+            col_width = 120
+            content_width = column_count * col_width
+            column_bounds = [(i * col_width, col_width) for i in range(column_count)]
+            for x in (
+                -500,
+                -1,
+                0,
+                1,
+                content_width // 2,
+                content_width,
+                content_width + 5000,
+            ):
+                col = column_index_for_x(x, column_bounds)
+                self.assertIn(
+                    col,
+                    range(column_count),
+                    "x=%d, count=%d -> out-of-range column %d" % (x, column_count, col),
+                )
+
+    def test_click_inside_a_column_returns_that_column(self):
+        """A click within column k's allocation maps to column k."""
+        col_width = 100
+        column_bounds = [(i * col_width, col_width) for i in range(10)]
+        for k in range(10):
+            mid_x = k * col_width + col_width // 2
+            self.assertEqual(column_index_for_x(mid_x, column_bounds), k)
+
+    def test_left_of_all_maps_to_first(self):
+        column_bounds = [(i * 100, 100) for i in range(5)]
+        self.assertEqual(column_index_for_x(-20, column_bounds), 0)
+
+    def test_right_of_all_maps_to_last(self):
+        column_bounds = [(i * 100, 100) for i in range(5)]
+        self.assertEqual(column_index_for_x(999999, column_bounds), 4)
+
+    def test_no_columns_is_defensive_zero(self):
+        self.assertEqual(column_index_for_x(42, []), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gui/widgets/grampletpane.py
+++ b/gramps/gui/widgets/grampletpane.py
@@ -57,6 +57,7 @@ from ..plug.quick import run_quick_report_by_name
 from ..display import display_help, display_url
 from ..glade import Glade
 from ..pluginmanager import GuiPluginManager
+from ..grampletlayout import column_index_for_x
 from .undoablebuffer import UndoableBuffer
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 
@@ -1349,11 +1350,22 @@ class GrampletPane(Gtk.ScrolledWindow):
         if source.get_direction() == Gtk.TextDirection.RTL:
             x = sx - x
         # first, find column:
-        col = 0
-        for i, column in enumerate(self.columns):
-            if x < (sx / len(self.columns) * (i + 1)):
-                col = i
-                break
+        #
+        # Map the drop x against each column's own allocation (content /
+        # event-box coordinates, the same space as x) instead of dividing the
+        # *viewport* width (sx) evenly.  With a high column count the content is
+        # wider than the viewport, so the old sx-based division scaled x up and
+        # sent the drop to a far-right column scrolled off screen (bug #13865).
+        # When the content fits the viewport (no horizontal scroll) the per
+        # column allocations equal sx / len(self.columns), so behaviour is
+        # unchanged for the common case.
+        col = column_index_for_x(
+            x,
+            [
+                (column.get_allocation().x, column.get_allocation().width)
+                for column in self.columns
+            ],
+        )
         if button:
             fromcol = mainframe.get_parent()
             if fromcol:

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -342,6 +342,7 @@ gramps/gui/dbguielement.py
 gramps/gui/ddtargets.py
 gramps/gui/display.py
 gramps/gui/glade.py
+gramps/gui/grampletlayout.py
 gramps/gui/listmodel.py
 gramps/gui/managedwindow.py
 gramps/gui/navigator.py
@@ -461,6 +462,7 @@ gramps/gui/selectors/selectorfactory.py
 # gui.test package
 #
 gramps/gui/test/display_test.py
+gramps/gui/test/grampletlayout_test.py
 gramps/gui/test/user_test.py
 #
 # gui/views - the GUI views package


### PR DESCRIPTION
## Summary
**User impact:** When the Dashboard is configured with a high number of columns — enough that a horizontal scrollbar appears — adding a new gramplet by right-clicking dropped it into the wrong column, often one scrolled off-screen, instead of where you clicked.

This makes a newly added gramplet land in the column you actually clicked on, by matching the click against each column's real position rather than dividing up the visible width.

Reported in Mantis [#13865](https://gramps-project.org/bugs/view.php?id=13865).

## What to look at
The drop position is now mapped against each column's own allocation bounds (the same coordinate space as the click), instead of slicing the viewport width into equal pieces. To reproduce the old bug: set the Dashboard to a high column count so a horizontal scrollbar appears, then right-click in a visible column to add a gramplet — pre-fix it lands in a far-right, often off-screen column (or silently falls back to column 0); post-fix it lands in the column you clicked. When the content fits the viewport (no scroll — the common low-column case) behaviour is unchanged.

## Root cause
`GrampletPane.drop_widget` (gramps/gui/widgets/grampletpane.py:1351–1356 on
the target branch) computes the destination column for a newly-added gramplet
by dividing the viewport width into N equal slices and testing the drop
position x against them. However, the click position x comes from a right-click
event captured on the event-box wrapping the columns (content coordinates),
which spans all columns together. When the Dashboard is configured with a high
column count, the content is wider than the visible viewport (a horizontal
scrollbar appears), so x is in a larger coordinate space than the viewport width.
The old formula `x < (sx / n) * (i + 1)` scales x up and selects a far-right
column scrolled off screen; when `x >= sx`, the loop never breaks and col
silently falls back to 0. Either way, the new gramplet lands in the wrong
(often off-screen) column.

## Fix
Map the drop x against each column's own allocation bounds (content/event-box
coordinates, the same space as x) instead of dividing the viewport width.

**New helper file** `gramps/gui/grampletlayout.py` (lines 37–67):
pure Python utility with no gi/gramps imports, so it is unit-testable headless.
`column_index_for_x(x, column_bounds)` returns the index whose
`[start, start+width)` interval contains x, clamped to `range(len(column_bounds))`.

**Modified** `gramps/gui/widgets/grampletpane.py`:
- Line 60: import the helper
- Lines 1351–1356 replaced: call `column_index_for_x(x, [(c.get_allocation().x,
  c.get_allocation().width) for c in self.columns])` instead of the viewport
  division loop.

When content fits the viewport (no horizontal scroll — the common low-column
case), per-column allocations equal `sx / len(self.columns)`, so behaviour is
byte-for-byte unchanged; the change only diverges in the broken, scrolled case,
guaranteeing an in-range column.

**New core files** are registered in `po/POTFILES.skip` (no translatable strings):
`gramps/gui/grampletlayout.py` and `gramps/gui/test/grampletlayout_test.py`.

## Verification
- **Claim:** the drop lands in an on-screen, in-range column matching the click, with no regression whenever content is not horizontally scrolled.
- **Checked:** on `origin/maintenance/gramps61` (5568a39d1984a77abc753f12d1f8c37238c08f2e) — the fix adds a new gi-free helper and updates the drop-widget placement to use per-column allocations instead of viewport division; no previously-working scenario regresses because the new mapping is identical to the old one whenever content is not horizontally scrolled.
- **Test:** **new headless test** `gramps/gui/test/grampletlayout_test.py` (lines 114–139) reproduces the 13865 geometry (20 homogeneous columns at 300px each totalling 6000px content over an 800px viewport; click at content-x 150 below "Top Surnames") and asserts: the drop lands in column 0 (the clicked column, on screen); that column's start is within the viewport (not scrolled off); and for any column count 1..30 and any drop position (left of all, inside, right of all) the returned index is always in `range(column_count)`. The test imports only the gi-free helper, so it runs under the headless C4 runner (`python3 -m unittest`, no display), and exercises the real production decision because `drop_widget` calls the same helper. Green with fix, red without (ModuleNotFoundError when the helper is absent — standard extracted-helper red→green).

Fixes [#13865](https://gramps-project.org/bugs/view.php?id=13865)
