### PR TITLE
Accept mixed-case GEDCOM date qualifiers (CAL/EST/INT)

### DIFF
--- a/gramps/plugins/importer/test/importgedcom_caldate_test.py
+++ b/gramps/plugins/importer/test/importgedcom_caldate_test.py
@@ -1,0 +1,135 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Mantis 8850 — GEDCOM date qualifiers (CAL/EST/INT) recognised case-insensitively.
+
+GEDCOM 5.5.1 specifies the approximate-date qualifier keywords ``CAL``
+(calculated), ``EST`` (estimated) and ``INT`` (interpreted) in uppercase,
+but real-world exporters emit them in mixed case (``2 DATE Cal 1847``).
+libgedcom's ``MOD`` regex used to be case-sensitive, so ``Cal``/``Est``/
+``Int`` never matched: the qualifier was left unrecognised and the value
+passed through as a literal text (``MOD_TEXTONLY``) date, which the
+Verify-the-Data tool then flags.  The same value in all-caps imported
+correctly as a Calculated date.
+
+These tests drive the real GEDCOM importer (``import_as_dict`` ->
+``libgedcom``) and assert that mixed-case qualifiers resolve to the right
+:class:`~gramps.gen.lib.date.Date` quality with the year parsed — matching
+the all-uppercase behaviour — rather than falling back to a text date.
+"""
+
+import os
+import tempfile
+import unittest
+
+from gramps.cli.user import User as CliUser
+from gramps.gen.db.utils import import_as_dict
+from gramps.gen.lib.date import Date
+
+# Each individual carries a birth DATE using a qualifier keyword in a
+# different case.  "Upper" is the all-uppercase control that already
+# worked; the mixed-case variants are the regression cases.  Distinct
+# surnames let the test key on the name instead of an importer-assigned
+# gramps_id (whose padded format, e.g. ``I0001``, is configuration-driven).
+GEDCOM_FIXTURE = """\
+0 HEAD
+1 SOUR Mantis 8850 fixture
+1 GEDC
+2 VERS 5.5.1
+2 FORM LINEAGE-LINKED
+1 CHAR UTF-8
+1 SUBM @SUBM@
+0 @SUBM@ SUBM
+1 NAME Bug 8850 fixture
+0 @I1@ INDI
+1 NAME Mixed /Calc/
+1 SEX M
+1 BIRT
+2 DATE Cal 1847
+0 @I2@ INDI
+1 NAME Mixed /Esti/
+1 SEX F
+1 BIRT
+2 DATE Est 1850
+0 @I3@ INDI
+1 NAME Mixed /Inte/
+1 SEX U
+1 BIRT
+2 DATE Int 1852
+0 @I4@ INDI
+1 NAME Upper /Calc/
+1 SEX M
+1 BIRT
+2 DATE CAL 1847
+0 TRLR
+"""
+
+
+class GedcomCalDateCaseInsensitiveTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        fd, cls.path = tempfile.mkstemp(suffix=".ged", text=True)
+        with os.fdopen(fd, "w") as f:
+            f.write(GEDCOM_FIXTURE)
+        # A plain CLI user that swallows callbacks; import_as_dict needs a
+        # User.  Same construction as importgedcom_ambiguous_date_test.py.
+        user = CliUser(callback=lambda *a, **k: None)
+        cls.db = import_as_dict(cls.path, user)
+        assert cls.db is not None, "import_as_dict returned None — import failed"
+        # Map "<First> <Surname>" -> imported birth Date, so lookups do not
+        # depend on the importer's gramps_id padding format.
+        cls.dates = {}
+        for person in cls.db.iter_people():
+            name = person.get_primary_name()
+            key = "%s %s" % (name.get_first_name(), name.get_surname())
+            birth_ref = person.get_birth_ref()
+            assert birth_ref is not None, "%s has no birth ref" % key
+            event = cls.db.get_event_from_handle(birth_ref.ref)
+            cls.dates[key] = event.get_date_object()
+
+    @classmethod
+    def tearDownClass(cls):
+        os.unlink(cls.path)
+
+    def _assert_qualified(self, key, expected_qual, year):
+        self.assertIn(key, self.dates, "person %s not imported" % key)
+        date = self.dates[key]
+        self.assertNotEqual(
+            date.get_modifier(),
+            Date.MOD_TEXTONLY,
+            "%s imported as a text date, not a parsed qualified date" % key,
+        )
+        self.assertEqual(date.get_quality(), expected_qual)
+        self.assertEqual(date.get_year(), year)
+
+    def test_cal_mixed_case_is_calculated(self):
+        # The reporter's case: "2 DATE Cal 1847".
+        self._assert_qualified("Mixed Calc", Date.QUAL_CALCULATED, 1847)
+
+    def test_est_mixed_case_is_estimated(self):
+        self._assert_qualified("Mixed Esti", Date.QUAL_ESTIMATED, 1850)
+
+    def test_int_mixed_case_is_calculated(self):
+        self._assert_qualified("Mixed Inte", Date.QUAL_CALCULATED, 1852)
+
+    def test_cal_upper_case_control_is_calculated(self):
+        # All-caps already worked; pin it so the fix matches its behaviour.
+        self._assert_qualified("Upper Calc", Date.QUAL_CALCULATED, 1847)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -883,7 +883,7 @@ NOTE_RE = re.compile(r"\s*\d+\s+\@(\S+)\@\s+NOTE(.*)$")
 CONT_RE = re.compile(r"\s*\d+\s+CONT\s?(.*)$")
 CONC_RE = re.compile(r"\s*\d+\s+CONC\s?(.*)$")
 PERSON_RE = re.compile(r"\s*\d+\s+\@(\S+)\@\s+INDI(.*)$")
-MOD = re.compile(r"\s*(INT|EST|CAL)\s+(.*)$")
+MOD = re.compile(r"\s*(INT|EST|CAL)\s+(.*)$", re.IGNORECASE)
 CAL = re.compile(r"\s*(ABT|BEF|AFT|FROM|TO)?\s*@#D?([^@]+)@\s*(.*)$")
 RANGE = re.compile(r"\s*BET\s+@#D?([^@]+)@\s*(.*)\s+AND\s+@#D?([^@]+)@\s*(.*)$")
 RANGE1 = re.compile(r"\s*BET\s+\s*(.*)\s+AND\s+@#D?([^@]+)@\s*(.*)$")
@@ -1104,6 +1104,11 @@ class GedLine:
         mod = ""
         if match:
             mod, text = match.groups()
+            # GEDCOM 5.5.1 specifies these qualifiers in uppercase, but
+            # non-conformant exporters emit mixed case (e.g. "Cal 1847").
+            # Normalise before the (uppercase-keyed) QUALITY_MAP lookup and
+            # before mod is reused in the range/span text reconstruction.
+            mod = mod.upper()
             qual = QUALITY_MAP.get(mod, Date.QUAL_NONE)
             mod += " "
         else:

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -596,6 +596,7 @@ gramps/plugins/importer/__init__.py
 # plugins/importer/test directory
 #
 gramps/plugins/importer/test/importgedcom_ambiguous_date_test.py
+gramps/plugins/importer/test/importgedcom_caldate_test.py
 gramps/plugins/importer/test/importgeneweb_test.py
 gramps/plugins/importer/test/importvcard_test.py
 #


### PR DESCRIPTION
## Summary
**User impact:** When you import a family-tree file where an approximate date was written in mixed case (for example "Cal 1847" for a calculated date), Gramps failed to recognise it as a real date and instead stored it as plain text — which the data-check tool then flagged as an error. The very same date written in all capitals ("CAL 1847") imported fine, so the outcome depended on how the other program happened to capitalise the word.

This PR makes date import accept those qualifier words in any capitalisation.

Reported in Mantis [#8850](https://gramps-project.org/bugs/view.php?id=8850).

## What to look at
Approximate-date qualifiers ("calculated", "estimated", "interpreted") are now recognised no matter how they are capitalised, matching how Gramps already tolerates other mixed-case modifier words. To try it: import a GEDCOM file containing `2 DATE Cal 1847` and confirm the birth date imports as a Calculated date (year 1847), not as a text-only date.

## Root cause
GEDCOM 5.5.1 specifies the approximate-date qualifier keywords `CAL` (calculated), `EST` (estimated), and `INT` (interpreted) in uppercase. However, real-world GEDCOM exporters emit them in mixed case (e.g., `2 DATE Cal 1847`). The module-level `MOD` regex in `gramps/plugins/lib/libgedcom.py:886` was case-sensitive, so mixed-case variants never matched. When unmatched, the `__extract_date` method (`:1103`) failed to extract the qualifier, leaving `qual = QUAL_NONE` and passing the literal text through to the fallback parser, which imported it as a `MOD_TEXTONLY` text-only date. The Verify-the-Data tool then flags such dates as errors. The same input in all-caps imported correctly as a Calculated date, exposing the gap.

## Fix
Two edits in `gramps/plugins/lib/libgedcom.py`:

1. **Line 886** — Add `re.IGNORECASE` flag to the `MOD` regex so mixed-case qualifiers match:
   ```python
   MOD = re.compile(r"\s*(INT|EST|CAL)\s+(.*)$", re.IGNORECASE)
   ```

2. **Lines 1104–1108** — After capturing the qualifier token, normalise it to uppercase before the `QUALITY_MAP` lookup and before it is reused in range/span reconstruction. This ensures both consumers (the map lookup and the text reconstruction) operate on a consistent uppercase form, matching the behaviour of all-caps input:
   ```python
   mod = mod.upper()
   qual = QUALITY_MAP.get(mod, Date.QUAL_NONE)
   ```

This restores leniency over the entire `CAL`/`EST`/`INT` qualifier class in any case, not just the single token `"Cal"` — matching the existing permissive treatment of in-text modifier words (`ABT`/`BEF`/`AFT`).

## Verification
- **Claim:** mixed-case `CAL`/`EST`/`INT` qualifiers import as their proper date quality (Calculated/Estimated/Interpreted) with the correct year, never as a text-only date.
- **Checked:** on `upstream/maintenance/gramps61`:
  - `gramps/plugins/lib/libgedcom.py:886` and `:1104–1108` — the regex `re.IGNORECASE` flag and the uppercase normalisation.
  - Companion test `gramps/plugins/importer/test/importgedcom_ambiguous_date_test.py:79` demonstrates the `CliUser` + `import_as_dict` pattern reused by the new test.
  - `po/POTFILES.skip:599` — registration of the new test (no translatable strings).
- **Test:** `gramps/plugins/importer/test/importgedcom_caldate_test.py` (new) drives the real GEDCOM importer (via `import_as_dict` → `libgedcom`) with a fixture of four individuals — three mixed-case regression cases (`Cal 1847`, `Est 1850`, `Int 1852`) and one all-caps control (`CAL 1847`). For each it locates the person by name, asserts the birth date has the correct quality (`QUAL_CALCULATED` / `QUAL_ESTIMATED`), asserts the year parsed correctly, and asserts the date is NOT `MOD_TEXTONLY`. Fails on the three mixed-case assertions pre-fix, passes on all four post-fix.

Fixes [#8850](https://gramps-project.org/bugs/view.php?id=8850)
