### PR TITLE
Add regression test for Top Surnames wrong-surname bug

### DIFF
--- a/gramps/plugins/gramplet/test/topsurnamesgramplet_test.py
+++ b/gramps/plugins/gramplet/test/topsurnamesgramplet_test.py
@@ -151,6 +151,40 @@ class TopSurnamesTest(unittest.TestCase):
         self.assertIn(representative_handle["Webb"], ("W1", "W2"))
         self.assertEqual(surnames["Webb"], 3)
 
+    def test_reported_repro_6826_clicked_surname_resolves_to_primary_carrier(self):
+        """
+        Bug #6826 (reported repro): a person P1 with primary surname "A" and
+        alternate surname "B", plus a person P2 whose primary surname is "B".
+
+        The Same Surnames quick view re-derives the clicked surname from the
+        representative's *primary* name, so the representative for "B" must be
+        P2 (whose primary name is "B") and never P1 (whose primary name is "A").
+        Otherwise double-clicking "B" opens "People sharing the surname 'A'".
+
+        Pre-fix the representative was overwritten unconditionally, so whichever
+        of the two was iterated last won "B" -- making the result depend on
+        database order.  Assert the primary-name carrier wins for *both* orders.
+        """
+        for order in (("P2", "P1"), ("P1", "P2")):
+            people_by_handle = {
+                "P1": make_person("P1", "A", alternates=("B",)),
+                "P2": make_person("P2", "B"),
+            }
+            people = [people_by_handle[handle] for handle in order]
+            surnames, representative_handle = tally(people)
+            # Clicking "B" must open the report for surname B (P2's primary).
+            self.assertEqual(
+                representative_handle["B"],
+                "P2",
+                msg=f"iteration order {order}: 'B' must resolve to the "
+                "primary-B carrier P2, not the alternate-name carrier P1",
+            )
+            # "A" is held by P1 as a primary name.
+            self.assertEqual(representative_handle["A"], "P1")
+            # "B" is counted for both: P1's alternate and P2's primary.
+            self.assertEqual(surnames["B"], 2)
+            self.assertEqual(surnames["A"], 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
**User impact:** In the Top Surnames gramplet, clicking a surname could open the "same surnames" report for the wrong surname. It happened when two people shared a name in different ways — one carrying it as an alternate name and another as their main name — so the wrong person's main surname was shown instead of the one you clicked.

This adds a regression test that guards the already-fixed behaviour, so the clicked surname always resolves to the person who carries it as their main name.

Reported in Mantis [#6826](https://gramps-project.org/bugs/view.php?id=6826).

## What to look at
This is a test-only change: it pins down the correct behaviour so it cannot silently regress. The underlying bug was already fixed by commit e39dc09e2e, which made the surname tally prefer a primary-name carrier as the representative. To reproduce the original defect: with person P1 having primary "A" plus alternate "B", and person P2 having primary "B", click "B" in Top Surnames — pre-fix it opened the report for surname "A". The new test models exactly this and checks the outcome is order-independent.

## Root cause
The Top Surnames gramplet assigned a representative for every group name from a person's primary and alternate names, without preferring primary-name carriers. When the Same Surnames quick view re-derived the clicked surname from the representative's *primary* name, surnames held only as alternates would resolve to a different person's primary surname. For the reported scenario (person P1 with primary "A" + alternate "B", person P2 with primary "B"), clicking "B" opened the report for surname "A" instead.

## Fix
This is a test-only patch that adds a regression test for the reported scenario. The underlying production bug was already fixed by commit e39dc09e2e2e (full hash), which modified `record_surnames()` to only assign or rewrite the representative when the surname matches the person's primary name or when no representative has been chosen yet. This ensures primary-name carriers always win, making the result independent of database iteration order. (This test-only PR does not carry the fix itself; commit e39dc09e2e is referenced by short hash as it already exists on the branch.)

## Verification
- **Claim:** the representative for a surname is always a primary-name carrier, so the clicked surname resolves correctly regardless of database iteration order.
- **Checked:** `gramps/plugins/gramplet/topsurnamesgramplet.py:54-78` on `maintenance/gramps61` — `record_surnames()` prefers primary-name carriers (fixed in commit e39dc09e2e); `gramps/plugins/gramplet/test/topsurnamesgramplet_test.py` — the existing surname-tally suite extended with the reported scenario.
- **Test:** `gramps/plugins/gramplet/test/topsurnamesgramplet_test.py` — `test_reported_repro_6826_clicked_surname_resolves_to_primary_carrier` (lines 154-186) models P1 primary "A" + alternate "B", P2 primary "B" and asserts the representative for "B" is P2 (not P1) for *both* database iteration orders, with correct counts (B twice, A once). This is a regression guard for an already-fixed bug: it imports `record_surnames` directly (no mocking) and runs headless (only `gramps.gen.*`). It is green on current code; it would go red if the fix were reverted.

Fixes [#6826](https://gramps-project.org/bugs/view.php?id=6826)
