### PR TITLE
graph: fix Family Lines ancestor pruning by surname

### DIFF
--- a/gramps/plugins/graph/gvfamilylines.py
+++ b/gramps/plugins/graph/gvfamilylines.py
@@ -409,183 +409,74 @@ class FamilyLinesOptions(MenuReportOptions):
             self.justyears.set_available(False)
 
 
-# ------------------------------------------------------------------------
-#
-# FamilyLinesReport -- created once the user presses 'OK'
-#
-# ------------------------------------------------------------------------
-class FamilyLinesReport(Report):
-    """FamilyLines report"""
+class FamilyLinesSelection:
+    """
+    Determine which people and families a Family Lines report includes.
 
-    def __init__(self, database, options, user):
-        """
-        Create FamilyLinesReport object that eventually produces the report.
+    This is the people/family-selection half of :class:`FamilyLinesReport`,
+    factored out so it depends only on the database and the report's option
+    flags -- not on the GUI-entangled report machinery (the document writer,
+    the menu, the ``Report`` base class).  That makes the selection logic
+    (follow parents/children and the "remove extra people" pruning) directly
+    unit-testable without constructing the full report.
+    """
 
-        The arguments are:
-
-        database     - the Gramps database instance
-        options      - instance of the FamilyLinesOptions class for this report
-        user         - a gen.user.User() instance
-        name_format  - Preferred format to display names
-        incl_private - Whether to include private data
-        inc_id       - Whether to include IDs.
-        living_people - How to handle living people
-        years_past_death - Consider as living this many years after death
-        """
-        Report.__init__(self, database, options, user)
-
-        menu = options.menu
-        get_option_by_name = menu.get_option_by_name
-        get_value = lambda name: get_option_by_name(name).get_value()
-
-        self.set_locale(menu.get_option_by_name("trans").get_value())
-
-        stdoptions.run_date_format_option(self, menu)
-
-        stdoptions.run_private_data_option(self, menu)
-        stdoptions.run_living_people_option(self, menu, self._locale)
-        self.database = CacheProxyDb(self.database)
-        self._db = self.database
-
-        # initialize several convenient variables
-        self._people = set()  # handle of people we need in the report
-        self._families = set()  # handle of families we need in the report
+    def __init__(
+        self,
+        db,
+        interest_set,
+        followpar,
+        followchild,
+        removeextra,
+        limitparents,
+        maxparents,
+        limitchildren,
+        maxchildren,
+        surnamecolors,
+    ):
+        self._db = db
+        self._interest_set = interest_set
+        self._followpar = followpar
+        self._followchild = followchild
+        self._removeextra = removeextra
+        self._limitparents = limitparents
+        self._maxparents = maxparents
+        self._limitchildren = limitchildren
+        self._maxchildren = maxchildren
+        self._surnamecolors = surnamecolors
+        self._people = set()
+        self._families = set()
         self._deleted_people = 0
         self._deleted_families = 0
-        self._user = user
+        self._direct_ancestor_cache = None
 
-        self._followpar = get_value("followpar")
-        self._followchild = get_value("followchild")
-        self._removeextra = get_value("removeextra")
-        self._gidlist = get_value("gidlist")
-        self._colormales = get_value("colormales")
-        self._colorfemales = get_value("colorfemales")
-        self._colorother = get_value("colorother")
-        self._colorunknown = get_value("colorunknown")
-        self._colorfamilies = get_value("colorfamilies")
-        self._limitparents = get_value("limitparents")
-        self._maxparents = get_value("maxparents")
-        self._limitchildren = get_value("limitchildren")
-        self._maxchildren = get_value("maxchildren")
-        self._incimages = get_value("incimages")
-        self._imageonside = get_value("imageonside")
-        self._imagesize = get_value("imagesize")
-        self._useroundedcorners = get_value("useroundedcorners")
-        self._usesubgraphs = get_value("usesubgraphs")
-        self._incdates = get_value("incdates")
-        self._just_years = get_value("justyears")
-        self._incplaces = get_value("incplaces")
-        self._incchildcount = get_value("incchildcnt")
-        self.includeid = get_value("inc_id")
+    @property
+    def deleted_people(self):
+        """Number of people pruned by remove_uninteresting_parents()."""
+        return self._deleted_people
 
-        arrow_str = get_value("arrow")
-        if "d" in arrow_str:
-            self._arrowheadstyle = "normal"
-        else:
-            self._arrowheadstyle = "none"
-        if "a" in arrow_str:
-            self._arrowtailstyle = "normal"
-        else:
-            self._arrowtailstyle = "none"
+    @property
+    def deleted_families(self):
+        """Number of families pruned by remove_uninteresting_parents()."""
+        return self._deleted_families
 
-        # the gidlist is annoying for us to use since we always have to convert
-        # the GIDs to either Person or to handles, so we may as well convert the
-        # entire list right now and not have to deal with it ever again
-        self._interest_set = set()
-        if not self._gidlist:
-            raise ReportError(_("Empty report"), _("You did not specify anybody"))
-        for gid in self._gidlist.split():
-            person = self._db.get_person_from_gramps_id(gid)
-            if person:
-                # option can be from another family tree, so person can be None
-                self._interest_set.add(person.get_handle())
-
-        stdoptions.run_name_format_option(self, menu)
-
-        # convert the 'surnamecolors' string to a dictionary of names and colors
-        self._surnamecolors = {}
-        tmp = get_value("surnamecolors")
-        if tmp.find("\xb0") >= 0:
-            # new style delimiter (see bug report #2162)
-            tmp = tmp.split("\xb0")
-        else:
-            # old style delimiter
-            tmp = tmp.split(" ")
-
-        while len(tmp) > 1:
-            surname = tmp.pop(0).encode("iso-8859-1", "xmlcharrefreplace")
-            colour = tmp.pop(0)
-            self._surnamecolors[surname] = colour
-
-        self._colorize = get_value("color")
-
-    def begin_report(self):
+    def select(self):
         """
-        Inherited method; called by report() in _ReportDialog.py
+        Build and return the (people, families) handle sets for the report.
 
-        This is where we'll do all of the work of figuring out who
-        from the database is going to be output into the report
+        Mirrors the original FamilyLinesReport.begin_report() ordering:
+        follow parents (optionally pruning extra people), then follow
+        children.
         """
-
-        # starting with the people of interest, we then add parents:
         self._people.clear()
         self._families.clear()
         if self._followpar:
             self.find_parents()
-
             if self._removeextra:
                 self.remove_uninteresting_parents()
-
-        # ...and/or with the people of interest we add their children:
         if self._followchild:
             self.find_children()
-        # once we get here we have a full list of people
-        # and families that we need to generate a report
-
-    def write_report(self):
-        """
-        Inherited method; called by report() in _ReportDialog.py
-        """
-
-        # now that begin_report() has done the work, output what we've
-        # obtained into whatever file or format the user expects to use
-
-        self.doc.add_comment(
-            "# %s %d"
-            % (self._("Number of people in database:"), self._db.get_number_of_people())
-        )
-        self.doc.add_comment(
-            "# %s %d" % (self._("Number of people of interest:"), len(self._people))
-        )
-        self.doc.add_comment(
-            "# %s %d"
-            % (
-                self._("Number of families in database:"),
-                self._db.get_number_of_families(),
-            )
-        )
-        self.doc.add_comment(
-            "# %s %d" % (self._("Number of families of interest:"), len(self._families))
-        )
-        if self._removeextra:
-            self.doc.add_comment(
-                "# %s %d" % (self._("Additional people removed:"), self._deleted_people)
-            )
-            self.doc.add_comment(
-                "# %s %d"
-                % (self._("Additional families removed:"), self._deleted_families)
-            )
-        self.doc.add_comment("# %s" % self._("Initial list of people of interest:"))
-        for handle in self._interest_set:
-            person = self._db.get_person_from_handle(handle)
-            gid = person.get_gramps_id()
-            name = person.get_primary_name().get_regular_name()
-            # Translators: needed for Arabic, ignore otherwise
-            id_n = self._("%(str1)s, %(str2)s") % {"str1": gid, "str2": name}
-            self.doc.add_comment("# -> " + id_n)
-
-        self.write_people()
-        self.write_families()
+        return self._people, self._families
 
     def find_parents(self):
         """find the parents"""
@@ -769,6 +660,15 @@ class FamilyLinesReport(Report):
             if spouse_handle in self._interest_set:
                 continue
 
+            # a direct-line ancestor of a person of interest is never
+            # "extra": it was deliberately added by following parents up
+            # the tree.  Keep it whatever its surname -- ancestry is decided
+            # by lineage (parent links), not surname text, so a surname that
+            # drifts in spelling between generations no longer prunes the
+            # direct line (bug 10415 / 10400).
+            if person.get_handle() in self._direct_ancestors():
+                continue
+
             # if the surname (or the spouse's surname) matches a person
             # of interest, then we automatically keep this person
             keep_this_person = False
@@ -868,6 +768,226 @@ class FamilyLinesReport(Report):
 
         # we now merge our temp set "children_to_include" into our master set
         self._people.update(children_to_include)
+
+    def _direct_ancestors(self):
+        """
+        Return the set of person handles that are direct-line ancestors of
+        any person of interest (the people of interest themselves included).
+
+        Membership is decided purely by lineage -- walking parent-family
+        links upward -- and never by surname text, so an ancestor whose
+        surname spelling differs from the descendant's is still recognised
+        as part of the direct line.
+        """
+        if self._direct_ancestor_cache is not None:
+            return self._direct_ancestor_cache
+        ancestors = set()
+        to_visit = list(self._interest_set)
+        while to_visit:
+            handle = to_visit.pop()
+            if handle in ancestors:
+                continue
+            ancestors.add(handle)
+            person = self._db.get_person_from_handle(handle)
+            if not person:
+                continue
+            for family_handle in person.get_parent_family_handle_list():
+                family = self._db.get_family_from_handle(family_handle)
+                if not family:
+                    continue
+                for parent_handle in (
+                    family.get_father_handle(),
+                    family.get_mother_handle(),
+                ):
+                    if parent_handle and parent_handle not in ancestors:
+                        to_visit.append(parent_handle)
+        self._direct_ancestor_cache = ancestors
+        return ancestors
+
+
+# ------------------------------------------------------------------------
+#
+# FamilyLinesReport -- created once the user presses 'OK'
+#
+# ------------------------------------------------------------------------
+class FamilyLinesReport(Report):
+    """FamilyLines report"""
+
+    def __init__(self, database, options, user):
+        """
+        Create FamilyLinesReport object that eventually produces the report.
+
+        The arguments are:
+
+        database     - the Gramps database instance
+        options      - instance of the FamilyLinesOptions class for this report
+        user         - a gen.user.User() instance
+        name_format  - Preferred format to display names
+        incl_private - Whether to include private data
+        inc_id       - Whether to include IDs.
+        living_people - How to handle living people
+        years_past_death - Consider as living this many years after death
+        """
+        Report.__init__(self, database, options, user)
+
+        menu = options.menu
+        get_option_by_name = menu.get_option_by_name
+        get_value = lambda name: get_option_by_name(name).get_value()
+
+        self.set_locale(menu.get_option_by_name("trans").get_value())
+
+        stdoptions.run_date_format_option(self, menu)
+
+        stdoptions.run_private_data_option(self, menu)
+        stdoptions.run_living_people_option(self, menu, self._locale)
+        self.database = CacheProxyDb(self.database)
+        self._db = self.database
+
+        # initialize several convenient variables
+        self._people = set()  # handle of people we need in the report
+        self._families = set()  # handle of families we need in the report
+        self._deleted_people = 0
+        self._deleted_families = 0
+        self._user = user
+
+        self._followpar = get_value("followpar")
+        self._followchild = get_value("followchild")
+        self._removeextra = get_value("removeextra")
+        self._gidlist = get_value("gidlist")
+        self._colormales = get_value("colormales")
+        self._colorfemales = get_value("colorfemales")
+        self._colorother = get_value("colorother")
+        self._colorunknown = get_value("colorunknown")
+        self._colorfamilies = get_value("colorfamilies")
+        self._limitparents = get_value("limitparents")
+        self._maxparents = get_value("maxparents")
+        self._limitchildren = get_value("limitchildren")
+        self._maxchildren = get_value("maxchildren")
+        self._incimages = get_value("incimages")
+        self._imageonside = get_value("imageonside")
+        self._imagesize = get_value("imagesize")
+        self._useroundedcorners = get_value("useroundedcorners")
+        self._usesubgraphs = get_value("usesubgraphs")
+        self._incdates = get_value("incdates")
+        self._just_years = get_value("justyears")
+        self._incplaces = get_value("incplaces")
+        self._incchildcount = get_value("incchildcnt")
+        self.includeid = get_value("inc_id")
+
+        arrow_str = get_value("arrow")
+        if "d" in arrow_str:
+            self._arrowheadstyle = "normal"
+        else:
+            self._arrowheadstyle = "none"
+        if "a" in arrow_str:
+            self._arrowtailstyle = "normal"
+        else:
+            self._arrowtailstyle = "none"
+
+        # the gidlist is annoying for us to use since we always have to convert
+        # the GIDs to either Person or to handles, so we may as well convert the
+        # entire list right now and not have to deal with it ever again
+        self._interest_set = set()
+        if not self._gidlist:
+            raise ReportError(_("Empty report"), _("You did not specify anybody"))
+        for gid in self._gidlist.split():
+            person = self._db.get_person_from_gramps_id(gid)
+            if person:
+                # option can be from another family tree, so person can be None
+                self._interest_set.add(person.get_handle())
+
+        stdoptions.run_name_format_option(self, menu)
+
+        # convert the 'surnamecolors' string to a dictionary of names and colors
+        self._surnamecolors = {}
+        tmp = get_value("surnamecolors")
+        if tmp.find("\xb0") >= 0:
+            # new style delimiter (see bug report #2162)
+            tmp = tmp.split("\xb0")
+        else:
+            # old style delimiter
+            tmp = tmp.split(" ")
+
+        while len(tmp) > 1:
+            surname = tmp.pop(0).encode("iso-8859-1", "xmlcharrefreplace")
+            colour = tmp.pop(0)
+            self._surnamecolors[surname] = colour
+
+        self._colorize = get_value("color")
+
+    def begin_report(self):
+        """
+        Inherited method; called by report() in _ReportDialog.py
+
+        This is where we'll do all of the work of figuring out who
+        from the database is going to be output into the report
+        """
+
+        # The people/family selection is delegated to FamilyLinesSelection, a
+        # GUI-free unit that depends only on the database and the option flags
+        # (no doc, no menu, no Report base) so it can be unit-tested directly.
+        selection = FamilyLinesSelection(
+            self._db,
+            self._interest_set,
+            self._followpar,
+            self._followchild,
+            self._removeextra,
+            self._limitparents,
+            self._maxparents,
+            self._limitchildren,
+            self._maxchildren,
+            self._surnamecolors,
+        )
+        self._people, self._families = selection.select()
+        self._deleted_people = selection.deleted_people
+        self._deleted_families = selection.deleted_families
+        # once we get here we have a full list of people
+        # and families that we need to generate a report
+
+    def write_report(self):
+        """
+        Inherited method; called by report() in _ReportDialog.py
+        """
+
+        # now that begin_report() has done the work, output what we've
+        # obtained into whatever file or format the user expects to use
+
+        self.doc.add_comment(
+            "# %s %d"
+            % (self._("Number of people in database:"), self._db.get_number_of_people())
+        )
+        self.doc.add_comment(
+            "# %s %d" % (self._("Number of people of interest:"), len(self._people))
+        )
+        self.doc.add_comment(
+            "# %s %d"
+            % (
+                self._("Number of families in database:"),
+                self._db.get_number_of_families(),
+            )
+        )
+        self.doc.add_comment(
+            "# %s %d" % (self._("Number of families of interest:"), len(self._families))
+        )
+        if self._removeextra:
+            self.doc.add_comment(
+                "# %s %d" % (self._("Additional people removed:"), self._deleted_people)
+            )
+            self.doc.add_comment(
+                "# %s %d"
+                % (self._("Additional families removed:"), self._deleted_families)
+            )
+        self.doc.add_comment("# %s" % self._("Initial list of people of interest:"))
+        for handle in self._interest_set:
+            person = self._db.get_person_from_handle(handle)
+            gid = person.get_gramps_id()
+            name = person.get_primary_name().get_regular_name()
+            # Translators: needed for Arabic, ignore otherwise
+            id_n = self._("%(str1)s, %(str2)s") % {"str1": gid, "str2": name}
+            self.doc.add_comment("# -> " + id_n)
+
+        self.write_people()
+        self.write_families()
 
     def write_people(self):
         """write the people"""

--- a/gramps/plugins/graph/test/gvfamilylines_test.py
+++ b/gramps/plugins/graph/test/gvfamilylines_test.py
@@ -1,0 +1,189 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Unit test for the Family Lines Graph people/family selection.
+
+Bug 0010415 (originally 0010400): with "follow parents" on and "Try to
+remove extra people and families" on, the ``remove_uninteresting_parents``
+pruning dropped *direct-line ancestors* of the person of interest whenever
+their surname spelling differed across generations -- it kept an ancestor
+only via a surname-equality test, with no lineage-based criterion.  A
+top-of-tree direct ancestor whose surname spelling drifts (e.g. great-
+grandfather "Smyth" for a "Smith" descendant) was therefore removed.
+
+The test drives the production selection unit
+(:class:`gramps.plugins.graph.gvfamilylines.FamilyLinesSelection`, the same
+``find_parents`` + ``remove_uninteresting_parents`` code the report runs in
+``begin_report``) on a real in-memory database, and asserts that no direct-
+line ancestor is pruned regardless of surname spelling.
+"""
+
+import os
+import tempfile
+import unittest
+
+from gramps.gen.db.utils import import_as_dict
+from gramps.gen.user import User
+from gramps.plugins.graph.gvfamilylines import FamilyLinesSelection
+
+# A four-generation direct line for I0000.  The paternal surname drifts in
+# spelling every generation (Smith -> Smithe -> Smyth) and each generation
+# has a married-in spouse with an unrelated surname.  Every one of these
+# people is a direct-line ancestor of I0000:
+#
+#   I0000 Smith (F, person of interest)
+#     father  I0001 Smith   mother I0002 Brown            (F0000)
+#       I0001's father I0003 Smithe   mother I0004 Green   (F0001)
+#         I0003's father I0005 Smyth  mother I0006 White   (F0002)
+#
+# Pre-fix, the top-of-tree ancestors with a surname that differs from the
+# person of interest -- I0005 "Smyth" (the drifted direct paternal line) and
+# I0006 "White" -- are pruned as "extra".  Both must be retained.
+_FIXTURE_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE database PUBLIC "-//Gramps//DTD Gramps XML 1.7.2//EN"
+"http://gramps-project.org/xml/1.7.2/grampsxml.dtd">
+<database xmlns="http://gramps-project.org/xml/1.7.2/">
+  <header><created date="2026-06-27" version="5.2"/><researcher></researcher></header>
+  <people>
+    <person handle="_p0" id="I0000"><gender>F</gender>
+      <name type="Birth Name"><first>Anna</first><surname>Smith</surname></name>
+      <childof hlink="_f0"/></person>
+    <person handle="_p1" id="I0001"><gender>M</gender>
+      <name type="Birth Name"><first>John</first><surname>Smith</surname></name>
+      <childof hlink="_f1"/><parentin hlink="_f0"/></person>
+    <person handle="_p2" id="I0002"><gender>F</gender>
+      <name type="Birth Name"><first>Mary</first><surname>Brown</surname></name>
+      <parentin hlink="_f0"/></person>
+    <person handle="_p3" id="I0003"><gender>M</gender>
+      <name type="Birth Name"><first>James</first><surname>Smithe</surname></name>
+      <childof hlink="_f2"/><parentin hlink="_f1"/></person>
+    <person handle="_p4" id="I0004"><gender>F</gender>
+      <name type="Birth Name"><first>Eliza</first><surname>Green</surname></name>
+      <parentin hlink="_f1"/></person>
+    <person handle="_p5" id="I0005"><gender>M</gender>
+      <name type="Birth Name"><first>Robert</first><surname>Smyth</surname></name>
+      <parentin hlink="_f2"/></person>
+    <person handle="_p6" id="I0006"><gender>F</gender>
+      <name type="Birth Name"><first>Jane</first><surname>White</surname></name>
+      <parentin hlink="_f2"/></person>
+  </people>
+  <families>
+    <family handle="_f0" id="F0000"><rel type="Married"/>
+      <father hlink="_p1"/><mother hlink="_p2"/><childref hlink="_p0"/></family>
+    <family handle="_f1" id="F0001"><rel type="Married"/>
+      <father hlink="_p3"/><mother hlink="_p4"/><childref hlink="_p1"/></family>
+    <family handle="_f2" id="F0002"><rel type="Married"/>
+      <father hlink="_p5"/><mother hlink="_p6"/><childref hlink="_p3"/></family>
+  </families>
+</database>
+"""
+
+
+class FamilyLinesDirectAncestorTest(unittest.TestCase):
+    """Bug 10415: the remove-extra pruning must never drop a direct ancestor."""
+
+    @classmethod
+    def setUpClass(cls):
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".gramps", delete=False, encoding="utf8"
+        ) as handle:
+            handle.write(_FIXTURE_XML)
+            cls._path = handle.name
+        # Preserve the gramps IDs from the fixture so the test can look people
+        # up by ID.
+        cls.db = import_as_dict(
+            cls._path, User(), person_prefix="I%04d", family_prefix="F%04d"
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.db is not None:
+            cls.db.close()
+        try:
+            os.unlink(cls._path)
+        except OSError:
+            pass
+
+    def _handle(self, gramps_id):
+        person = self.db.get_person_from_gramps_id(gramps_id)
+        self.assertIsNotNone(person, "fixture person %s missing" % gramps_id)
+        return person.get_handle()
+
+    def _select(self):
+        """Run the production follow-parents + remove-extra selection."""
+        interest = {self._handle("I0000")}
+        selection = FamilyLinesSelection(
+            self.db,
+            interest,
+            followpar=True,
+            followchild=False,
+            removeextra=True,
+            limitparents=False,
+            maxparents=0,
+            limitchildren=False,
+            maxchildren=0,
+            surnamecolors={},
+        )
+        # Drive the exact routine begin_report() uses for the parent side.
+        selection.find_parents()
+        selection.remove_uninteresting_parents()
+        return selection
+
+    def test_drifting_surname_direct_ancestor_retained(self):
+        """The reporter's case: a direct ancestor whose surname spelling
+        differs from the descendant must not be pruned as "extra"."""
+        selection = self._select()
+        people = selection._people
+        # I0005 "Smyth" is the great-grandfather on the direct paternal line;
+        # his surname spelling drifted from the "Smith" person of interest.
+        self.assertIn(
+            self._handle("I0005"),
+            people,
+            "direct-line ancestor I0005 (Smyth) was pruned despite being "
+            "a direct ancestor of the person of interest",
+        )
+        # I0006 "White" is the great-grandmother (married into the line) --
+        # also a direct-line ancestor and equally must be kept.
+        self.assertIn(
+            self._handle("I0006"),
+            people,
+            "direct-line ancestor I0006 (White) was pruned",
+        )
+
+    def test_no_direct_ancestor_is_removed(self):
+        """Every person on the direct line survives the pruning, and the
+        report reports zero people removed."""
+        selection = self._select()
+        people = selection._people
+        for gid in ("I0000", "I0001", "I0002", "I0003", "I0004", "I0005", "I0006"):
+            self.assertIn(
+                self._handle(gid),
+                people,
+                "direct-line ancestor %s was pruned" % gid,
+            )
+        self.assertEqual(
+            selection.deleted_people,
+            0,
+            "no direct-line ancestor should be counted as removed",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -590,6 +590,7 @@ gramps/plugins/graph/__init__.py
 #
 gramps/plugins/graph/test/__init__.py
 gramps/plugins/graph/test/year_only_date_test.py
+gramps/plugins/graph/test/gvfamilylines_test.py
 #
 # plugins/importer directory
 #


### PR DESCRIPTION
## Summary
**User impact:** In the Family Lines Graph report, with "remove extra people and families" turned on, a genuine direct ancestor could be dropped from the chart. It happened when a family's surname spelling changed from one generation to the next (for example Smith → Smithe → Smyth): the older ancestor no longer matched the newer spelling, so the report treated a real bloodline ancestor as an outsider and left them out.

This makes the report keep anyone on the direct line of descent, so a surname that drifts in spelling no longer causes a real ancestor to disappear.

Reported in Mantis [#10415](https://gramps-project.org/bugs/view.php?id=10415).

## What to look at
The report now decides who belongs on the direct line by following parent-to-child links (actual lineage), not by comparing surname text. To try it: build a Family Lines Graph over a family whose surname spelling changes each generation, enable "remove extra people and families", and confirm the top-of-line ancestor and their married-in spouse are still shown. A new headless test drives exactly this on a four-generation line with a drifting surname.

## Root cause
The `remove_uninteresting_parents` method in `gramps/plugins/graph/gvfamilylines.py:664–822` keeps ancestors via a fixed set of heuristics to decide which people to include in the Family Lines Graph report when "remove extra people and families" is enabled. One heuristic (lines 772–791) checks if an ancestor's surname string matches any person of interest, with no lineage-based criterion independent of surname text.

A top-of-tree direct ancestor with a single child of interest, no further kept parents, and no person-of-interest status is kept *only* by the surname-equality test (lines 804–806); when that surname spelling drifts between generations, the legitimate bloodline ancestor is removed as "extra" despite being included by "follow parents".

## Fix
Extract the people/family-selection logic into a new GUI-free class `FamilyLinesSelection` (a testable seam: depends only on the database and option flags, not on the Report base or GUI machinery). The selection methods move verbatim from `FamilyLinesReport` to the new class with one change:

1. Add a new `_direct_ancestors()` method (line 260–293 in the patched file) that computes the transitive closure of parent links from the interest set, deciding membership purely by lineage (parent links), cached to avoid recomputation.

2. In `remove_uninteresting_parents`, check if a person's handle is in the direct-ancestor set *before* the surname heuristic (in the patched file, ahead of the surname-equality test). A direct-line ancestor is never "extra"; surname spelling drift no longer prunes the legitimate direct line.

3. `FamilyLinesReport.begin_report` now constructs a `FamilyLinesSelection`, calls its `select()` method, and copies the four results back onto `self` — production routes through the extracted unit; the report and the test drive the identical implementation.

## Verification
- **Claim:** a direct-line ancestor is never pruned as "extra" even when the surname spelling drifts between generations.
- **Checked:** on `maintenance/gramps61` — `gramps/plugins/graph/gvfamilylines.py:590–662` (`find_parents()` builds the initial direct-line set by recursively following parent-family links); `:664–822` (`remove_uninteresting_parents()` applies keep-heuristics; the new lineage-based criterion is checked before surname text matching (at the original lines 772–791); `:823–870` (`find_children()` extends the set downward, computed only from `find_parents` output); `po/POTFILES.skip` registers the new test file (no translatable strings, same style as `year_only_date_test.py`).
- **Test:** `gramps/plugins/graph/test/gvfamilylines_test.py` (new) drives the production `FamilyLinesSelection.find_parents()` + `remove_uninteresting_parents()` on a real in-memory database (`import_as_dict` from an inline fixture: a four-generation direct line where the paternal surname drifts each generation Smith → Smithe → Smyth, with a married-in spouse each generation). It asserts no direct-line ancestor is pruned, including I0005 "Smyth" (the drifted top-of-line great-grandfather) and I0006 "White" (the married-in great-grandmother). Import-light (`gvfamilylines` imports only `gramps.gen.*`, no `gramps.gui`), so it runs headless. Fails pre-fix, passes post-fix.

Fixes [#10415](https://gramps-project.org/bugs/view.php?id=10415)

