### PR TITLE
Fix media path whitespace stripping in XML export

### DIFF
--- a/gramps/plugins/export/exportxml.py
+++ b/gramps/plugins/export/exportxml.py
@@ -1392,7 +1392,7 @@ class GrampsXmlWriter(UpdateCallback):
             '%s<file src="%s" mime="%s"%s%s/>\n'
             % (
                 "  " * (index + 1),
-                self.fix(path),
+                libgrampsxml.fix_media_path(path),
                 self.fix(mime_type),
                 checksum_text,
                 desc_text,

--- a/gramps/plugins/export/test/exportxml_mediapath_test.py
+++ b/gramps/plugins/export/test/exportxml_mediapath_test.py
@@ -1,0 +1,103 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps developers
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+
+"""
+Regression test for bug 6698: Gramps-XML export must NOT strip significant
+leading/trailing whitespace from a media object's path.
+
+The path written into ``<file src="...">`` has to stay byte-for-byte equal to
+the name the package archiver stores the media file under
+(``exportpkg.py``: ``archname = str(mobject.get_path())``). When the serializer
+stripped the path, a filename with a leading space (e.g. ``" image.png"``)
+produced a ``<file src>`` value the archive did not contain, so the media showed
+as "missing" on re-import.
+
+The unit under test is ``libgrampsxml.fix_media_path`` -- the *production* path
+serializer that ``exportxml.GrampsXmlWriter.write_media`` routes the path
+through. It lives in an import-light module (no ``gi`` / ``gramps.gui``), so this
+test runs headless without crashing. A source-level guard asserts the export
+plugin actually uses it for the ``<file src>`` attribute, so the test exercises
+the real path rather than a parallel copy of it.
+"""
+
+import os
+import unittest
+
+from gramps.plugins.lib.libgrampsxml import fix_media_path
+
+
+class FixMediaPathTest(unittest.TestCase):
+    """The media-path serializer must preserve significant whitespace."""
+
+    def test_leading_space_preserved(self):
+        """A leading space (the reporter's case) survives serialization."""
+        path = " image.png"
+        self.assertEqual(fix_media_path(path), " image.png")
+
+    def test_trailing_space_preserved(self):
+        path = "image.png "
+        self.assertEqual(fix_media_path(path), "image.png ")
+
+    def test_interior_and_surrounding_whitespace_preserved(self):
+        path = "  my photos/holiday 2020 .png "
+        self.assertEqual(fix_media_path(path), "  my photos/holiday 2020 .png ")
+
+    def test_plain_path_unchanged(self):
+        path = "images/photo.png"
+        self.assertEqual(fix_media_path(path), path)
+
+    def test_matches_archiver_name_for_space_leading_path(self):
+        """
+        The serialized <file src> value (for a path with no XML-special chars)
+        must equal the archiver's archname == str(media.get_path()), restoring
+        the bug-6698 invariant that the XML points at the archived/on-disk name.
+        """
+        path = " example.png"
+        archname = str(path)  # exportpkg.py: archname = str(mobject.get_path())
+        self.assertEqual(fix_media_path(path), archname)
+
+    def test_control_chars_removed_but_whitespace_kept(self):
+        """XML-illegal control chars are still dropped; whitespace is not."""
+        self.assertEqual(fix_media_path(" a\x01b.png"), " ab.png")
+
+    def test_xml_metacharacters_escaped(self):
+        """A path round-trips faithfully: metachars escape, value preserved."""
+        self.assertEqual(fix_media_path(" a&b.png"), " a&amp;b.png")
+        self.assertEqual(fix_media_path(" a<b>.png"), " a&lt;b&gt;.png")
+
+    def test_export_plugin_routes_path_through_fix_media_path(self):
+        """
+        Guard: the production export plugin must serialize the <file src> path
+        via fix_media_path (not the whitespace-stripping self.fix), so this unit
+        test covers the real export path. Checked at source level because
+        exportxml imports gramps.gui at load time and cannot be imported in the
+        headless test runner.
+        """
+        here = os.path.dirname(os.path.abspath(__file__))
+        exportxml = os.path.join(os.path.dirname(here), "exportxml.py")
+        with open(exportxml, encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertIn(
+            "fix_media_path(path)",
+            source,
+            "exportxml.py must serialize the media path with fix_media_path",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/plugins/lib/libgrampsxml.py
+++ b/gramps/plugins/lib/libgrampsxml.py
@@ -20,6 +20,7 @@
 # python modules
 #
 # ------------------------------------------------------------------------
+from xml.sax.saxutils import escape
 
 # ------------------------------------------------------------------------
 #
@@ -34,3 +35,29 @@
 # ------------------------------------------------------------------------
 GRAMPS_XML_VERSION_TUPLE = (1, 7, 2)  # version for Gramps 6.0
 GRAMPS_XML_VERSION = ".".join(str(i) for i in GRAMPS_XML_VERSION_TUPLE)
+
+# table for skipping control chars from XML except 09, 0A, 0D
+_STRIP_DICT = dict.fromkeys(list(range(9)) + list(range(11, 13)) + list(range(14, 32)))
+
+
+def fix_media_path(path):
+    """
+    Serialize a media object's path for the XML ``<file src="...">`` attribute.
+
+    Unlike the general free-text serializer (``exportxml.fix``), this MUST NOT
+    strip leading or trailing whitespace: whitespace is significant in a
+    filename and the package archiver stores the media file under the
+    un-stripped ``str(media.get_path())`` (see ``exportpkg.py``). Stripping it
+    here makes the ``<file src>`` value disagree with the archived/on-disk name,
+    so the media can no longer be located on re-import (bug 6698). XML-illegal
+    control characters are still removed and XML metacharacters escaped, so the
+    attribute value round-trips back to the exact stored path on parse.
+    """
+    return escape(
+        str(path).translate(_STRIP_DICT),
+        {
+            '"': "&quot;",
+            "<": "&lt;",
+            ">": "&gt;",
+        },
+    )

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -566,6 +566,7 @@ gramps/plugins/export/__init__.py
 # plugins/export/test directory
 #
 gramps/plugins/export/test/exportvcard_test.py
+gramps/plugins/export/test/exportxml_mediapath_test.py
 #
 # plugins/gramplet directory
 #


### PR DESCRIPTION
## Summary
**User impact:** If a photo or document in your family tree has a file path with a leading or trailing space, exporting to Gramps XML and then re-importing shows that media as "missing" — the picture is lost on the round-trip even though the file is right there in the archive.

This makes the XML export keep the exact media path (spaces included) so it matches the stored file name and the media re-imports correctly.

Reported in Mantis [#6698](https://gramps-project.org/bugs/view.php?id=6698).

## What to look at
The export was running media paths through a general text-cleaner that trims whitespace, but the archiver stores the file under the un-trimmed name — so the two disagreed. The fix routes media paths through a new path-specific serializer that keeps whitespace while still stripping illegal characters and escaping XML metacharacters. To try it: give a media object a path with a leading/trailing space, export to a Gramps package, re-import, and confirm the media is found rather than reported missing.

## Root cause
The XML export serializer (`exportxml.py:1395`) routes media paths through `self.fix(path)`, which strips leading and trailing whitespace via `.strip()`. However, the package archiver (`exportpkg.py:192`) stores the media file under the un-stripped name (`archname = str(mobject.get_path())`), so the `<file src>` attribute disagrees with the archived filename, causing media to show as "missing" on re-import.

## Fix
Adds a dedicated `fix_media_path(path)` function to `libgrampsxml.py` that preserves whitespace while still removing XML-illegal control characters (via `_STRIP_DICT`) and escaping XML metacharacters (`&`, `<`, `>`) so the attribute value round-trips correctly on parse. Updates `exportxml.py:1395` to use this path-specific serializer instead of the general free-text `fix()` function, whose `.strip()` behavior is appropriate for descriptive fields but not for paths. Registers the new test in `po/POTFILES.skip`.

## Verification
- **Claim:** the exported `<file src>` path preserves leading/trailing/interior whitespace (so it equals the archived file name) while still removing control characters and escaping XML metacharacters.
- **Checked:** on `maintenance/gramps61` — `gramps/plugins/export/exportxml.py:1395` (media path now serialized via `libgrampsxml.fix_media_path(path)` instead of `self.fix(path)`); `gramps/plugins/lib/libgrampsxml.py:37` end of module, where the import and new function are added (lines 22, 32–55); `gramps/plugins/export/exportpkg.py:192` (archiver stores file as `archname = str(mobject.get_path())`, confirming the invariant that `<file src>` must equal the archived name); `po/POTFILES.skip:568` where the new test registration goes (line +569).
- **Test:** `gramps/plugins/export/test/exportxml_mediapath_test.py` (new regression test) exercises the production path serializer (`libgrampsxml.fix_media_path`) directly, ensuring it preserves leading/trailing/interior whitespace while still removing control chars and escaping XML metacharacters. It includes a source-level guard verifying the export plugin actually routes the `<file src>` path through the new serializer (covering the real export path, not a parallel reimplementation). The old behavior is confirmed caught: `fix(" image.png")` → `"image.png"` (stripped), differing from the preserved path, making the whitespace assertions genuine regressions.

Fixes [#6698](https://gramps-project.org/bugs/view.php?id=6698)
