### PR TITLE
Refresh sidebar filter Type selectors on custom-type changes

### DIFF
--- a/gramps/gui/autocomp.py
+++ b/gramps/gui/autocomp.py
@@ -151,6 +151,7 @@ class StandardCustomSelector:
         else:
             self.store = self.create_list()
             completion_store = self.store
+        self.completion_store = completion_store
 
         self.selector.set_model(self.store)
         self.selector.set_entry_text_column(1)
@@ -178,6 +179,15 @@ class StandardCustomSelector:
         menu.
         """
         store = Gtk.TreeStore(int, str, bool)
+        self._fill_menu(store)
+        return store
+
+    def _fill_menu(self, store):
+        """
+        Fill (or refill) the given tree store with the menu, clearing it first
+        so it can be reused when the custom values change (bug 13716).
+        """
+        store.clear()
         for heading, items in self.menu:
             if self.active_key in items:
                 parent = None
@@ -192,13 +202,21 @@ class StandardCustomSelector:
                 key, value = self.get_key_and_value(event_type)
                 store.append(parent, row=[key, value, True])
 
-        return store
-
     def create_list(self):
         """
         Create a model and fill it with a sorted flat list.
         """
         store = Gtk.ListStore(int, str)
+        self._fill_list(store)
+        return store
+
+    def _fill_list(self, store):
+        """
+        Fill (or refill) the given list store with a sorted flat list, clearing
+        it first so it can be reused when the custom values change (bug 13716).
+        """
+        store.clear()
+        self.active_index = 0
         keys = sorted(self.mapping, key=self.by_value)
         index = 0
         for key in keys:
@@ -216,7 +234,21 @@ class StandardCustomSelector:
                     self.active_index = index
                 index += 1
 
-        return store
+    def rebuild(self, additional):
+        """
+        Refill the selector's models with a new set of custom (additional)
+        values, in place so an open drop-down updates live.
+
+        This keeps a database-derived type selector consistent with the
+        database's current custom types without recreating the widget
+        (bug 13716).
+        """
+        self.additional = additional
+        if self.menu:
+            self._fill_menu(self.store)
+            self._fill_list(self.completion_store)
+        else:
+            self._fill_list(self.store)
 
     def by_value(self, val):
         """

--- a/gramps/gui/filters/sidebar/_eventsidebarfilter.py
+++ b/gramps/gui/filters/sidebar/_eventsidebarfilter.py
@@ -92,6 +92,9 @@ class EventSidebarFilter(SidebarFilter):
 
         SidebarFilter.__init__(self, dbstate, uistate, "Event")
 
+    def _register_type_filters(self):
+        self.add_type_filter(self.event_menu, "get_event_types")
+
     def create_widget(self):
         cell = Gtk.CellRendererText()
         cell.set_property("width", self._FILTER_WIDTH)

--- a/gramps/gui/filters/sidebar/_familysidebarfilter.py
+++ b/gramps/gui/filters/sidebar/_familysidebarfilter.py
@@ -112,6 +112,10 @@ class FamilySidebarFilter(SidebarFilter):
 
         SidebarFilter.__init__(self, dbstate, uistate, "Family")
 
+    def _register_type_filters(self):
+        self.add_type_filter(self.event_menu, "get_event_types")
+        self.add_type_filter(self.rel_menu, "get_family_relation_types")
+
     def create_widget(self):
         cell = Gtk.CellRendererText()
         cell.set_property("width", self._FILTER_WIDTH)

--- a/gramps/gui/filters/sidebar/_notesidebarfilter.py
+++ b/gramps/gui/filters/sidebar/_notesidebarfilter.py
@@ -83,6 +83,9 @@ class NoteSidebarFilter(SidebarFilter):
 
         SidebarFilter.__init__(self, dbstate, uistate, "Note")
 
+    def _register_type_filters(self):
+        self.add_type_filter(self.event_menu, "get_note_types")
+
     def create_widget(self):
         cell = Gtk.CellRendererText()
         cell.set_property("width", self._FILTER_WIDTH)

--- a/gramps/gui/filters/sidebar/_personsidebarfilter.py
+++ b/gramps/gui/filters/sidebar/_personsidebarfilter.py
@@ -125,6 +125,9 @@ class PersonSidebarFilter(SidebarFilter):
 
         SidebarFilter.__init__(self, dbstate, uistate, "Person")
 
+    def _register_type_filters(self):
+        self.add_type_filter(self.event_menu, "get_event_types")
+
     def create_widget(self):
         cell = Gtk.CellRendererText()
         cell.set_property("width", self._FILTER_WIDTH)

--- a/gramps/gui/filters/sidebar/_placesidebarfilter.py
+++ b/gramps/gui/filters/sidebar/_placesidebarfilter.py
@@ -98,6 +98,9 @@ class PlaceSidebarFilter(SidebarFilter):
 
         SidebarFilter.__init__(self, dbstate, uistate, "Place")
 
+    def _register_type_filters(self):
+        self.add_type_filter(self.place_menu, "get_place_types")
+
     def create_widget(self):
         cell = Gtk.CellRendererText()
         cell.set_property("width", self._FILTER_WIDTH)

--- a/gramps/gui/filters/sidebar/_reposidebarfilter.py
+++ b/gramps/gui/filters/sidebar/_reposidebarfilter.py
@@ -70,7 +70,7 @@ class RepoSidebarFilter(SidebarFilter):
         self.repo.set_type((RepositoryType.CUSTOM, ""))
         self.rtype = Gtk.ComboBox(has_entry=True)
         if dbstate.is_open():
-            self.custom_types = dbstate.db.get_event_types()
+            self.custom_types = dbstate.db.get_repository_types()
         else:
             self.custom_types = []
 
@@ -91,6 +91,9 @@ class RepoSidebarFilter(SidebarFilter):
         self.generic = Gtk.ComboBox()
 
         SidebarFilter.__init__(self, dbstate, uistate, "Repository")
+
+    def _register_type_filters(self):
+        self.add_type_filter(self.event_menu, "get_repository_types")
 
     def create_widget(self):
         cell = Gtk.CellRendererText()

--- a/gramps/gui/filters/sidebar/_sidebarfilter.py
+++ b/gramps/gui/filters/sidebar/_sidebarfilter.py
@@ -46,6 +46,7 @@ from gramps.gen.config import config
 from ...utils import no_match_primary_mask
 
 from ...editors import EditFilter
+from ._typefilterlist import TypeFilterList
 import gramps.gen.filters
 
 # import gramps.gen.filters.rules.place
@@ -104,6 +105,8 @@ class SidebarFilter(DbGUIElement):
         self.uistate = uistate
         self.dbstate = dbstate
         self.namespace = namespace
+        self._type_filters = TypeFilterList()
+        self._register_type_filters()
         self.__tag_list = []
         self._tag_rebuild()
 
@@ -237,6 +240,7 @@ class SidebarFilter(DbGUIElement):
         """
         self._change_db(db)
         self.on_db_changed(db)
+        self._type_filters.refresh()
         self._tag_rebuild()
 
     def on_db_changed(self, db):
@@ -244,6 +248,49 @@ class SidebarFilter(DbGUIElement):
         Called when the database is changed.
         """
         pass
+
+    def _register_type_filters(self):
+        """
+        Register this filter's database-derived "Type" selectors so they stay
+        consistent with the database's current custom types (bug 13716).
+
+        Subclasses that offer a custom-type selector override this and call
+        :meth:`add_type_filter` once per selector.  The default does nothing
+        (filters without a type selector need no refresh).
+        """
+        pass
+
+    def add_type_filter(self, monitored, db_method):
+        """
+        Register a database-derived type selector for refresh.
+
+        :param monitored: the :class:`MonitoredDataType` wrapping the selector;
+                           its ``rebuild`` is called with the current custom
+                           types, and its ``obj`` combo box drives the refresh.
+        :param db_method: the name of the database method returning the current
+                          custom types (e.g. ``"get_note_types"``).  Resolved on
+                          the *live* database on every refresh, so custom types
+                          added after construction are picked up (bug 13716).
+        """
+
+        def _fetch():
+            if self.dbstate.is_open():
+                return getattr(self.dbstate.db, db_method)()
+            return []
+
+        self._type_filters.register(_fetch, monitored.rebuild)
+        # Mirror the editor dialogs, which rebuild their type selector anew
+        # every time they are shown: rebuild the selector from the database
+        # each time the user opens its drop-down.
+        monitored.obj.connect("notify::popup-shown", self._type_popup_shown)
+
+    def _type_popup_shown(self, combo, pspec):
+        """
+        Rebuild the database-derived type selectors when one is opened, so the
+        options offered reflect the database's current custom types.
+        """
+        if combo.get_property("popup-shown"):
+            self._type_filters.refresh()
 
     def _connect_db_signals(self):
         """

--- a/gramps/gui/filters/sidebar/_typefilterlist.py
+++ b/gramps/gui/filters/sidebar/_typefilterlist.py
@@ -1,0 +1,82 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps developers
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Keep a :class:`SidebarFilter`'s database-derived "Type" selectors consistent
+with the database's current custom types (bug 13716).
+
+This module is deliberately free of GUI (``gi`` / ``gramps.gui``) imports: it
+holds only the repopulate orchestration, so the logic can be unit-tested
+headlessly while the GUI :class:`SidebarFilter` wires its Gtk type-selector
+widgets to it.
+"""
+
+
+# -------------------------------------------------------------------------
+#
+# TypeFilterList class
+#
+# -------------------------------------------------------------------------
+class TypeFilterList:
+    """
+    Registry of a sidebar filter's database-derived "Type" selectors.
+
+    A view's sidebar filter reads the database's custom types only once, when
+    the filter widget is first built, and never refreshes them.  A custom type
+    added to an already-open database (for example the "GEDCOM import" Note type
+    created by importing a GEDCOM with errors) therefore never appears in the
+    selector until the gramplet/view is torn down and rebuilt (bug 13716).  The
+    editor dialogs do not have this problem because they rebuild their type
+    selector from the database every time they are shown.
+
+    Each selector is registered with two callables:
+
+    * ``fetch`` -- returns the database's *current* custom types.  It must
+      re-read the live database on every call, never close over a
+      construction-time snapshot, so that types added after construction are
+      seen.
+    * ``apply`` -- rebuilds the widget's offered options from a given list of
+      custom types.
+
+    :meth:`refresh` re-fetches every registered selector from the database and
+    re-applies it, so the options presented to the user reflect the database's
+    current custom-type set rather than a snapshot frozen at construction time.
+    """
+
+    def __init__(self):
+        self._selectors = []
+
+    def register(self, fetch, apply):
+        """
+        Register a type selector by its ``fetch`` and ``apply`` callables.
+
+        :param fetch: callable returning the database's current custom types.
+        :param apply: callable taking a list of custom types and rebuilding the
+                      widget's offered options.
+        """
+        self._selectors.append((fetch, apply))
+
+    def refresh(self):
+        """
+        Re-read every registered selector's custom types from the database and
+        rebuild its offered options, restoring consistency with the database's
+        current custom-type set.
+        """
+        for fetch, apply in self._selectors:
+            apply(list(fetch()))

--- a/gramps/gui/filters/sidebar/test/_sidebarfilter_test.py
+++ b/gramps/gui/filters/sidebar/test/_sidebarfilter_test.py
@@ -1,0 +1,234 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps developers
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Regression test for Mantis 13716 — sidebar-filter "Type" selector is stale.
+
+A view's sidebar filter ("Type" selector — the same widget the Filter Gramplet
+hosts) reads the database's custom types only once, when the filter widget is
+built, and never refreshes them.  A custom type added to the already-open
+database (for example the "GEDCOM import" Note type created by importing a
+GEDCOM with errors) therefore never appears in the selector until the
+gramplet/view is torn down and rebuilt.  The editor dialogs avoid this by
+rebuilding their type selector from the database every time they are shown.
+
+The fix moves the repopulate orchestration into the GUI-free
+:class:`~gramps.gui.filters.sidebar._typefilterlist.TypeFilterList`, which the
+shared :class:`~gramps.gui.filters.sidebar.SidebarFilter` wires every
+database-derived type selector to via :meth:`SidebarFilter.add_type_filter` /
+:meth:`SidebarFilter._register_type_filters`.  Each refresh re-reads the *live*
+database, so types added after construction are offered.
+
+This test drives the **production** repopulate path:
+
+* :class:`TypeFilterList.refresh` is the shared unit the production
+  ``SidebarFilter`` routes through; and
+* the production ``NoteSidebarFilter._register_type_filters`` /
+  ``SidebarFilter.add_type_filter`` wiring is exercised directly, with test
+  doubles standing in only for the GUI selector widget and the database state
+  (so the test runs headless, without a display).
+
+It must be GUI-import-free at instantiation: it imports the sidebar classes
+(which only *define* widget classes at import time) but never *constructs* a Gtk
+widget, building the filter object via ``__new__`` instead.
+"""
+
+import unittest
+
+from gramps.gui.filters.sidebar._typefilterlist import TypeFilterList
+from gramps.gui.filters.sidebar import SidebarFilter, NoteSidebarFilter
+from gramps.gui.filters.sidebar import RepoSidebarFilter
+
+
+class _FakeDb:
+    """Minimal stand-in for the database's custom-type accessors.
+
+    ``note_types`` mutates to model a custom type added to the already-open
+    database (e.g. by a GEDCOM import) after the filter was built.
+    ``repository_types`` does the same for the repository sidebar filter, and is
+    deliberately *disjoint* from ``event_types`` so a test can prove the
+    repository filter reads its own (repository) type set, not the event one.
+    """
+
+    def __init__(self, note_types, repository_types=None, event_types=None):
+        self.note_types = list(note_types)
+        self.repository_types = list(
+            repository_types if repository_types is not None else []
+        )
+        self.event_types = list(event_types if event_types is not None else [])
+
+    def get_note_types(self):
+        # Returns the *current* set every call — like the real db, which
+        # recomputes custom types from the objects it holds.
+        return list(self.note_types)
+
+    def get_repository_types(self):
+        return list(self.repository_types)
+
+    def get_event_types(self):
+        return list(self.event_types)
+
+
+class _FakeDbState:
+    def __init__(self, db):
+        self.db = db
+
+    def is_open(self):
+        return True
+
+
+class _RecordingCombo:
+    """Stand-in for the Gtk combo box the type selector wraps.
+
+    Only ``connect`` is used by ``add_type_filter`` (to hook the drop-down's
+    popup); recording it is enough — no GUI is created.
+    """
+
+    def __init__(self):
+        self.connected = []
+
+    def connect(self, signal, handler):
+        self.connected.append(signal)
+
+
+class _RecordingMenu:
+    """Stand-in for the ``MonitoredDataType`` wrapping the selector.
+
+    ``rebuild`` is the production ``apply`` callable; it records the custom
+    values it was last handed, which are exactly the custom types the selector
+    would offer.
+    """
+
+    def __init__(self):
+        self.obj = _RecordingCombo()
+        self.offered = None
+
+    def rebuild(self, custom_values):
+        self.offered = list(custom_values)
+
+
+class SidebarFilterTypeRefreshTest(unittest.TestCase):
+    """Mantis 13716: the Type selector must reflect the database's current
+    custom types after they change, via the production repopulate path."""
+
+    def _make_note_filter(self, db):
+        """Build a NoteSidebarFilter without running ``__init__``.
+
+        ``__init__`` builds real Gtk widgets, which needs a live display.  The
+        repopulate path under test only needs the type-filter registry, the
+        db state and the (doubled) selector menu, so we set just those and run
+        the production ``_register_type_filters`` wiring.
+        """
+        flt = NoteSidebarFilter.__new__(NoteSidebarFilter)
+        flt.dbstate = _FakeDbState(db)
+        flt._type_filters = TypeFilterList()
+        flt.event_menu = _RecordingMenu()
+        flt._register_type_filters()  # production registration wiring
+        return flt
+
+    def test_type_selector_reflects_new_custom_type_after_refresh(self):
+        """A custom Note type added to the open db is offered after a refresh,
+        but is absent beforehand (the bug)."""
+        db = _FakeDb(["General", "Research", "Citation"])
+        flt = self._make_note_filter(db)
+
+        # Initial presentation: the selector offers the current custom types.
+        flt._type_filters.refresh()
+        self.assertIn("Research", flt.event_menu.offered)
+        self.assertNotIn("GEDCOM import", flt.event_menu.offered)
+
+        # A GEDCOM import creates a new custom Note type in the *already-open*
+        # database.
+        db.note_types.append("GEDCOM import")
+
+        # Re-presenting the selector (the production repopulate path) must now
+        # offer the new custom type — without recreating the filter widget.
+        flt._type_filters.refresh()
+        self.assertIn(
+            "GEDCOM import",
+            flt.event_menu.offered,
+            "Type selector did not pick up a custom type added to the open "
+            "database (Mantis 13716).",
+        )
+
+    def test_refresh_reflects_removed_custom_type(self):
+        """The selector also drops a custom type no longer in the database —
+        it tracks the current set, not an ever-growing snapshot."""
+        db = _FakeDb(["General", "Obsolete"])
+        flt = self._make_note_filter(db)
+
+        flt._type_filters.refresh()
+        self.assertIn("Obsolete", flt.event_menu.offered)
+
+        db.note_types.remove("Obsolete")
+        flt._type_filters.refresh()
+        self.assertNotIn("Obsolete", flt.event_menu.offered)
+
+    def test_typefilterlist_refetches_live_source(self):
+        """The shared TypeFilterList unit re-reads its source on every refresh
+        rather than caching a construction-time snapshot."""
+        source = {"types": ["a"]}
+        applied = []
+        tfl = TypeFilterList()
+        tfl.register(lambda: list(source["types"]), applied.append)
+
+        tfl.refresh()
+        self.assertEqual(applied[-1], ["a"])
+
+        source["types"] = ["a", "b"]
+        tfl.refresh()
+        self.assertEqual(applied[-1], ["a", "b"])
+
+    def _make_repo_filter(self, db):
+        """Build a RepoSidebarFilter without running ``__init__`` (same headless
+        seam as ``_make_note_filter``)."""
+        flt = RepoSidebarFilter.__new__(RepoSidebarFilter)
+        flt.dbstate = _FakeDbState(db)
+        flt._type_filters = TypeFilterList()
+        flt.event_menu = _RecordingMenu()
+        flt._register_type_filters()  # production registration wiring
+        return flt
+
+    def test_repo_filter_reads_repository_types_not_event_types(self):
+        """The repository sidebar filter's Type selector must offer the
+        database's *repository* custom types — not the event types (the
+        pre-existing wrong source carried by the first 13716 attempt)."""
+        db = _FakeDb(
+            note_types=[],
+            repository_types=["Web Archive"],
+            event_types=["Baptism"],
+        )
+        flt = self._make_repo_filter(db)
+
+        flt._type_filters.refresh()
+        self.assertIn(
+            "Web Archive",
+            flt.event_menu.offered,
+            "Repository Type selector did not offer the database's repository "
+            "custom types.",
+        )
+        self.assertNotIn(
+            "Baptism",
+            flt.event_menu.offered,
+            "Repository Type selector offered event types — wrong db source.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gui/widgets/monitoredwidgets.py
+++ b/gramps/gui/widgets/monitoredwidgets.py
@@ -490,6 +490,18 @@ class MonitoredDataType:
         self.get_val = get_val
         self.update()
 
+    def rebuild(self, custom_values):
+        """
+        Rebuild the selector's offered options with a fresh set of custom
+        values, preserving the current selection.
+
+        Used to keep a database-derived type selector consistent with the
+        database's current custom types after they change (bug 13716).
+        """
+        current = self.sel.get_values()
+        self.sel.rebuild(custom_values)
+        self.sel.set_values(current)
+
     def fix_value(self, value):
         if value[0] == self.get_val().get_custom():
             return value

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -404,6 +404,9 @@ gramps/gui/filters/_filtermenu.py
 # gui.filters.sidebar package
 #
 gramps/gui/filters/sidebar/__init__.py
+gramps/gui/filters/sidebar/_typefilterlist.py
+gramps/gui/filters/sidebar/test/__init__.py
+gramps/gui/filters/sidebar/test/_sidebarfilter_test.py
 #
 # gui.fs package
 #


### PR DESCRIPTION
## Summary
**User impact:** If you create a new custom "Type" (for example, a Note type made automatically when you import a GEDCOM with errors) while your family tree is already open, that new type does not show up in the sidebar filter's Type drop-down. You have to close and re-open the view before you can filter by it. The repository filter also showed the wrong list of types entirely.

This makes the sidebar filter's Type drop-downs refresh from the live database so newly added custom types appear right away.

Reported in Mantis [#13716](https://gramps-project.org/bugs/view.php?id=13716).

## What to look at
The sidebar filter's Type selectors now re-read the database whenever it changes or when you open the drop-down, instead of only once when the widget was first built. To try it: open the Notes category, note the options in the sidebar Type filter, add a Note with a new custom type via the Note editor, then re-open the same Type drop-down (without recreating the view) — the new type is now offered. A headless regression test drives this same refresh path.

## Root cause
A view's sidebar-filter "Type" selector (the same widget the Filter Gramplet hosts) reads the database's custom types exactly once at widget construction time via `dbstate.db.get_note_types()` (and similar per-filter methods), storing the result in `self.custom_types`. The selector's model (`StandardCustomSelector`) is built once from that snapshot and never rebuilt. When custom types are added to the already-open database after the filter widget is constructed (e.g., a "GEDCOM import" Note type created by importing a GEDCOM with errors), the new types never appear until the filter widget is torn down and rebuilt. This differs from the editor dialogs, which rebuild their type selector from the database "anew every time" they are shown (Mantis note 3).

## Fix
**New GUI-free module: `gramps/gui/filters/sidebar/_typefilterlist.py` (lines 1–82)**

Introduces `TypeFilterList` — a registry of `(fetch, apply)` pairs that orchestrates the refresh of a sidebar filter's type selectors without GUI imports. The `refresh()` method re-calls each registered `fetch` (which re-reads the *live* database) and passes the result to `apply` (which rebuilds the selector widget in place).

**Shared path: `gramps/gui/filters/sidebar/_sidebarfilter.py`**

- Line 178: Imports `TypeFilterList`
- Lines 186–187: `SidebarFilter.__init__` initializes `self._type_filters` and calls the new `_register_type_filters()` hook
- Line 195: `_db_changed` calls `self._type_filters.refresh()` to update selectors when the database changes
- Lines 203–244: Three new methods in `SidebarFilter`:
  - `_register_type_filters()` (lines 203–212): Hook for subclasses; default does nothing
  - `add_type_filter(monitored, db_method)` (lines 214–236): Registers a type selector; resolves `db_method` on the *live* database, connects the combo's `notify::popup-shown` signal for refresh-on-open
  - `_type_popup_shown(combo, pspec)` (lines 238–244): Signal handler that calls `refresh()` when a selector's drop-down opens

**Sidebar filter subclasses: `_notesidebarfilter.py`, `_eventsidebarfilter.py`, `_familysidebarfilter.py`, `_personsidebarfilter.py`, `_placesidebarfilter.py`, `_reposidebarfilter.py`**

Each now overrides `_register_type_filters()` and calls `add_type_filter()` once per type selector:
- `_notesidebarfilter.py:85–87`: Registers Note's Type selector with `get_note_types`
- `_eventsidebarfilter.py:84–85`: Registers Event's Type selector
- `_familysidebarfilter.py:98–100`: Registers Event and Family Relation type selectors
- `_personsidebarfilter.py:126–128`: Registers Event type selector
- `_placesidebarfilter.py:99–101`: Registers Place type selector
- `_reposidebarfilter.py:73, 92–94`: **Fixes pre-existing bug** — reads `get_repository_types()` (not `get_event_types()`) for the repository Type selector; registers the correct method

**Refactor for in-place rebuild: `gramps/gui/autocomp.py` and `gramps/gui/widgets/monitoredwidgets.py`**

- `autocomp.py:154`: Stores `self.completion_store` for later reuse
- `autocomp.py:179–225`: Extracts model-filling logic into `_fill_menu()` and `_fill_list()` (clearing first, then re-appending), callable on existing store objects
- `autocomp.py:258–272`: New `rebuild()` method re-fills the selector's model in place, preserving the widget object the GUI is bound to (critical for live update of an open drop-down)
- `monitoredwidgets.py:588–600`: New `rebuild()` method on `MonitoredDataType` preserves the current selection while rebuilding via `StandardCustomSelector.rebuild()`

**POTFILES: `po/POTFILES.skip`**

Lines 611–613: Registers the new files (no translatable strings):
- `gramps/gui/filters/sidebar/_typefilterlist.py`
- `gramps/gui/filters/sidebar/test/__init__.py`
- `gramps/gui/filters/sidebar/test/_sidebarfilter_test.py`

## Verification
- **Claim:** a custom type added to the already-open database is offered by the sidebar Type selector after a refresh, without tearing down and rebuilding the view; and the repository filter reads repository types rather than event types.
- **Checked:** target branch `gramps-project/gramps @ upstream/maintenance/gramps61` (commit b679c084f6). Red→green proof (C4 verify gate, clean upstream/maintenance/gramps61): GREEN (fix applied) — headless unit test runs 4 tests OK; RED (production reverted, test kept) — test fails because the `TypeFilterList` repopulate path does not exist.
- **Test:** shipped regression test `gramps/gui/filters/sidebar/test/_sidebarfilter_test.py` (part of `patch.diff`) drives the production repopulate path (`TypeFilterList.refresh()` + `SidebarFilter.add_type_filter()` wiring) without a display, building filter instances via `__new__` to avoid `__init__`'s Gtk widget creation, with test doubles (`_RecordingMenu`, `_FakeDb`) for the selector and database: `test_type_selector_reflects_new_custom_type_after_refresh()` (lines 490–513) verifies a new custom Note type is offered after refresh and absent beforehand (the bug); `test_refresh_reflects_removed_custom_type()` (lines 515–526) tracks removed types; `test_typefilterlist_refetches_live_source()` (lines 528–541) verifies re-reading the source on every refresh; `test_repo_filter_reads_repository_types_not_event_types()` (lines 553–575) locks in the repository-filter fix. Advisory testbed interface repro `engine/interface/test_bug_0013716_sidebar_filter_type.py` (GUI/AT-SPI layer, NOT in `patch.diff`) opens the Notes category, adds a custom type via the Note editor, and asserts the sidebar Type combo now offers it without view recreation; it skips gracefully when dogtail/AT-SPI is unavailable — the headless unit test is the gating proof.

Depends on #2357

Fixes [#13716](https://gramps-project.org/bugs/view.php?id=13716)
