### PR TITLE
Include FS CSS in Windows build

### DIFF
--- a/scripts/build_hook.py
+++ b/scripts/build_hook.py
@@ -218,6 +218,7 @@ class GrampsBuildHook(BuildHookInterface):
             copy2(source, destination)
 
         data_files = [
+            "familysearch.css",
             "gramps.css",
             "grampsxml.rng",
             "grampsxml.dtd",


### PR DESCRIPTION
Windows executable only has files copied into share/gramps, and scripts/build_hook.py was only copying gramps.css, not familysearch.css, update for that. It was causing the windows version not to have the CSS styling.

What it should be:
<img width="984" height="723" alt="image" src="https://github.com/user-attachments/assets/1e573403-b226-4c64-843f-a9183c0c7f52" />

<img width="1412" height="882" alt="image" src="https://github.com/user-attachments/assets/d9a0d757-09b7-4415-b7d2-da2908459b68" />


What it was:
<img width="690" height="421" alt="image" src="https://github.com/user-attachments/assets/753375cb-8597-455f-9213-5037423ac645" />

<img width="690" height="497" alt="image" src="https://github.com/user-attachments/assets/ee09ff5d-fb20-41cb-8bdb-01152ce3ef2d" />
