### PR TITLE
Fix LaTeX docgen picture-width TypeError when emitting table cells

### DIFF
--- a/gramps/plugins/docgen/latexdoc.py
+++ b/gramps/plugins/docgen/latexdoc.py
@@ -846,7 +846,7 @@ class LaTeXDoc(BaseDoc, TextDoc):
                         "".join(
                             (
                                 "\\setlength{\\grpictsize}{",
-                                self.pict_width,
+                                repr(self.pict_width),
                                 "\\grbaseindent}%\n",
                             )
                         )

--- a/gramps/plugins/docgen/test/latexdoc_test.py
+++ b/gramps/plugins/docgen/test/latexdoc_test.py
@@ -18,12 +18,26 @@
 #
 
 """
-Unittest for the LaTeX docgen multicolumn counter (bug 13418).
+Unittests for the LaTeX docgen: the multicolumn counter (bug 13418) and
+the picture-in-table width emission (bug 11166).
 """
 
+import os
+import tempfile
 import unittest
+from unittest import mock
 
-from gramps.plugins.docgen.latexdoc import str_incr, MULTCOL_COUNT_BASE
+from gramps.gen.plug.docgen import (
+    PaperSize,
+    PaperStyle,
+    PAPER_PORTRAIT,
+    ParagraphStyle,
+    StyleSheet,
+    TableCellStyle,
+    TableStyle,
+)
+from gramps.plugins.docgen import latexdoc
+from gramps.plugins.docgen.latexdoc import LaTeXDoc, str_incr, MULTCOL_COUNT_BASE
 
 
 # ------------------------------------------------------------
@@ -56,6 +70,83 @@ class StrIncrTest(unittest.TestCase):
         counter = str_incr("az")
         self.assertEqual(next(counter), "az")
         self.assertEqual(next(counter), "ba")  # full carry
+
+
+# ------------------------------------------------------------
+#
+# LaTeXPictureInTableTest
+#
+# ------------------------------------------------------------
+class LaTeXPictureInTableTest(unittest.TestCase):
+    """
+    A table that contains a picture cell (e.g. the Complete Individual
+    Report with "Add Pictures" enabled) drives
+    :meth:`LaTeXDoc.calc_latex_widths`, which emits the
+    ``\\setlength{\\grpictsize}`` command. Before the fix it joined the
+    numeric ``self.pict_width`` straight into that LaTeX string, so the
+    report crashed with::
+
+        TypeError: sequence item 1: expected str instance, float found
+
+    The two sibling emission sites (``repack_row`` and the cell emit)
+    already stringify the width with ``repr``; this exercises the third
+    one through the real doc API so it stays consistent (bug 11166).
+
+    ``add_media`` only produces a clean ``\\grmkpicture`` picture cell
+    (the one that reaches the crash site) when Pillow is available — the
+    condition on the affected user's machine. The image extra is not part
+    of the unit-test environment, so ``HAVE_PIL`` is forced on to
+    reproduce it; a ``.jpg`` source means the production code never
+    actually calls into Pillow (it skips conversion for an already-jpg
+    input), so no real Pillow install is needed.
+    """
+
+    def _make_doc(self, path):
+        """Build a LaTeXDoc with the minimal styles its API needs."""
+        styles = StyleSheet()
+        styles.add_paragraph_style("Default", ParagraphStyle())
+
+        table = TableStyle()
+        table.set_width(100)
+        table.set_columns(1)
+        table.set_column_widths([100])
+        styles.add_table_style("PictureTable", table)
+
+        styles.add_cell_style("PictureCell", TableCellStyle())
+
+        paper = PaperStyle(PaperSize("Letter", 27.94, 21.59), PAPER_PORTRAIT)
+        doc = LaTeXDoc(styles, paper)
+        doc.open(path)
+        return doc
+
+    def test_picture_cell_emits_without_typeerror(self):
+        """end_table()->calc_latex_widths() must stringify the picture width."""
+        with tempfile.TemporaryDirectory() as tmp:
+            doc = self._make_doc(os.path.join(tmp, "report"))
+            doc.start_table("table", "PictureTable")
+            doc.start_row()
+            doc.start_cell("PictureCell")
+            # Emulate the affected environment (Pillow present). The .jpg input
+            # makes add_media skip conversion, so Pillow is never actually
+            # invoked — but the cell becomes a clean \grmkpicture cell and
+            # self.pict_width is set to the (float) width, exactly as in the
+            # Complete Individual Report with "Add Pictures" enabled.
+            with mock.patch.object(latexdoc, "HAVE_PIL", True):
+                doc.add_media(os.path.join(tmp, "image.jpg"), "single", 5.0, 4.0)
+            doc.end_cell()
+            doc.end_row()
+            # Sanity: the cell really is the picture cell that reaches the crash
+            # site, and the width is the bare float that triggered it.
+            cell = doc.tabmem.rows[0].cells[0]
+            self.assertTrue(cell.content.startswith("\\grmkpicture"))
+            self.assertIsInstance(doc.pict_width, float)
+            try:
+                # Before the fix this raises:
+                #   TypeError: sequence item 1: expected str instance, float found
+                doc.end_table()
+            except TypeError as err:
+                self.fail("LaTeX picture-in-table emission raised TypeError: %s" % err)
+            doc.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
**User impact:** Trying to produce a report in LaTeX format that puts a picture inside a table cell fails outright — the report crashes instead of generating. Anyone using the LaTeX output with images in tables hits this.

This makes the LaTeX output render the picture width as text so the report generates without crashing.

Reported in Mantis [#11166](https://gramps-project.org/bugs/view.php?id=11166).

## What to look at
The whole change is one place where a numeric picture width was being joined into LaTeX markup without being turned into text first, which two sibling code paths already did correctly. To try it: generate a LaTeX-format report containing a table with an image cell — it now completes instead of raising a `TypeError`. A new regression test drives the real table+picture path.

## Root cause
`LaTeXDoc.calc_latex_widths` builds the `\setlength{\grpictsize}` LaTeX command with `"".join((...))` over a tuple of fragments; one fragment is the bare numeric `self.pict_width` (a float) instead of its text form. Because `str.join()` requires every item to be a `str`, emitting a picture cell raises `TypeError: sequence item 1: expected str instance, float found`.

The two sibling emission sites already stringify the width consistently with `repr()`, but `calc_latex_widths` was the odd one out.

## Fix
**gramps/plugins/docgen/latexdoc.py:849** — wrap `self.pict_width` in `repr()` so the numeric value is rendered as text in the LaTeX markup, matching the two sibling emission sites at :804 and :1235.

**gramps/plugins/docgen/test/latexdoc_test.py** — extend the existing docgen test suite with `LaTeXPictureInTableTest`, which drives the production `LaTeXDoc` table+picture path via the real API (`start_table` → `start_row` → `start_cell` → `add_media` → `end_cell` → `end_row` → `end_table`) and asserts the emit raises no `TypeError`.

## Verification
- **Claim:** emitting a picture cell in a LaTeX table no longer raises `TypeError`; the picture width is stringified with `repr()` consistently with the two sibling emission sites.
- **Checked:** on `maintenance/gramps61` — `gramps/plugins/docgen/latexdoc.py:804` (`repack_row` already uses `repr(self.pict_width)`) and `:1235` (cell emit also uses `repr(self.pict_width)`), matching the fix at `:849`; `:703` shows `pict_width` initialized as `0` (int), set to numeric width `x` at `:1455`, confirming the value is always numeric at emission.
- **Test:** `gramps/plugins/docgen/test/latexdoc_test.py::LaTeXPictureInTableTest::test_picture_cell_emits_without_typeerror` — builds a one-column table through the real `LaTeXDoc` API with a picture cell (`add_media` with float width 5.0), then asserts `end_table()` (which calls `calc_latex_widths`) raises no `TypeError`. It forces `HAVE_PIL = True` via `mock.patch.object` to reproduce the affected environment; a `.jpg` input makes production skip actual image conversion, so no Pillow install is exercised. Without the fix the test fails with the exact `TypeError: sequence item 1: expected str instance, float found` at line 846; with the fix all three tests (the two pre-existing `StrIncr` tests for bug 13418 plus the new picture test) pass. The pre-existing `StrIncrTest` is preserved alongside the new case.

Fixes [#11166](https://gramps-project.org/bugs/view.php?id=11166)
