### PR TITLE
Fix ODF table column-style naming for tables with >63 columns

### DIFF
--- a/gramps/plugins/docgen/odfdoc.py
+++ b/gramps/plugins/docgen/odfdoc.py
@@ -422,6 +422,28 @@ _SHEADER_FOOTER = """\
 _CLICKABLE = r"""<text:a xlink:type="simple" xlink:href="\1">\1</text:a>"""
 
 
+def _column_style_suffix(col):
+    """
+    Return the table-column-style name suffix for the zero-based column
+    index *col*.
+
+    A column style is named ``<table-style>.<suffix>``.  The historical
+    suffix ``chr(ord("A") + col)`` is only a valid, unique token for the
+    first 26 columns: past column 25 it emits non-letter characters and
+    past column 62 it runs beyond ``chr(127)``, yielding malformed style
+    names and breaking ODF output for tables with many columns (bug
+    #6549).  Generate a spreadsheet-style bijective base-26 token
+    (A, B, ... Z, AA, AB, ... AZ, BA, ...) instead, which is a valid and
+    unique identifier for any column count.
+    """
+    suffix = ""
+    col += 1
+    while col > 0:
+        col, remainder = divmod(col - 1, 26)
+        suffix = chr(ord("A") + remainder) + suffix
+    return suffix
+
+
 # -------------------------------------------------------------------------
 #
 # ODFDoc
@@ -698,12 +720,12 @@ class ODFDoc(BaseDoc, TextDoc, DrawDoc):
                 + "</style:style>\n"
             )
 
-            for col in range(0, min(style.get_columns(), 50)):
+            for col in range(0, style.get_columns()):
                 width = table_width * float(style.get_column_width(col) / 100.0)
                 width_str = "%.4f" % width
                 wrt(
                     '<style:style style:name="%s.%s" '
-                    % (style_name, chr(ord("A") + col))
+                    % (style_name, _column_style_suffix(col))
                     + 'style:family="table-column">'
                     + "<style:table-column-properties "
                     + 'style:column-width="%scm"/>' % width_str
@@ -1093,7 +1115,7 @@ class ODFDoc(BaseDoc, TextDoc, DrawDoc):
         for col in self.column_order:
             self.cntnt.write(
                 '<table:table-column table:style-name="%s.%s"/>\n'
-                % (style_name, str(chr(ord("A") + col)))
+                % (style_name, _column_style_suffix(col))
             )
 
     def end_table(self):

--- a/gramps/plugins/docgen/test/odfdoc_test.py
+++ b/gramps/plugins/docgen/test/odfdoc_test.py
@@ -1,0 +1,136 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Eduard Ralph
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Unittest for the ODF docgen table-column-style naming (bug 6549).
+
+The ODF generator names each table-column style ``<table-style>.<suffix>``.
+The historical suffix ``chr(ord("A") + col)`` only yields a valid, unique
+token for the first 26 columns: past column 25 it emits non-letter
+characters and past column 62 it runs beyond ``chr(127)``, producing
+malformed/invalid column-style names.  A second, related defect capped the
+column-style *definition* loop at 50 columns while the *reference* loop
+emitted one reference per column, so for a wide table (e.g. the census
+report's 78-column US-1840 table) every column past 49 referenced a style
+name that was never defined.
+
+These tests drive the production ``ODFDoc`` emission path -- the same
+``init`` (column-style definitions) and ``start_table`` (column-style
+references) methods a real report uses -- for a 78-column table, then assert
+on the generated content that every referenced column-style name is valid,
+was actually defined, and is unique per column.
+"""
+
+import os
+import re
+import tempfile
+import unittest
+
+from gramps.gen.plug.docgen import (
+    PaperSize,
+    PaperStyle,
+    PAPER_PORTRAIT,
+    StyleSheet,
+    TableStyle,
+)
+from gramps.plugins.docgen.odfdoc import ODFDoc
+
+# More than 63 columns: the threshold past which the old chr() scheme ran
+# beyond chr(127), and well past the old 50-column definition cap.
+NCOLS = 78
+TABLE_STYLE = "GRAPHTABLE"
+
+# A column-style suffix must be a valid identifier token: only ASCII
+# letters (the ODF validator rejects control/punctuation characters in a
+# style name).
+_VALID_SUFFIX = re.compile(r"^[A-Za-z]+$")
+
+# style:name="GRAPHTABLE.<suffix>" on a table-column family style (a
+# column-style DEFINITION emitted by ODFDoc.init).
+_DEFINED = re.compile(
+    r'<style:style style:name="'
+    + re.escape(TABLE_STYLE)
+    + r'\.([^"]+)" style:family="table-column"'
+)
+# table:style-name="GRAPHTABLE.<suffix>" on a table-column (a column-style
+# REFERENCE emitted by ODFDoc.start_table).
+_REFERENCED = re.compile(
+    r'<table:table-column table:style-name="' + re.escape(TABLE_STYLE) + r'\.([^"]+)"'
+)
+
+
+def _wide_table_content():
+    """Build an ODFDoc whose only table style declares NCOLS columns and run
+    the production emission methods, returning the generated content XML
+    (column-style definitions from ``init`` followed by the table's column
+    references from ``start_table``)."""
+    table = TableStyle()
+    table.set_width(100)
+    table.set_columns(NCOLS)
+    for col in range(NCOLS):
+        table.set_column_width(col, 100.0 / NCOLS)
+
+    sheet = StyleSheet()
+    sheet.add_table_style(TABLE_STYLE, table)
+
+    paper = PaperStyle(PaperSize("Letter", 27.94, 21.59), PAPER_PORTRAIT)
+    doc = ODFDoc(sheet, paper)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        doc.open(os.path.join(tmp, "wide"))
+        doc.init()  # emits the column-style DEFINITIONS
+        doc.start_table("the_table", TABLE_STYLE)  # emits the REFERENCES
+        return doc.cntnt.getvalue()
+
+
+class ODFWideTableTest(unittest.TestCase):
+    """Drive the production ODFDoc path for a >63-column table (bug 6549)."""
+
+    def setUp(self):
+        self.content = _wide_table_content()
+        self.defined = set(_DEFINED.findall(self.content))
+        self.referenced = _REFERENCED.findall(self.content)
+
+    def test_emits_one_reference_per_column(self):
+        self.assertEqual(len(self.referenced), NCOLS)
+
+    def test_every_referenced_name_is_valid(self):
+        # Past column 25 the old chr() scheme emitted non-letter characters
+        # (and past column 62, characters beyond chr(127)).
+        for name in self.referenced:
+            with self.subTest(name=name):
+                self.assertRegex(name, _VALID_SUFFIX)
+
+    def test_every_referenced_name_was_defined(self):
+        # The definition loop and the reference loop must agree for every
+        # column -- the old min(get_columns(), 50) cap left every column past
+        # 49 referencing a style name that was never defined.
+        missing = [n for n in self.referenced if n not in self.defined]
+        self.assertEqual(
+            missing,
+            [],
+            "column references with no matching definition: %r" % (missing,),
+        )
+
+    def test_referenced_names_are_unique(self):
+        self.assertEqual(len(set(self.referenced)), NCOLS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -556,6 +556,7 @@ gramps/plugins/docgen/__init__.py
 #
 gramps/plugins/docgen/test/__init__.py
 gramps/plugins/docgen/test/latexdoc_test.py
+gramps/plugins/docgen/test/odfdoc_test.py
 #
 # plugins/drawreport directory
 #


### PR DESCRIPTION
## Summary
**User impact:** Build a report containing a very wide table — more than about 50 columns — and save it as an OpenDocument (ODF) file, and the result comes out broken: the table's column formatting is garbled, and the document can fail to open or validate. Ordinary narrower tables are fine; only wide ones break.

This makes wide tables name their column formatting correctly, so the saved ODF file is valid no matter how many columns the table has.

Reported in Mantis [#6549](https://gramps-project.org/bugs/view.php?id=6549).

## What to look at
The whole change is how table columns are labelled: instead of a scheme that only works for the first 26 columns, columns now get spreadsheet-style labels (A, B, … Z, AA, AB, …) so every column has a valid, unique name, and a hidden 50-column cap that left extra columns pointing at labels that were never created is removed. To try it: generate an ODF report with a table wider than 63 columns and confirm the file opens and validates. A new headless test drives exactly this on a 78-column table.

## Root cause
The ODF docgen names table-column styles using `chr(ord("A") + col)`, which is only valid and unique for columns 0–25 (A–Z). Past column 25, this produces non-letter characters; past column 62, it emits characters beyond `chr(127)`, yielding malformed style names that fail ODF validation. A second independent defect caps the style-definition loop at `min(get_columns(), 50)` while the style-reference loop iterates all columns, so for tables wider than 50 columns every excess column references a style name that was never defined.

## Fix
Add a module-level helper `_column_style_suffix(col)` (new, inserted at line 425) that generates spreadsheet-style bijective base-26 tokens (A, B, … Z, AA, AB, … AZ, BA, …), a valid, unique identifier for any column count. Update the style-definition loop (odfdoc.py:701) to remove the 50-column cap (`range(0, min(style.get_columns(), 50))` → `range(0, style.get_columns())`) and use the new helper at both the definition site (odfdoc.py:706) and the reference site in `start_table` (odfdoc.py:1096). Both sites now route through a single source of truth, ensuring valid, unique, and consistent column-style names for any table width. Register the new test file in `po/POTFILES.skip` (alongside the sibling `latexdoc_test.py`).

## Verification
- **Claim:** for a table of any width, every column-style reference names a valid, unique ASCII-letter style that was actually defined.
- **Checked:** on `maintenance/gramps61` — `gramps/plugins/docgen/odfdoc.py:701` (definition-loop cap removed), `:706` (definition site now calls `_column_style_suffix(col)`), `:1096` (reference site in `start_table` now calls `_column_style_suffix(col)`); `po/POTFILES.skip:556` registers the new test file alongside `latexdoc_test.py`.
- **Test:** `gramps/plugins/docgen/test/odfdoc_test.py` (new) drives the real ODFDoc emission path (`init()` column-style definitions and `start_table()` references) for a 78-column table and asserts on the generated content XML that: one reference is emitted per column (78), every referenced suffix matches `^[A-Za-z]+$`, every referenced name was actually defined (no undefined references), and referenced names are unique per column. Import-light (imports only `ODFDoc`, no `gi`/`gramps.gui`), so it runs headless. Pre-fix it fails with invalid names (punctuation, control characters) and 28 undefined column references (cols 50–77); post-fix all assertions pass.

Fixes [#6549](https://gramps-project.org/bugs/view.php?id=6549)
