### PR TITLE
Use birth names in marriage narratives to prevent ambiguity

### DIFF
--- a/gramps/plugins/lib/libnarrate.py
+++ b/gramps/plugins/lib/libnarrate.py
@@ -37,6 +37,7 @@ from gramps.gen.lib.person import Person
 from gramps.gen.lib.eventroletype import EventRoleType
 from gramps.gen.lib.eventtype import EventType
 from gramps.gen.lib.familyreltype import FamilyRelType
+from gramps.gen.lib.nametype import NameType
 from gramps.gen.display.name import displayer as _nd
 from gramps.gen.display.place import displayer as _pd
 from gramps.gen.utils.alive import probably_alive
@@ -88,6 +89,44 @@ def convert_prefix(word):
         # Prefix a maqaf for non-Hebrew words and numbers
         word = "־" + word
     return word
+
+
+def _get_birth_name(person):
+    """
+    Return the person's Birth Name (a :class:`~.name.Name`), or None if the
+    person has no name of type ``NameType.BIRTH``.
+
+    The primary name is checked first so that, when the preferred name *is* a
+    birth name, it is the one returned.
+    """
+    for name in [person.get_primary_name()] + person.get_alternate_names():
+        if name and name.get_type() == NameType.BIRTH:
+            return name
+    return None
+
+
+def _get_spouse_name(spouse, name_display=None):
+    """
+    Return the name string used to refer to a spouse in a marriage /
+    relationship sentence of a narrative report (bug 4862).
+
+    The sentence describes a *past* event, so the spouse must be named by a
+    name that stays stable if the spouse later acquires a different preferred
+    name (e.g. after a divorce and remarriage). The spouse's Birth Name is
+    used when one exists; only when the spouse has no Birth Name do we fall
+    back to the currently-preferred primary name (the historical behaviour).
+
+    :param spouse: the spouse to be named.
+    :type spouse: :class:`~gen.lib.person.Person`
+    :param name_display: an object to be used for displaying names; when None
+        the global name displayer is used.
+    :type name_display: :class:`~gen.display.name.NameDisplay`
+    """
+    displayer = name_display if name_display is not None else _nd
+    name = _get_birth_name(spouse)
+    if name is None:
+        return displayer.display(spouse)
+    return displayer.display_name(name)
 
 
 # avoid normal translation!
@@ -2366,10 +2405,7 @@ class Narrator:
         if spouse_handle:
             spouse = self.__db.get_person_from_handle(spouse_handle)
             if spouse:
-                if not name_display:
-                    spouse_name = _nd.display(spouse)
-                else:
-                    spouse_name = name_display.display(spouse)
+                spouse_name = _get_spouse_name(spouse, name_display)
         if not spouse_name:
             spouse_name = self.__translate_text("Unknown")  # not: _("Unknown")
 

--- a/gramps/plugins/lib/test/libnarrate_test.py
+++ b/gramps/plugins/lib/test/libnarrate_test.py
@@ -1,0 +1,155 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Unit test for the spouse-name selection of
+:meth:`gramps.plugins.lib.libnarrate.Narrator.get_married_string`.
+
+Bug 0004862: in the marriage sentence of a narrative report
+("He married <name> on <date>.") the spouse was rendered with the spouse's
+*currently preferred* (primary) name. When the spouse later divorced and
+remarried, that preferred name became a later married name, so the sentence
+about the *earlier* marriage silently changed to the new name -- ambiguous.
+
+The fix names the spouse by a stable Birth Name when one exists, falling back
+to the preferred name only when the spouse has no Birth Name. These tests
+drive the production ``get_married_string`` path (not a copy) through a
+real :class:`~.Narrator` over in-memory Gramps objects.
+"""
+
+import unittest
+
+from gramps.gen.lib import (
+    Family,
+    FamilyRelType,
+    Name,
+    NameType,
+    Person,
+    Surname,
+)
+from gramps.plugins.lib.libnarrate import Narrator
+
+
+def _make_name(name_type, given, surname):
+    """Build a :class:`~.Name` of the given type, given name and surname."""
+    surname_obj = Surname()
+    surname_obj.set_surname(surname)
+    name = Name()
+    name.set_type(name_type)
+    name.set_first_name(given)
+    name.add_surname(surname_obj)
+    return name
+
+
+def _make_person(handle, gender, primary_name, alternate_names=()):
+    person = Person()
+    person.set_handle(handle)
+    person.set_gender(gender)
+    person.set_primary_name(primary_name)
+    for alt in alternate_names:
+        person.add_alternate_name(alt)
+    return person
+
+
+class _FakeDb:
+    """Minimal db: the narrator only needs to resolve the spouse handle."""
+
+    def __init__(self, people):
+        self._people = {p.get_handle(): p for p in people}
+
+    def get_person_from_handle(self, handle):
+        return self._people.get(handle)
+
+
+def _married_sentence(subject, spouse):
+    """Run the production get_married_string() path and return its sentence."""
+    family = Family()
+    family.set_father_handle(subject.get_handle())
+    family.set_mother_handle(spouse.get_handle())
+    family.set_relationship(FamilyRelType(FamilyRelType.MARRIED))
+
+    narrator = Narrator(_FakeDb([subject, spouse]), verbose=True)
+    narrator.set_subject(subject)
+    return narrator.get_married_string(family)
+
+
+class TestMarriedStringSpouseName(unittest.TestCase):
+    def setUp(self):
+        # The narrated subject; a plain Birth-named husband.
+        self.subject = _make_person(
+            "subj", Person.MALE, _make_name(NameType.BIRTH, "Peter", "Black")
+        )
+
+    def test_uses_birth_name_not_later_preferred_married_name(self):
+        """
+        Spouse whose *preferred* (primary) name is a later Married Name but who
+        still carries her Birth Name as an alternate must be named by the
+        stable Birth Name in the marriage sentence -- not the later name.
+        """
+        spouse = _make_person(
+            "sp",
+            Person.FEMALE,
+            _make_name(NameType.MARRIED, "Agnes", "White"),  # later preferred
+            [_make_name(NameType.BIRTH, "Agnes", "Red")],  # birth name
+        )
+
+        sentence = _married_sentence(self.subject, spouse)
+
+        self.assertIn("Red", sentence)
+        self.assertNotIn("White", sentence)
+
+    def test_stable_when_a_later_preferred_name_is_acquired(self):
+        """
+        Acquiring a later preferred (married) name must not change the name the
+        marriage sentence uses: it stays the spouse's Birth Name.
+        """
+        birth = _make_name(NameType.BIRTH, "Agnes", "Red")
+        before = _make_person("sp", Person.FEMALE, birth)
+        sentence_before = _married_sentence(self.subject, before)
+
+        # Same person later divorces and remarries: the preferred name becomes a
+        # later Married Name and the Birth Name is demoted to an alternate.
+        after = _make_person(
+            "sp",
+            Person.FEMALE,
+            _make_name(NameType.MARRIED, "Agnes", "White"),
+            [_make_name(NameType.BIRTH, "Agnes", "Red")],
+        )
+        sentence_after = _married_sentence(self.subject, after)
+
+        self.assertEqual(sentence_before, sentence_after)
+
+    def test_falls_back_to_preferred_name_without_a_birth_name(self):
+        """
+        When the spouse has no Birth Name the historical behaviour is kept: the
+        preferred (primary) name is used.
+        """
+        spouse = _make_person(
+            "sp",
+            Person.FEMALE,
+            _make_name(NameType.MARRIED, "Agnes", "White"),
+        )
+
+        sentence = _married_sentence(self.subject, spouse)
+
+        self.assertIn("White", sentence)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -612,6 +612,11 @@ gramps/plugins/lib/libodfbackend.py
 gramps/plugins/lib/libplaceimport.py
 gramps/plugins/lib/librecurse.py
 #
+# plugins/lib/test directory
+#
+gramps/plugins/lib/test/__init__.py
+gramps/plugins/lib/test/libnarrate_test.py
+#
 # plugins/lib/maps directory
 #
 gramps/plugins/lib/maps/__init__.py


### PR DESCRIPTION
## Summary
**User impact:** In narrative text reports (Detailed Descendant, Detailed Ancestor, and similar), a sentence about a past marriage names the spouse by whatever name they currently go by. If that spouse later divorced and remarried, the sentence about the *earlier* marriage silently uses the *later* married name — so the reader cannot tell which marriage the sentence is actually describing.

This names the spouse in marriage sentences by their birth name when they have one, so the sentence stays clear and unambiguous even after later name changes.

Reported in Mantis [#4862](https://gramps-project.org/bugs/view.php?id=4862).

## What to look at
The marriage sentence now refers to the spouse by a stable birth name where one exists, falling back to the current preferred name for anyone without one (so output is unchanged for them). To try it: run a Detailed Descendant report over a couple where the wife's preferred name is a later married name but she keeps her birth name as an alternate — the marriage sentence should name her by her birth name, and should read identically before and after she acquires the later name. A new headless test covers all three cases.

## Root cause
In narrative text reports (Detailed Descendant, Detailed Ancestor, etc.), the spouse in a marriage sentence is rendered with the spouse's currently-preferred (primary) name using `name_display.display(spouse)`. When the spouse later divorces and remarries, their preferred name changes to a later married name, so the past-tense sentence about the *earlier* marriage silently becomes ambiguous — the reader cannot tell which marriage the sentence refers to.

The shared narrator method (`gramps/plugins/lib/libnarrate.py:2369-2372` on the target branch) needs to name the spouse by a stable reference unaffected by later name changes.

## Fix
Added two helper functions to `gramps/plugins/lib/libnarrate.py`:
- `_get_birth_name(person)` — scans the person's primary and alternate names, returning the first name of type `NameType.BIRTH` if present
- `_get_spouse_name(spouse, name_display)` — displays the spouse using their birth name when present; otherwise falls back to the currently-preferred name (preserving output for everyone without a separate birth name)

Modified `Narrator.get_married_string()` to call `_get_spouse_name()` instead of the inline `name_display.display(spouse)` code. This single change in the shared narrator fixes the spouse-naming issue for all narrative reports that use it. Added `NameType` import after the existing imports. Registered the new test files (`gramps/plugins/lib/test/__init__.py` and `gramps/plugins/lib/test/libnarrate_test.py`) in `po/POTFILES.skip` as test-only files with no translatable strings.

## Verification
- **Claim:** a spouse with a birth name is named by that stable birth name in the marriage sentence, so the sentence reads identically regardless of any later preferred name; spouses without a birth name are unaffected.
- **Checked:** on `maintenance/gramps61` — `gramps/plugins/lib/libnarrate.py:39` (import location for `NameType`), `:91-94` (where the new helper functions are added), `:2369-2372` (the original spouse-naming code replaced by the helper call); `po/POTFILES.skip:610+` (test file registration area).
- **Test:** `gramps/plugins/lib/test/libnarrate_test.py` (new; gramps core `test/` package, `*_test.py` suffix) drives the production `Narrator.get_married_string()` path over in-memory Gramps objects: `test_uses_birth_name_not_later_preferred_married_name` (spouse whose preferred name is a later married name but who retains her birth name as an alternate must be named by the stable birth name), `test_stable_when_a_later_preferred_name_is_acquired` (the same spouse before and after acquiring a later preferred married name must yield the identical sentence), and `test_falls_back_to_preferred_name_without_a_birth_name` (non-regression: no birth name → preferred name still used). Import-light (no `gi`/`gramps.gui`), so it runs headless. Verified red→green: tests 1 and 2 fail without the fix (AssertionError on the spouse surname); test 3 stays green both ways.

Fixes [#4862](https://gramps-project.org/bugs/view.php?id=4862)
