### PR TITLE
Add image source option to genealogytree Tree reports

### DIFF
--- a/gramps/gen/plug/docgen/test/treedoc_test.py
+++ b/gramps/gen/plug/docgen/test/treedoc_test.py
@@ -1,0 +1,162 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Unit tests for the image-source option of
+``gramps.gen.plug.docgen.treedoc`` (bug 0013888).
+
+Since PR 1620 (core commit 7335883f68) the genealogytree (Tree) reports
+embed only cached thumbnails. This adds a user-selectable ``images``
+option restoring the pre-1620 full-resolution emission as an opt-in, and
+- when a thumbnail is used - annotates the node with the original
+filename as a LaTeX comment so the ``.tex`` stays identifiable.
+
+These tests drive the production ``TreeDocBase.write_node`` path (via the
+concrete ``TreeGraphDoc`` subclass and a real options menu built by
+``TreeOptions``) and assert both branches:
+
+* ``images = "original"`` -> ``image = {<original media path>}`` and no
+  ``% original image:`` comment;
+* ``images = "thumbnail"`` (default) -> the cached-thumbnail path (not the
+  original) plus a ``% original image: <path>`` comment naming the source.
+
+Import-safety
+-------------
+This module imports no GUI toolkit at load time, and the thumbnail case
+replaces ``get_thumbnail_path`` (an unchanged collaborator that would,
+when run for real, load thumbnailer plugins and transitively a Gtk widget
+that aborts a headless interpreter) with a stub. The branch routing and
+the comment emission under test remain the production ``write_node`` code;
+only the thumbnail *path source* is stubbed, so the test exercises the
+real code path while staying safe under the plain headless C4 runner.
+"""
+
+import base64
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from gramps.gen.lib import Media, MediaRef, Person
+from gramps.gen.plug.menu import Menu
+from gramps.gen.plug.docgen.treedoc import TreeGraphDoc, TreeOptions
+
+# A minimal valid 1x1 PNG so the on-disk media file is a real image.
+_PNG_1x1 = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mN"
+    "kYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+)
+
+
+class _StubDb:
+    """Just enough database surface for ``write_node`` to resolve one
+    image media reference. ``media_path_full`` is given an absolute path,
+    so the media base path is never consulted."""
+
+    def __init__(self, media):
+        self._media = media
+
+    def get_media_from_handle(self, _handle):
+        return self._media
+
+
+class WriteNodeImageSourceTest(unittest.TestCase):
+    """Exercise the production ``write_node`` image-source branches."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.image_path = os.path.join(self._tmp.name, "portrait.png")
+        with open(self.image_path, "wb") as handle:
+            handle.write(_PNG_1x1)
+        # A stand-in for the cached thumbnail get_thumbnail_path would
+        # return: a real file (so write_node's os.path.isfile check passes)
+        # whose path is distinct from the original.
+        self.thumb_path = os.path.join(self._tmp.name, "thumb_deadbeef.png")
+        with open(self.thumb_path, "wb") as handle:
+            handle.write(_PNG_1x1)
+
+        media = Media()
+        media.set_path(self.image_path)
+        media.set_mime_type("image/png")
+
+        mediaref = MediaRef()
+        mediaref.set_reference_handle("media-handle")
+
+        self.person = Person()
+        self.person.gramps_id = "I0001"
+        self.person.gender = Person.MALE
+        self.person.add_media_reference(mediaref)
+
+        self.db = _StubDb(media)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _make_doc(self, images_value):
+        """Build a real options menu, select the image source, and return
+        a concrete TreeDocBase instance (production wiring)."""
+        menu = Menu()
+        TreeOptions().add_menu_options(menu)
+        menu.get_option_by_name("images").set_value(images_value)
+
+        class _Options:
+            pass
+
+        options = _Options()
+        options.menu = menu
+        return TreeGraphDoc(options, None)
+
+    def _render(self, images_value):
+        """Run the production write_node, stubbing the (unchanged) thumbnail
+        generator so the test stays headless-safe and deterministic."""
+        doc = self._make_doc(images_value)
+        with mock.patch(
+            "gramps.gen.utils.thumbnails.get_thumbnail_path",
+            return_value=self.thumb_path,
+        ):
+            doc.write_node(self.db, 0, "child", self.person, False)
+        return doc._tex.getvalue()
+
+    def test_default_is_thumbnail(self):
+        """The option defaults to today's behaviour (PR 1620 preserved)."""
+        doc = self._make_doc("thumbnail")
+        self.assertEqual(doc.images, "thumbnail")
+
+    def test_original_emits_full_resolution_path(self):
+        """``original`` restores the pre-1620 emission: the full media
+        path, with no thumbnail comment."""
+        tex = self._render("original")
+        self.assertIn("image = {%s}," % self.image_path, tex)
+        self.assertNotIn("original image:", tex)
+
+    def test_thumbnail_emits_thumbnail_path_and_comment(self):
+        """``thumbnail`` emits the cached-thumbnail path (not the original)
+        and a ``% original image:`` comment naming the source file."""
+        tex = self._render("thumbnail")
+
+        # The embedded image is the thumbnail, not the original.
+        self.assertIn("image = {%s}," % self.thumb_path, tex)
+        self.assertNotIn("image = {%s}," % self.image_path, tex)
+
+        # The original file stays recorded as an inert LaTeX comment.
+        self.assertIn("%% original image: %s" % self.image_path, tex)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gen/plug/docgen/treedoc.py
+++ b/gramps/gen/plug/docgen/treedoc.py
@@ -68,6 +68,11 @@ _DETAIL = [
     {"name": _("Short"), "value": "short"},
 ]
 
+_IMAGES = [
+    {"name": _("Thumbnails (smaller PDF)"), "value": "thumbnail"},
+    {"name": _("Original images (full resolution)"), "value": "original"},
+]
+
 _NAME_FORMAT = [
     {"name": _("Given Nickname Surname"), "value": "1"},
     {"name": _("Surname Given Nickname"), "value": "2"},
@@ -167,6 +172,7 @@ class TreeOptions:
     def __init__(self):
         # Node Options
         self.detail = None
+        self.images = None
         self.marriage = None
         self.nodesize = None
         self.levelsize = None
@@ -200,6 +206,19 @@ class TreeOptions:
         detail.set_help(_("Detail of information to be shown in a node."))
         menu.add_option(category, "detail", detail)
         self.detail = detail
+
+        images = EnumeratedListOption(_("Images"), "thumbnail")
+        for item in _IMAGES:
+            images.add_item(item["value"], item["name"])
+        images.set_help(
+            _(
+                "Whether to embed the cached thumbnail (smaller PDF) or the "
+                "original full-resolution image (larger, but standalone and "
+                "print quality). The original is the pre-Gramps 5.1 behaviour."
+            )
+        )
+        menu.add_option(category, "images", images)
+        self.images = images
 
         name_format = EnumeratedListOption(_("Name Format"), "1")
         for item in _NAME_FORMAT:
@@ -377,6 +396,7 @@ class TreeDocBase(BaseDoc, TreeDoc):
         get_option = options.menu.get_option_by_name
 
         self.detail = get_option("detail").get_value()
+        self.images = get_option("images").get_value()
         self.name_format = get_option("name_format").get_value()
         self.preferred_name = get_option("preferred_name").get_value()
         self.marriage = get_option("marriage").get_value()
@@ -593,13 +613,22 @@ class TreeDocBase(BaseDoc, TreeDoc):
         for mediaref in person.get_media_list():
             media = db.get_media_from_handle(mediaref.ref)
             if media.get_mime_type().startswith("image"):
-                path = get_thumbnail_path(
-                    media_path_full(db, media.get_path()),
-                    rectangle=mediaref.get_rectangle(),
-                )
+                original = media_path_full(db, media.get_path())
+                if self.images == "original":
+                    # Pre-PR-1620 behaviour: embed the full-resolution image.
+                    path = original
+                else:
+                    path = get_thumbnail_path(
+                        original,
+                        rectangle=mediaref.get_rectangle(),
+                    )
                 if os.path.isfile(path):
                     if win():
                         path = path.replace("\\", "/")
+                    if self.images != "original":
+                        # Record the source file so the cached thumbnail's
+                        # hash filename stays identifiable in the .tex.
+                        self.write(level + 1, "%% original image: %s\n" % original)
                     self.write(level + 1, "image = {%s},\n" % path)
                     break  # first image only
         self.write(level, "}\n")

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -240,6 +240,7 @@ gramps/gen/plug/docgen/textdoc.py
 #
 gramps/gen/plug/docgen/test/__init__.py
 gramps/gen/plug/docgen/test/graphdoc_test.py
+gramps/gen/plug/docgen/test/treedoc_test.py
 #
 # gen.plug.menu
 #


### PR DESCRIPTION
## Summary
**User impact:** When you make a genealogy Tree chart report, the photos in it come out low-quality (small thumbnails), and there is no way to get full-resolution pictures — the generated files also carry machine-specific thumbnail filenames that make them hard to share or identify. This affects anyone who wants print-quality images in a Tree report.

This adds a user-selectable option to choose full-resolution original images instead of the cached thumbnails.

Reported in Mantis [#13888](https://gramps-project.org/bugs/view.php?id=13888).

## What to look at
The change adds an "Images" choice to the Tree report's Node Options: thumbnails (default, smaller PDF) or original full-resolution images. To try it: generate a genealogytree Tree report, find the new Images option, switch it to "Original images (full resolution)", and confirm the output uses the full-size photos; with the default, the output uses thumbnails but records the original path in a LaTeX comment so the `.tex` stays identifiable.

## Root cause
Since PR 1620 (core commit 7335883f68), Tree reports embed only cached thumbnails to avoid unreasonably large PDFs and LaTeX parser failures on special-character paths. However, this reduced image quality (3–12 kB thumbnails vs 500 kB–2 MB originals) and machine-tied filenames make the generated `.tex` files non-standalone and unidentifiable.

## Fix
This adds a user-selectable `images` option to `gramps/gen/plug/docgen/treedoc.py` allowing users to choose between cached thumbnails (default, preserving PR 1620) and original full-resolution images (pre-1620 behaviour, now opt-in).

**Changes in `gramps/gen/plug/docgen/treedoc.py`:**

- New `_IMAGES` constant (around line 65) defining two items: `"thumbnail"` (default, _("Thumbnails (smaller PDF)")) and `"original"` (_("Original images (full resolution)")).
- `TreeOptions.__init__` (line 169): Add `self.images = None` alongside `self.detail`.
- `TreeOptions.add_menu_options` (line 201): Add `EnumeratedListOption("Images", "thumbnail")` in the Node Options category, immediately after the detail option, with help text explaining the size/standalone trade-off.
- `TreeDocBase.__init__` (line 379): Read the option with `self.images = get_option("images").get_value()`.
- `write_node` (line 593–604): Compute the full media path once, then branch on `self.images`:
  - When `"original"`: emit the full-resolution path (pre-1620 behaviour).
  - When `"thumbnail"` (default): emit the cached thumbnail path plus a LaTeX comment `% original image: <path>` so the `.tex` stays identifiable.

**Changes in `po/POTFILES.skip`:**

- Register the new test file `gramps/gen/plug/docgen/test/treedoc_test.py` in the `gen.plug.docgen.test` section (line 241), as a test with no translatable strings.

## Verification
- **Claim:** users can opt into full-resolution original images in Tree reports, with cached thumbnails (the PR 1620 safe behaviour) remaining the default.
- **Checked:** on `maintenance/gramps61` — `gramps/gen/plug/docgen/treedoc.py:65-69` (`_IMAGES` defines both items, defaults to thumbnail), `:169` (`self.images` initialized in `TreeOptions.__init__`), `:201-202` (option added to Node Options after detail, translatable label + help), `:379` (`self.images` fetched in `TreeDocBase.__init__`), `:593-604` (`write_node` branches: full path when `"original"`, thumbnail path + `% original image:` comment when `"thumbnail"`); `po/POTFILES.skip:241` registers the new test.
- **Test:** `gramps/gen/plug/docgen/test/treedoc_test.py` (new) — drives the production `write_node` path via a real `TreeOptions` menu, a concrete `TreeGraphDoc` subclass, a stub database and a media reference. Asserts `original` → `.tex` contains `image = {<original media path>}` with no `% original image:` comment; `thumbnail` (default) → `.tex` contains `image = {<cached thumbnail path>}` (not the original) plus a `% original image: <original path>` comment. It stubs `get_thumbnail_path` (an unchanged collaborator that would load Gtk in the headless runner) while keeping branch routing and comment emission in production code. Green-with-fix / red-without-fix on clean upstream (both the option and the branching logic are required).

cc @hgohel — this reconciles the requirements outlined in 13888 as left over (PR 1620 safety with user opt-in for original resolution + identifiability), defaulting to the current safe behaviour. I don't have arzdev's github handle and am also not 100% sure this is exactly what you had discussed, so I'd appreciate some feedback here.

Fixes [#13888](https://gramps-project.org/bugs/view.php?id=13888)
