### PR TITLE
Accept compact 8-digit dates without separators in date parser

### DIFF
--- a/gramps/gen/datehandler/_dateparser.py
+++ b/gramps/gen/datehandler/_dateparser.py
@@ -579,6 +579,7 @@ class DateParser:
             r"(\d+)?\s+?%s\.?\s*((\d+)(/\d+)?)?\s*$" % self._smon_str, re.IGNORECASE
         )
         self._numeric = re.compile(r"((\d+)[/\.]\s*)?((\d+)[/\.]\s*)?(\d+)\s*$")
+        self._compact8 = re.compile(r"^\s*(\d{2})(\d{2})(\d{4})\s*$")
         self._iso = re.compile(r"(\d+)(/(\d+))?-(\d+)(-(\d+))?\s*$")
         self._isotimestamp = re.compile(
             r"^\s*?(\d{4})([01]\d)([0123]\d)(?:(?:[012]\d[0-5]\d[0-5]\d)|"
@@ -739,6 +740,22 @@ class DateParser:
             if check is None or check((d, m, y)):
                 return (d, m, y, False)
             return Date.EMPTY
+
+        # Compact 8-digit input without separators: DDMMYYYY (dmy) or
+        # MMDDYYYY (mdy). Must be checked before _isotimestamp, which would
+        # otherwise greedily match DDMMYYYY as a bogus YYYYMMDD. For ymd
+        # locales, _isotimestamp below already handles YYYYMMDD correctly.
+        if not self.ymd:
+            match = self._compact8.match(text)
+            if match:
+                a, b, y = int(match.group(1)), int(match.group(2)), int(match.group(3))
+                if self.dmy:
+                    d, m = a, b
+                else:
+                    m, d = a, b
+                if not check or check((d, m, y)):
+                    return (d, m, y, False)
+                # invalid under locale field order — fall through to _isotimestamp
 
         # Database datetime format, used in ex. MSSQL
         # YYYYMMDD HH:MM:SS or YYYYMMDD or YYYYMMDDHHMMSS

--- a/gramps/gen/datehandler/test/dateparser_test.py
+++ b/gramps/gen/datehandler/test/dateparser_test.py
@@ -165,5 +165,69 @@ class Test_generate_variants(unittest.TestCase):
         self.assertIn("Maj", v)
 
 
+class TestCompact8DateParsing(unittest.TestCase):
+    """Tests for compact 8-digit date input (DDMMYYYY / MMDDYYYY / YYYYMMDD)."""
+
+    def setUp(self):
+        from .._dateparser import DateParser
+
+        self.parser_mdy = DateParser()
+        self.parser_mdy.dmy = False
+        self.parser_mdy.ymd = False
+
+        self.parser_dmy = DateParser()
+        self.parser_dmy.dmy = True
+        self.parser_dmy.ymd = False
+
+        self.parser_ymd = DateParser()
+        self.parser_ymd.dmy = False
+        self.parser_ymd.ymd = True
+
+    def test_mdy_compact(self):
+        """MMDDYYYY: 01121720 -> month=01, day=12, year=1720."""
+        date = self.parser_mdy.parse("01121720")
+        self.assertEqual(date.get_ymd(), (1720, 1, 12))
+
+    def test_dmy_compact(self):
+        """DDMMYYYY: 01121720 -> day=01, month=12, year=1720."""
+        date = self.parser_dmy.parse("01121720")
+        self.assertEqual(date.get_ymd(), (1720, 12, 1))
+
+    def test_ymd_yyyymmdd_via_isotimestamp(self):
+        """YMD locale: 17201201 parsed as YYYYMMDD -> year=1720, month=12, day=01."""
+        date = self.parser_ymd.parse("17201201")
+        self.assertEqual(date.get_ymd(), (1720, 12, 1))
+
+    def test_yyyymmdd_falls_through_compact_in_dmy(self):
+        """In a DMY locale, YYYYMMDD (e.g. 17201201) has invalid month under DMY
+        (month=20), so compact8 falls through to _isotimestamp which parses it
+        correctly as year=1720, month=12, day=01."""
+        date = self.parser_dmy.parse("17201201")
+        self.assertEqual(date.get_ymd(), (1720, 12, 1))
+
+    def test_yyyymmdd_falls_through_compact_in_mdy(self):
+        """In an MDY locale, YYYYMMDD (e.g. 17201201) has invalid month under MDY
+        (month=17), so compact8 falls through to _isotimestamp which parses it
+        correctly as year=1720, month=12, day=01."""
+        date = self.parser_mdy.parse("17201201")
+        self.assertEqual(date.get_ymd(), (1720, 12, 1))
+
+    def test_invalid_day_for_month_becomes_text(self):
+        """31021720 (February 31) is invalid in any calendar; must not silently
+        produce a wrong date — it should be stored as text."""
+        date = self.parser_dmy.parse("31021720")
+        self.assertEqual(date.get_modifier(), Date.MOD_TEXTONLY)
+
+    def test_invalid_month_becomes_text(self):
+        """99991720 has month=99 which is impossible; must become text."""
+        date = self.parser_mdy.parse("99991720")
+        self.assertEqual(date.get_modifier(), Date.MOD_TEXTONLY)
+
+    def test_whitespace_stripped(self):
+        """Leading/trailing whitespace is tolerated (strip() runs before parsing)."""
+        date = self.parser_dmy.parse("  01121720  ")
+        self.assertEqual(date.get_ymd(), (1720, 12, 1))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Adds a `_compact8` regex that matches exactly 8 consecutive digits and parses them as a full date (day, month, year) according to the locale's field order.
- **DMY locales** (e.g. German): `01121720` → day=01, month=12, year=1720 (displayed as `01.12.1720`)
- **MDY locales** (e.g. US English): `01121720` → month=01, day=12, year=1720
- **YMD locales** (e.g. Japanese): unchanged — `_isotimestamp` already handles `YYYYMMDD`
- The new check runs before `_isotimestamp` to prevent that pattern from greedily misinterpreting `DDMMYYYY` input as a bogus year. If the compact digits don't form a valid date under the locale's field order, parsing falls through to `_isotimestamp` so genuine `YYYYMMDD` input still works.

Suggested by a user on the Gramps forum: https://gramps.discourse.group/t/whats-in-development-for-gramps-6-2/9641/6

## Tests

8 unit tests added to `gramps/gen/datehandler/test/dateparser_test.py` (`TestCompact8DateParsing`):

- DMY compact input: `01121720` → day=1, month=12, year=1720
- MDY compact input: `01121720` → month=1, day=12, year=1720
- YMD locale: `17201201` still handled correctly by `_isotimestamp` (unchanged path)
- YYYYMMDD fallthrough in DMY/MDY locales: compact8 rejects invalid month, `_isotimestamp` picks it up
- Invalid day for month (Feb 31) → stored as text, not silently mangled
- Invalid month (99) → stored as text
- Leading/trailing whitespace tolerated

## Test plan

- [ ] Type `01121720` in a date field on a DMY locale (e.g. German) — should display as `01.12.1720`
- [ ] Type `01121720` in a date field on an MDY locale (e.g. US English) — should display as `January 12, 1720`
- [ ] Type `17201201` — should still parse as year=1720, month=12, day=1 via `_isotimestamp` (YYYYMMDD)
- [ ] Type `31021720` (invalid: Feb 31) — should remain as text, not silently accepted
- [ ] Existing date formats with separators (`01.12.1720`, `12/01/1720`) still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)