### PR TITLE
Fix date quality keyword matching inside words

### DIFF
--- a/gramps/gen/datehandler/_dateparser.py
+++ b/gramps/gen/datehandler/_dateparser.py
@@ -525,7 +525,10 @@ class DateParser:
         self._ny = re.compile(r"(.*)\s+\(%s\)( ?.*)" % self._ny_str, re.IGNORECASE)
         self._ny_iso = re.compile(r"(.*)\s+\((\d{1,2}-\d{1,2})\)( ?.*)")
 
-        self._qual = re.compile(r"(.* ?)%s\s+(.+)" % self._qual_str, re.IGNORECASE)
+        # The \b before the quality keyword anchors it to a word boundary so a
+        # keyword embedded in an unrelated word (e.g. "est" inside "Test") is not
+        # stripped, mangling otherwise-free-text date input (bug 5516).
+        self._qual = re.compile(r"(.* ?)\b%s\s+(.+)" % self._qual_str, re.IGNORECASE)
 
         self._span = re.compile(
             r"(from)\s+(?P<start>.+)\s+to\s+(?P<stop>.+)", re.IGNORECASE

--- a/gramps/gen/datehandler/test/dateparser_test.py
+++ b/gramps/gen/datehandler/test/dateparser_test.py
@@ -117,6 +117,27 @@ class DateParserTest(unittest.TestCase):
         self.assertEqual(date.get_quality(), Date.QUAL_CALCULATED)
         self.assertEqual(date.get_calendar(), Date.CAL_JULIAN)
 
+    def test_quality_keyword_not_matched_inside_word(self):
+        # Regression (bug 5516): a free-text date that merely CONTAINS a quality
+        # keyword as a substring of an ordinary word must be preserved, not
+        # mangled. "Test data" was stored as "Tdata" (the "est" inside "Test"
+        # was stripped) and wrongly marked estimated.
+        date = self.parser.parse("Test data")
+        self.assertEqual(date.get_modifier(), Date.MOD_TEXTONLY)
+        self.assertEqual(date.get_text(), "Test data")
+        self.assertEqual(date.get_quality(), Date.QUAL_NONE)
+
+    def test_quality_keyword_whole_token_still_parses(self):
+        # The genuine quality-prefixed dates must keep parsing as before.
+        for text, qual in (
+            ("est 1900", Date.QUAL_ESTIMATED),
+            ("estimated 1900", Date.QUAL_ESTIMATED),
+            ("calc 1900", Date.QUAL_CALCULATED),
+        ):
+            date = self.parser.parse(text)
+            self.assertEqual(date.get_quality(), qual, msg=text)
+            self.assertEqual(date.get_year(), 1900, msg=text)
+
 
 class Test_generate_variants(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
**User impact:** When Gramps reads a free-text date, an ordinary word that happens to contain a date-quality keyword got mangled. For example a date typed as "Test data" came back as "Tdata" — Gramps spotted "est" (the keyword for "estimated") buried inside "Test" and stripped it out, corrupting the text.

This makes Gramps recognise a quality keyword only when it stands as its own word, so ordinary words are left untouched while genuine "est 1900"-style dates still parse.

Reported in Mantis [#5516](https://gramps-project.org/bugs/view.php?id=5516).

## What to look at
The fix adds a word-boundary so a quality keyword must be a whole word, not a fragment inside another word. To try it: enter a date of "Test data" and confirm it stays "Test data" (quality: none, not estimated); enter "est 1900" and confirm it is still read as an estimated date for the year 1900. Two new regression tests cover both directions.

## Root cause
The `DateParser.match_quality` method uses a regex (gramps/gen/datehandler/_dateparser.py:528) with an unanchored leading group and no word-boundary anchor before the quality keyword, so keywords like "est" match as substrings inside unrelated words. For input "Test data", the pattern matched group(1)="T", the keyword "est" inside "Test", then group(3)="data", and the match handler stripped the keyword, yielding corrupted text "Tdata".

## Fix
Add a word-boundary anchor `\b` before the quality keyword alternation in the regex pattern at gramps/gen/datehandler/_dateparser.py:528, changing from `r"(.* ?)%s\s+(.+)"` to `r"(.* ?)\b%s\s+(.+)"`. This ensures the keyword matches only as a whole token, so "est" inside "Test" no longer triggers, while genuinely quality-prefixed dates ("est 1900", "calculated 1900") continue to match and parse correctly.

## Verification
- **Claim:** a quality keyword is stripped only when it appears as a whole word; free text containing the keyword as a fragment is preserved, and genuine quality-prefixed dates still parse.
- **Checked:** `gramps/gen/datehandler/_dateparser.py:528` on `maintenance/gramps61` — the regex now anchors the quality-keyword alternation with `\b`; `gramps/gen/datehandler/test/dateparser_test.py:117+` — regression tests added to the existing `DateParserTest` class.
- **Test:** `gramps/gen/datehandler/test/dateparser_test.py` — `test_quality_keyword_not_matched_inside_word()` verifies "Test data" parses as a free-text date with text preserved (not "Tdata") and quality QUAL_NONE; `test_quality_keyword_whole_token_still_parses()` verifies "est 1900", "estimated 1900", "calc 1900" still parse with the correct quality (QUAL_ESTIMATED / QUAL_CALCULATED) and year. Verified end-to-end against the real `DateParser` on the target base commit with the patch applied ("Test data" → text "Test data", QUAL_NONE; "est 1900" → QUAL_ESTIMATED, year 1900); with the production code reverted the test is red.

Fixes [#5516](https://gramps-project.org/bugs/view.php?id=5516)
