### PR TITLE
Add GEDCOM export test for accented place titles

### DIFF
--- a/gramps/plugins/export/test/exportgedcom_place_test.py
+++ b/gramps/plugins/export/test/exportgedcom_place_test.py
@@ -1,0 +1,178 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Mantis 8362 — GEDCOM export of an event place must not depend on the
+place TYPE, and an accented place title must round-trip as UTF-8.
+
+Reported on 4.1.1 (2015): the marriage ``PLAC`` line a GEDCOM export
+produced differed depending on the place type ("Città" vs "Town"), which
+the reporter blamed on the accented "à".  Under the pre-5.0 place model
+the exporter mapped place parts into the GEDCOM ADDR/CITY structure by
+matching the (translated) place type against English "City"/"Town", and
+the Python-2 handling of the accented character interacted with that
+mapping.
+
+The 5.0 place-model rewrite removed the type→ADDR/CITY mapping for event
+places: :meth:`GedcomWriter._place` now emits ``PLAC = <display name>``
+(plus MAP / notes) independent of the place type, and Python-3 / UTF-8
+carries the accent intact.  This test pins that behaviour:
+
+  * an accented place title round-trips as UTF-8 in the ``PLAC`` line, and
+  * the ``PLAC`` output is byte-identical whether the place type is the
+    accented "Città" or the English "Town" — the type no longer drives
+    the place export.
+
+Import-light: the test stubs the two ``gramps.gui`` symbols that
+``exportgedcom`` (and the db plugin layer it pulls) reference at import
+time, so it runs headless (no display / GTK widget realisation) while
+still exercising the real production export path
+(:meth:`GedcomWriter._place` / ``_writeln`` / the place displayer)."""
+
+import os
+import sys
+import tempfile
+import types
+import unittest
+
+# ---------------------------------------------------------------------------
+# Headless import shims.
+#
+# ``exportgedcom`` does ``from gramps.gui.plug.export import WriterOptionBox``
+# at module load (kept "even though not obviously used"), and the db plugin
+# layer pulled in by ``gramps.gen.db`` imports ``gramps.gui.dbguielement``.
+# Neither symbol is used on the export path under test, but importing the real
+# ``gramps.gui`` package realises GTK widget classes, which is exactly what
+# crashes a no-display unit runner.  Register lightweight stand-ins BEFORE the
+# gramps imports so the unit stays import-light yet drives the real writer.
+# ---------------------------------------------------------------------------
+for _name in (
+    "gramps.gui",
+    "gramps.gui.plug",
+    "gramps.gui.plug.export",
+    "gramps.gui.dbguielement",
+):
+    if _name not in sys.modules:
+        _mod = types.ModuleType(_name)
+        _mod.__path__ = []  # advertise as a package so submodule imports resolve
+        sys.modules[_name] = _mod
+
+
+class _WriterOptionBox:  # stand-in for gramps.gui.plug.export.WriterOptionBox
+    pass
+
+
+class _DbGUIElement:  # stand-in for gramps.gui.dbguielement.DbGUIElement
+    pass
+
+
+sys.modules["gramps.gui.plug.export"].WriterOptionBox = _WriterOptionBox
+sys.modules["gramps.gui.dbguielement"].DbGUIElement = _DbGUIElement
+
+from gramps.cli.user import User
+from gramps.gen.db import DbTxn
+from gramps.gen.db.utils import make_database
+from gramps.gen.lib import (
+    Event,
+    EventRef,
+    EventType,
+    Family,
+    Place,
+    PlaceName,
+    PlaceType,
+)
+from gramps.plugins.export.exportgedcom import GedcomWriter
+
+# Accented marriage-place title — the "à"/"ì" the 2015 reporter blamed.
+PLACE_TITLE = "Forlì à la Côte"
+# UTF-8 byte sequences for the accented characters, asserted explicitly so a
+# regression to a non-UTF-8 / mangled encoding is caught.
+ACCENT_BYTES = (
+    "ì".encode("utf-8"),  # b"\xc3\xac"
+    "à".encode("utf-8"),  # b"\xc3\xa0"
+    "ô".encode("utf-8"),  # b"\xc3\xb4"
+)
+
+
+def _export_marriage_place(place_type):
+    """Build a one-family tree whose marriage event has a place titled
+    ``PLACE_TITLE`` and typed ``place_type``, export it to GEDCOM, and return
+    ``(raw_bytes, [PLAC lines])``."""
+    db = make_database("sqlite")
+    db.load(":memory:")
+
+    place = Place()
+    name = PlaceName()
+    name.set_value(PLACE_TITLE)
+    place.set_name(name)
+    place.set_title(PLACE_TITLE)
+    place.set_type(PlaceType(place_type))
+
+    event = Event()
+    event.set_type(EventType(EventType.MARRIAGE))
+
+    family = Family()
+
+    with DbTxn("8362 fixture", db) as trans:
+        place_handle = db.add_place(place, trans)
+        db.commit_place(place, trans)
+        event.set_place_handle(place_handle)
+        event_handle = db.add_event(event, trans)
+        db.commit_event(event, trans)
+        eref = EventRef()
+        eref.set_reference_handle(event_handle)
+        family.add_event_ref(eref)
+        db.add_family(family, trans)
+        db.commit_family(family, trans)
+
+    fd, path = tempfile.mkstemp(suffix=".ged")
+    os.close(fd)
+    try:
+        GedcomWriter(db, User()).write_gedcom_file(path)
+        with open(path, "rb") as handle:
+            raw = handle.read()
+    finally:
+        os.unlink(path)
+
+    plac_lines = [line for line in raw.decode("utf-8").splitlines() if " PLAC " in line]
+    return raw, plac_lines
+
+
+class GedcomExportPlaceTypeAccentTest(unittest.TestCase):
+    def test_accented_title_roundtrips_as_utf8(self):
+        raw, plac_lines = _export_marriage_place("Città")
+        self.assertEqual(
+            plac_lines,
+            ["2 PLAC " + PLACE_TITLE],
+            "marriage place must export as a single PLAC line carrying the "
+            "accented title intact",
+        )
+        # The file is valid UTF-8 and the accented bytes survive verbatim.
+        for accent in ACCENT_BYTES:
+            self.assertIn(accent, raw)
+
+    def test_place_type_does_not_drive_place_export(self):
+        raw_citta, plac_citta = _export_marriage_place("Città")
+        raw_town, plac_town = _export_marriage_place(PlaceType.TOWN)
+        # Same title, only the type differs → the PLAC output is identical.
+        self.assertEqual(plac_citta, plac_town)
+        self.assertEqual(plac_citta, ["2 PLAC " + PLACE_TITLE])
+        # And not via an empty/missing line on either side.
+        self.assertTrue(plac_citta)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/plugins/export/test/exportgedcom_place_test.py
+++ b/gramps/plugins/export/test/exportgedcom_place_test.py
@@ -79,8 +79,11 @@ class _DbGUIElement:  # stand-in for gramps.gui.dbguielement.DbGUIElement
     pass
 
 
-sys.modules["gramps.gui.plug.export"].WriterOptionBox = _WriterOptionBox
-sys.modules["gramps.gui.dbguielement"].DbGUIElement = _DbGUIElement
+# ``setattr`` (rather than direct attribute assignment) keeps mypy happy: it
+# types ``sys.modules[<key>]`` as a bare ``types.ModuleType``, so assigning a
+# new attribute on it would otherwise raise ``attr-defined``.
+setattr(sys.modules["gramps.gui.plug.export"], "WriterOptionBox", _WriterOptionBox)
+setattr(sys.modules["gramps.gui.dbguielement"], "DbGUIElement", _DbGUIElement)
 
 from gramps.cli.user import User
 from gramps.gen.db import DbTxn

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -567,6 +567,7 @@ gramps/plugins/export/__init__.py
 #
 # plugins/export/test directory
 #
+gramps/plugins/export/test/exportgedcom_place_test.py
 gramps/plugins/export/test/exportvcard_test.py
 #
 # plugins/gramplet directory


### PR DESCRIPTION
## Summary
**User impact:** A place whose name contains accented letters (for example "Forlì à la Côte") should export to a GEDCOM file with its accents intact, and the exported place name should not change depending on how the place is categorised. The original report described the exported place differing by its category; on today's Gramps that no longer happens.

This adds a regression test that locks in the correct behaviour — accents survive the export, and the place's category does not alter the exported place line.

Reported in Mantis [#8362](https://gramps-project.org/bugs/view.php?id=8362).

## What to look at
This is a test-only change: it pins existing correct behaviour so it cannot regress. The test builds an in-memory tree, runs the real GEDCOM writer, and inspects the exported bytes. To sanity-check by hand: export a family tree whose marriage place is titled "Forlì à la Côte" and confirm the accented letters appear unchanged in the PLAC line, and that changing the place type does not change that line.

## Root cause
The pre-5.0 GEDCOM exporter mapped place parts into the ADDR/CITY structure by matching the (translated) place type against English "City"/"Town", so the place type drove the output. The 5.0 place-model rewrite removed that mapping entirely, and Python-3 UTF-8 correctly carries accented characters — so the reported discrepancy (export differing by place type) cannot reproduce on the current code.

## Fix
This patch adds a regression test (`gramps/plugins/export/test/exportgedcom_place_test.py`, new) that verifies:
1. An accented place title (e.g., "Forlì à la Côte") round-trips as UTF-8 in the exported PLAC line, preserving the accented bytes (ì, à, ô).
2. The PLAC output is byte-identical whether the place type is the accented "Città" or English "Town" — the type no longer drives the place export.

The test exercises the real production export path: it builds an in-memory tree, calls the real `GedcomWriter.write_gedcom_file()`, and inspects the raw bytes. Import-light shims (`sys.modules` stubs for `gramps.gui.*`) keep the test headless while exercising the real writer and place displayer. `po/POTFILES.skip` must be updated at commit time to register the new test file (it has no translatable strings; it sorts before `exportvcard_test.py` at line 568).

## Verification
- **Claim:** an accented place title round-trips as UTF-8 in the PLAC line, and the exported PLAC line is byte-identical regardless of the place type.
- **Checked:** on `maintenance/gramps61` — `gramps/plugins/export/exportgedcom.py:1579–1605` (`GedcomWriter._place()` emits only `PLAC = <place display name>` + MAP + notes, no reference to place type); `:1243–1245` (event export calls `_place()`, reached via `_families()` → `_family()` → `_family_events()`); `gramps/gen/display/place.py:88` and `gramps/gen/utils/location.py:39` (place display defaults to the place title when `place-auto=True`, the config default; the test sets both the `PlaceName` value and title for robustness).
- **Test:** `gramps/plugins/export/test/exportgedcom_place_test.py` (new). `test_accented_title_roundtrips_as_utf8` exports a marriage place titled "Forlì à la Côte" and asserts the PLAC line contains the accented UTF-8 bytes; `test_place_type_does_not_drive_place_export` exports the same place once typed "Città" and once as `PlaceType.TOWN` and asserts identical PLAC output. This is a test that pins existing correct behaviour, not a fix for broken code — both cases pass on current `maintenance/gramps61` HEAD. Because this pins already-correct behaviour, there is no production code to revert for a failing-then-passing leg; it ships as a durable guard and was reviewed manually.

Fixes [#8362](https://gramps-project.org/bugs/view.php?id=8362)

