### PR TITLE
Add regression test for German date parser "bis" modifier

### DIFF
--- a/gramps/gen/datehandler/test/date_de_test.py
+++ b/gramps/gen/datehandler/test/date_de_test.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Unit tests for the German date parser.
+
+Bug 0013163: with the German UI, entering "bis 1760" ("until 1760") as a
+date was silently converted to "0.8.1760" (August 1760).  "bis" was not in
+the German modifier table, so the parser fell through to month-name matching
+and matched the Old-German harvest-moon month name "bisemond" (= August).
+
+"bis" is now an entry in ``DateParserDE.modifier_to_int`` mapping to
+``Date.MOD_TO``, so "bis 1760" parses as a to/until date for the year 1760
+with no month, never August.
+"""
+
+import unittest
+
+from ...lib.date import Date
+from .._date_de import DateParserDE
+
+
+class DateParserDETest(unittest.TestCase):
+    """Exercise ``DateParserDE.parse`` for the bug-13163 German "bis" case."""
+
+    def setUp(self):
+        self.parser = DateParserDE()
+
+    def test_bis_year_is_mod_to_not_august(self):
+        """
+        Bug 13163 repro: "bis 1760" must parse as MOD_TO (to/until) of the
+        year 1760, NOT as August (month 8) 1760.
+        """
+        date = self.parser.parse("bis 1760")
+        self.assertEqual(date.get_modifier(), Date.MOD_TO)
+        self.assertEqual(date.get_year(), 1760)
+        # The reported "0.8.1760" August conversion: month must be 0 (no
+        # month), never 8 (August / "bisemond").
+        self.assertEqual(date.get_month(), 0)
+        self.assertNotEqual(date.get_month(), 8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -70,6 +70,7 @@ gramps/gen/datehandler/_grampslocale.py
 #
 # gen.datehandler.test package
 #
+gramps/gen/datehandler/test/date_de_test.py
 gramps/gen/datehandler/test/datedisplay_test.py
 gramps/gen/datehandler/test/datehandler_test.py
 gramps/gen/datehandler/test/dateparser_test.py


### PR DESCRIPTION
## Summary
**User impact:** With the German interface, typing "bis 1760" (meaning "until 1760") as a date was silently turned into "August 1760" — the word "bis" was mistaken for an old German month name, so the date you saved was not the date you entered. This is a guard against that bug ever coming back.

This PR adds a regression test confirming "bis 1760" is read as an until-date for the year 1760, never as August.

Reported in Mantis [#13163](https://gramps-project.org/bugs/view.php?id=13163).

## What to look at
No production code change — the fix is already on the target branch. The test parses "bis 1760" and confirms it becomes a to/until date for 1760 with no month. To try it manually: with the German UI, enter "bis 1760" as a date and confirm it is kept as an until-date, not converted to August 1760.

## Root cause
With the German UI, entering "bis 1760" ("until 1760") as a date was silently converted to "0.8.1760" (August 1760). The parser did not recognize "bis" as a modifier and fell through to month-name matching, where the loose prefix abbreviation expansion matched "bisemond" (an old German month name for August, month 8), yielding the incorrect conversion.

## Fix
The fix — adding "bis" to `DateParserDE.modifier_to_int` mapping to `Date.MOD_TO` — is already in place on the target branch (maintenance/gramps61). This merge adds a regression test to ensure the behaviour does not break in the future. The test verifies that parsing "bis 1760" yields a to/until date (modifier MOD_TO) for year 1760 with no month, never month 8 (August).

## Verification
- **Claim:** parsing "bis 1760" yields `modifier == Date.MOD_TO`, `year == 1760`, and `month == 0` (not 8/August).
- **Checked:** on `maintenance/gramps61`:
  - `gramps/gen/datehandler/_date_de.py:219` — `"bis": Date.MOD_TO` is in the `DateParserDE.modifier_to_int` table, ensuring "bis" is consumed as a modifier before month-name matching is reached.
  - `po/POTFILES.skip:73` — the new test file is registered as having no translatable strings.
- **Test:** `gramps/gen/datehandler/test/date_de_test.py` (new) exercises `DateParserDE.parse("bis 1760")` and asserts `get_modifier() == Date.MOD_TO`, `get_year() == 1760`, and `get_month() == 0` (explicitly not 8), mirroring the existing Finnish parser test (`date_fi_test.py`). It imports only `Date` and `DateParserDE`, so it runs headless under plain `unittest` (no GUI/D-Bus/display). This is a test-only change: the reported symptom is already resolved on the target branch, so it is verified manually and the test pins the fix against future regression.

Fixes [#13163](https://gramps-project.org/bugs/view.php?id=13163)

