### PR TITLE
Test: regression guard for citation-less sources in Citation Tree View

### DIFF
--- a/gramps/gui/views/treemodels/test/citationtreemodel_test.py
+++ b/gramps/gui/views/treemodels/test/citationtreemodel_test.py
@@ -1,0 +1,126 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps developers
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Regression test for :class:`CitationTreeModel` — bug 0007230.
+
+Bug 7230 reported that in the Citation Tree View a source with **no
+citations** did not appear in the tree at all: a freshly created,
+citation-less source was invisible and hard to manage.
+
+The tree model now uses a two-cursor ``has_secondary=True`` design.  The
+*primary* cursor iterates **all** sources (``get_source_cursor`` /
+``get_number_of_sources``) and :meth:`CitationTreeModel.add_row` adds each
+one as a top-level node, while the *secondary* citation cursor only adds
+citation children.  Under that design every source is a parent node whether
+or not any citation references it.
+
+This test drives the **production** model build against an in-memory
+database holding one cited source and one citation-less source, and asserts
+that *both* sources exist as top-level nodes — the citation-less one with no
+children.  It is a guard against a regression to the pre-fix behaviour where
+sources were only materialised as a side effect of iterating citations.
+
+The model is built with ``uistate=None``: for a tiny database the loading
+``ProgressMonitor`` never reaches its popup threshold, so no GTK dialog (and
+no display) is required and the test runs headless.
+"""
+
+import unittest
+
+import gi  # noqa: E402
+
+gi.require_version("Gtk", "3.0")  # noqa: E402
+
+from gramps.gen.db import DbTxn  # noqa: E402
+from gramps.gen.db.utils import make_database  # noqa: E402
+from gramps.gen.lib import Citation, Source  # noqa: E402
+
+from ..citationtreemodel import CitationTreeModel  # noqa: E402
+
+
+class CitationTreeModelEmptySourceTest(unittest.TestCase):
+    """Bug 0007230 regression: every source is a top-level node."""
+
+    def setUp(self):
+        """Create an in-memory db with a cited and a citation-less source."""
+        self.db = make_database("sqlite")
+        self.db.load(":memory:")
+        with DbTxn("setup", self.db) as trans:
+            # A source that *is* referenced by a citation.
+            cited = Source()
+            cited.set_title("Cited Source")
+            self.cited_handle = self.db.add_source(cited, trans)
+
+            citation = Citation()
+            citation.set_reference_handle(self.cited_handle)
+            citation.set_page("p. 1")
+            self.citation_handle = self.db.add_citation(citation, trans)
+
+            # A brand-new source with no citations at all (the bug case).
+            lonely = Source()
+            lonely.set_title("Lonely Source")
+            self.lonely_handle = self.db.add_source(lonely, trans)
+
+    def tearDown(self):
+        self.db.close()
+
+    def _build_model(self):
+        # search=(False, None, False) is the "no filter, no search" tuple the
+        # view passes for an unfiltered tree; uistate=None is safe headless
+        # (see module docstring).
+        return CitationTreeModel(self.db, uistate=None, search=(False, None, False))
+
+    def _top_level_handles(self, model):
+        top = model.tree[None]
+        return {model.nodemap.node(nodeid).handle for _, nodeid in top.children}
+
+    def test_citationless_source_is_a_top_level_node(self):
+        """A source with zero citations must still be a top-level node."""
+        model = self._build_model()
+        top_handles = self._top_level_handles(model)
+
+        # The core assertion of bug 7230: the citation-less source appears.
+        self.assertIn(
+            self.lonely_handle,
+            top_handles,
+            "a source with no citations is missing from the Citation Tree View",
+        )
+        # It is present as a parent node with no children.
+        self.assertEqual(model.tree[self.lonely_handle].children, [])
+
+    def test_every_source_is_listed_independent_of_citations(self):
+        """Both the cited and the citation-less source are top-level nodes."""
+        model = self._build_model()
+        top_handles = self._top_level_handles(model)
+
+        self.assertIn(self.cited_handle, top_handles)
+        self.assertIn(self.lonely_handle, top_handles)
+
+        # The citation is a child of its source, not a top-level node.
+        self.assertNotIn(self.citation_handle, top_handles)
+        cited_children = {
+            model.nodemap.node(nodeid).handle
+            for _, nodeid in model.tree[self.cited_handle].children
+        }
+        self.assertEqual(cited_children, {self.citation_handle})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -481,6 +481,7 @@ gramps/gui/views/treemodels/sourcemodel.py
 #
 # gui.views.treemodels.test package
 #
+gramps/gui/views/treemodels/test/citationtreemodel_test.py
 gramps/gui/views/treemodels/test/node_test.py
 gramps/gui/views/treemodels/test/treebasemodel_test.py
 #


### PR DESCRIPTION
## Summary
**User impact:** A source that has no citations attached to it used to vanish from the Citation Tree View — you could not see it or select it there, even though it exists in your tree. This is a guard against that bug ever coming back.

This PR adds a regression test that confirms every source shows up in the Citation Tree View, whether or not it has any citations.

Reported in Mantis [#7230](https://gramps-project.org/bugs/view.php?id=7230).

## What to look at
No production code changes — the defect is already fixed on the target branch. The test drives the real `CitationTreeModel` against an in-memory database holding both a cited source and a citation-less source, and confirms both appear as top-level nodes. To try it manually: create a source with no citations and confirm it still appears in the Citation Tree View.

## Root cause
The original 2013 defect (bug 7230) existed because the CitationTreeModel used a single-cursor design where sources were only materialized as a side effect of iterating citations — a source with no citations never got a node. The current `maintenance/gramps61` tree model has been refactored to use a two-cursor `has_secondary=True` design, which decouples source visibility from citation count.

## Fix
No production code change is required — the defect is already fixed. This PR ships a regression test (`gramps/gui/views/treemodels/test/citationtreemodel_test.py`) that drives the **production** `CitationTreeModel.__init__` against an in-memory database holding both a cited source and a citation-less source, and verifies that both appear as top-level nodes. The test is registered in `po/POTFILES.skip` per the translation-file conventions.

## Verification
- **Claim:** every source is listed as a top-level node in the Citation Tree View independent of its citation count.
- **Checked:** on `maintenance/gramps61`:
  - `gramps/gui/views/treemodels/citationtreemodel.py:83-85` — the primary cursor binding (`number_items` / `map` / `gen_cursor` to `get_number_of_sources` / `get_raw_source_data` / `get_source_cursor`); sources are enumerated independent of citations.
  - `gramps/gui/views/treemodels/citationtreemodel.py:192-200` — `add_row` adds **every** source as a top-level node unconditionally (`self.add_node(None, handle, sort_key, handle)`), with no dependence on citation count.
  - `gramps/gui/views/treemodels/citationtreemodel.py:202-224` — the secondary citation cursor only adds citation *children* via `add_row2`; the else-branch defensively back-fills sources only if the primary cursor failed (now unreachable).
- **Test:** `gramps/gui/views/treemodels/test/citationtreemodel_test.py` (new) — `test_citationless_source_is_a_top_level_node` verifies a source with zero citations is present as a top-level node with no children; `test_every_source_is_listed_independent_of_citations` verifies both a cited and a citation-less source appear as top-level nodes with the citation as a *child* of its source. Runs headless with `uistate=None`. This is a test-only change for an already-fixed defect: red→green cannot run because there is no production line whose removal re-hides the source (reverting `po/POTFILES.skip` alone leaves the test green). It ships as a durable guard against a future regression to the pre-refactor coupling.

Fixes [#7230](https://gramps-project.org/bugs/view.php?id=7230)

