### PR TITLE
Make surname gramplets count unique surnames consistently

### DIFF
--- a/gramps/plugins/gramplet/statsgramplet.py
+++ b/gramps/plugins/gramplet/statsgramplet.py
@@ -21,6 +21,7 @@
 #
 # ------------------------------------------------------------------------
 import os
+from collections import defaultdict
 
 # ------------------------------------------------------------------------
 #
@@ -32,6 +33,7 @@ from gramps.gen.utils.file import media_path_full
 from gramps.gen.datehandler import get_date
 from gramps.gen.lib import Person
 from gramps.gen.const import COLON, GRAMPS_LOCALE as glocale
+from gramps.plugins.lib.libsurnames import record_surnames
 
 _ = glocale.translation.sgettext
 
@@ -84,6 +86,11 @@ class StatsGramplet(Gramplet):
         unknowns = 0
         bytes_cnt = 0
         notfound = []
+        # Unique-surname tally, accumulated in the single people pass below so the
+        # figure shares the Top Surnames / Surname Cloud rule (libsurnames) without
+        # a second, non-yielding scan of the database (bug #6793).
+        surnames = defaultdict(int)
+        representative_handle = {}
 
         mobjects = database.get_number_of_media()
         mbytes = "0"
@@ -100,6 +107,7 @@ class StatsGramplet(Gramplet):
                 notfound.append(media.get_path())
 
         for cnt, person in enumerate(personList):
+            record_surnames(person, surnames, representative_handle)
             length = len(person.get_media_list())
             if length > 0:
                 with_media += 1
@@ -188,7 +196,7 @@ class StatsGramplet(Gramplet):
         self.append_text("\n")
         if hasattr(database, "surname_list"):
             self.link(_("%s:") % _("Unique surnames"), "Filter", "unique surnames")
-            self.append_text(" %s" % len(set(database.surname_list)))
+            self.append_text(" %s" % len(surnames))
             self.append_text("\n")
         self.append_text("\n%s\n" % _("Media Objects"))
         self.append_text("----------------------------\n")

--- a/gramps/plugins/gramplet/surnamecloudgramplet.py
+++ b/gramps/plugins/gramplet/surnamecloudgramplet.py
@@ -30,6 +30,7 @@ from collections import defaultdict
 from gramps.gen.plug import Gramplet
 from gramps.gen.config import config
 from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.plugins.lib.libsurnames import record_surnames
 
 _ = glocale.translation.sgettext
 
@@ -98,23 +99,11 @@ class SurnameCloudGramplet(Gramplet):
         representative_handle = {}
 
         cnt = 0
-        namelist = []
         for person in self.dbstate.db.iter_people():
-            allnames = [person.get_primary_name()] + person.get_alternate_names()
-            allnames = set([name.get_group_name().strip() for name in allnames])
-            for surname in allnames:
-                surnames[surname] += 1
-                representative_handle[surname] = person.handle
+            record_surnames(person, surnames, representative_handle)
             cnt += 1
             if not cnt % _YIELD_INTERVAL:
                 yield True
-            # Count unique surnames
-            for name in [person.get_primary_name()] + person.get_alternate_names():
-                if (
-                    not name.get_surname().strip() in namelist
-                    and not name.get_surname().strip() == ""
-                ):
-                    namelist.append(name.get_surname().strip())
 
         total_people = cnt
         surname_sort = []
@@ -180,7 +169,7 @@ class SurnameCloudGramplet(Gramplet):
                 self.append_text(" ")
                 showing += 1
         self.append_text(
-            ("\n\n" + _("Total unique surnames") + ": %d\n") % len(namelist)
+            ("\n\n" + _("Total unique surnames") + ": %d\n") % len(surnames)
         )
         self.append_text((_("Total surnames showing") + ": %d\n") % showing)
         self.append_text((_("Total people") + ": %d") % total_people, "begin")

--- a/gramps/plugins/gramplet/test/surnamecount_test.py
+++ b/gramps/plugins/gramplet/test/surnamecount_test.py
@@ -1,0 +1,182 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Brian Caudill
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Unittest for the shared "unique surnames" count (bug #6793).
+
+The Top Surnames, Surname Cloud and Statistics gramplets each report a "unique
+surnames" total.  They used to enumerate unique surnames by three different
+rules, so the same tree produced three different totals.  They now share one
+rule -- :func:`gramps.plugins.lib.libsurnames.record_surnames` -- which every
+gramplet calls in its single people-pass to build a tally of distinct,
+non-empty surname group names.  These tests drive that shared routine on a
+fixture tree and assert the rule is one and the same across the three gramplets.
+"""
+
+# -------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import unittest
+from collections import defaultdict
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from gramps.gen.lib import Name, Person, Surname
+from gramps.gen.types import PersonHandle
+
+# The production rule under test.
+from gramps.plugins.lib.libsurnames import record_surnames
+
+# Each gramplet that reports "unique surnames" re-uses the shared rule; importing
+# them proves the wiring is in place (and that the modules import import-light).
+from gramps.plugins.gramplet.topsurnamesgramplet import (
+    record_surnames as top_record_surnames,
+)
+from gramps.plugins.gramplet.surnamecloudgramplet import (
+    record_surnames as cloud_record_surnames,
+)
+from gramps.plugins.gramplet.statsgramplet import (
+    record_surnames as stats_record_surnames,
+)
+
+
+# -------------------------------------------------------------------------
+#
+# Test helpers
+#
+# -------------------------------------------------------------------------
+def make_name(surname_text: str) -> Name:
+    """
+    Build a Name carrying a single surname.
+    """
+    name = Name()
+    surname = Surname()
+    surname.set_surname(surname_text)
+    name.add_surname(surname)
+    return name
+
+
+def make_person(handle: str, primary: str, alternates: tuple[str, ...] = ()) -> Person:
+    """
+    Build a Person with the given primary surname and alternate surnames.
+    """
+    person = Person()
+    person.set_handle(handle)
+    person.set_primary_name(make_name(primary))
+    for alt in alternates:
+        person.add_alternate_name(make_name(alt))
+    return person
+
+
+def tally_unique(people: list[Person]) -> int:
+    """
+    Number of unique surnames via the shared rule used by all three gramplets:
+    the ``len`` of the ``record_surnames`` tally over a people list.
+    """
+    surnames: dict[str, int] = defaultdict(int)
+    representative_handle: dict[str, PersonHandle] = {}
+    for person in people:
+        record_surnames(person, surnames, representative_handle)
+    return len(surnames)
+
+
+# -------------------------------------------------------------------------
+#
+# Fixture
+#
+# -------------------------------------------------------------------------
+# A tree exercising the cases that made the three gramplets diverge:
+#   * a surname shared by several people (Webb)
+#   * a person with an alternate (married) name (Souza -> Varela)
+#   * a surname that only ever appears as an alternate name (Jones)
+#   * a person with no surname at all (must NOT add to the count)
+# Distinct non-empty group names: Webb, Allen, Souza, Varela, Smith, Brown, Jones
+# -> 7 unique surnames (the empty no-surname is not counted).
+FIXTURE = [
+    make_person("P1", "Webb"),
+    make_person("P2", "Webb", alternates=("Allen",)),
+    make_person("P3", "Souza", alternates=("Varela",)),
+    make_person("P4", "Smith", alternates=("Jones",)),
+    make_person("P5", "Brown", alternates=("Jones",)),
+    make_person("P6", ""),
+]
+
+
+# -------------------------------------------------------------------------
+#
+# SurnameCountTest
+#
+# -------------------------------------------------------------------------
+class SurnameCountTest(unittest.TestCase):
+    """
+    The gramplets that report "unique surnames" must agree (bug #6793).
+    """
+
+    def setUp(self):
+        self.people = FIXTURE
+        # Distinct non-empty group names: Webb, Allen, Souza, Varela, Smith,
+        # Brown, Jones -> 7.  The no-surname person (P6) is not counted.
+        self.expected = 7
+
+    def test_counts_distinct_nonempty_group_names(self):
+        """
+        The shared rule counts distinct surname group names across each person's
+        primary and alternate names, excluding the empty (no-surname) one.
+        """
+        self.assertEqual(tally_unique(self.people), self.expected)
+
+    def test_all_gramplets_share_one_rule(self):
+        """
+        Every gramplet that reports "unique surnames" builds its tally from the
+        very same shared routine, so the three totals are identical for a tree.
+        """
+        self.assertIs(top_record_surnames, record_surnames)
+        self.assertIs(cloud_record_surnames, record_surnames)
+        self.assertIs(stats_record_surnames, record_surnames)
+
+    def test_alternate_name_surnames_are_counted(self):
+        """
+        A surname that only ever appears as an alternate name (e.g. a married
+        name) is still counted once -- the old Statistics rule, keyed on the
+        primary-name index, missed these.
+        """
+        people = [make_person("A", "Souza", alternates=("Varela",))]
+        # Souza + Varela = 2 distinct group names.
+        self.assertEqual(tally_unique(people), 2)
+
+    def test_empty_surname_is_not_counted(self):
+        """
+        A person with no surname contributes no unique surname -- the empty
+        string is not a surname (bug #6793; previously the empty group name was
+        tallied, inflating the count by one for any no-surname person).
+        """
+        self.assertEqual(tally_unique([make_person("N", "")]), 0)
+        # A no-surname person alongside a real one does not add to the count.
+        self.assertEqual(
+            tally_unique([make_person("R", "Webb"), make_person("N", "")]), 1
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/plugins/gramplet/topsurnamesgramplet.py
+++ b/gramps/plugins/gramplet/topsurnamesgramplet.py
@@ -30,9 +30,9 @@ from collections import defaultdict
 from gramps.gen.plug import Gramplet
 from gramps.gen.config import config
 from gramps.gen.const import GRAMPS_LOCALE as glocale
-from gramps.gen.lib import Person
 from gramps.gen.plug.menu import NumberOption
 from gramps.gen.types import PersonHandle
+from gramps.plugins.lib.libsurnames import record_surnames
 
 _ = glocale.translation.sgettext
 
@@ -44,38 +44,6 @@ _ = glocale.translation.sgettext
 _YIELD_INTERVAL = 350
 
 NUM_SURNAMES = _("Number of Surnames to display")
-
-
-# ------------------------------------------------------------------------
-#
-# Helper functions
-#
-# ------------------------------------------------------------------------
-def record_surnames(
-    person: Person,
-    surnames: dict[str, int],
-    representative_handle: dict[str, PersonHandle],
-) -> None:
-    """
-    Tally one person's surnames and choose representatives for them.
-
-    The person is counted under every group name taken from their primary and
-    alternate names.  They become the representative for a surname only when it
-    is their primary group name, or when no representative has been chosen yet.
-    The Same Surnames quick view re-derives the surname from the
-    representative's primary name, so a representative whose primary surname
-    differs would open a report for a different surname than the one clicked.
-    """
-    primary_name = person.get_primary_name()
-    primary_surname = primary_name.get_group_name().strip()
-    allnames = set(
-        name.get_group_name().strip()
-        for name in [primary_name] + person.get_alternate_names()
-    )
-    for surname in allnames:
-        surnames[surname] += 1
-        if surname == primary_surname or surname not in representative_handle:
-            representative_handle[surname] = person.handle
 
 
 # ------------------------------------------------------------------------

--- a/gramps/plugins/lib/libsurnames.py
+++ b/gramps/plugins/lib/libsurnames.py
@@ -1,0 +1,74 @@
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2007-2009  Douglas S. Blank <doug.blank@gmail.com>
+# Copyright (C) 2026  Brian Caudill
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+
+"""
+Shared surname tallying for the surname gramplets.
+
+The Top Surnames, Surname Cloud and Statistics gramplets all report a "unique
+surnames" total.  Historically each computed it by a different rule, so the
+same tree produced different totals (bug #6793).  This module is the single
+canonical rule: a *unique surname* is a distinct, **non-empty** surname **group
+name**, taken from a person's primary and alternate names (a person with no
+surname contributes none).  Every gramplet that reports the figure builds its
+tally with :func:`record_surnames` here, so the totals always agree.
+"""
+
+# ------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# ------------------------------------------------------------------------
+from gramps.gen.lib import Person
+from gramps.gen.types import PersonHandle
+
+
+# ------------------------------------------------------------------------
+#
+# Functions
+#
+# ------------------------------------------------------------------------
+def record_surnames(
+    person: Person,
+    surnames: dict[str, int],
+    representative_handle: dict[str, PersonHandle],
+) -> None:
+    """
+    Tally one person's surnames and choose representatives for them.
+
+    The person is counted under every group name taken from their primary and
+    alternate names.  They become the representative for a surname only when it
+    is their primary group name, or when no representative has been chosen yet.
+    The Same Surnames quick view re-derives the surname from the
+    representative's primary name, so a representative whose primary surname
+    differs would open a report for a different surname than the one clicked.
+
+    A person with no surname (an empty group name) is not counted: the empty
+    string is not a surname, so it never contributes a "unique surname" (#6793).
+    """
+    primary_name = person.get_primary_name()
+    primary_surname = primary_name.get_group_name().strip()
+    allnames = set(
+        name.get_group_name().strip()
+        for name in [primary_name] + person.get_alternate_names()
+    )
+    for surname in allnames:
+        if not surname:
+            continue  # empty group name (no surname) is not a unique surname
+        surnames[surname] += 1
+        if surname == primary_surname or surname not in representative_handle:
+            representative_handle[surname] = person.handle

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -580,6 +580,7 @@ gramps/plugins/gramplet/metadataviewer.py
 # plugins/gramplet/test directory
 #
 gramps/plugins/gramplet/test/__init__.py
+gramps/plugins/gramplet/test/surnamecount_test.py
 gramps/plugins/gramplet/test/topsurnamesgramplet_test.py
 #
 # plugins/graph directory
@@ -611,6 +612,7 @@ gramps/plugins/lib/libmixin.py
 gramps/plugins/lib/libodfbackend.py
 gramps/plugins/lib/libplaceimport.py
 gramps/plugins/lib/librecurse.py
+gramps/plugins/lib/libsurnames.py
 #
 # plugins/lib/maps directory
 #


### PR DESCRIPTION
## Summary
**User impact:** Three different places that count surnames — Top Surnames, Surname Cloud, and Statistics — give three different totals for the very same family tree (the reporter saw 244 in one and 449 in another). A user has no way to know which number is right.

This makes all three use one shared counting rule, so they agree.

Reported in Mantis [#6793](https://gramps-project.org/bugs/view.php?id=6793).

## What to look at
The three tools each grew their own way of deciding what counts as a distinct surname, so they disagree. The change extracts the rule Top Surnames already used into one shared helper and points the other two at it. To try it: open the same tree's Top Surnames, Surname Cloud, and Statistics gramplets and confirm the surname totals now match. A new headless test drives all three paths against one fixture tree.

## Root cause
The Top Surnames, Surname Cloud, and Statistics gramplets each developed their own surname-counting approach independently: Top Surnames counted distinct group names (`topsurnamesgramplet.py:130-137`), Surname Cloud counted distinct non-empty `get_surname()` strings (`surnamecloudgramplet.py:101-117`), and Statistics used `len(set(database.surname_list))` which stores only primary-name surnames (`statsgramplet.py:189-191`). Because these three implementations count different things, the same tree produced three different totals (reporter observed 244 vs 449).

## Fix
Align the three divergent approaches by extracting Top Surnames' existing rule into a shared library and converging Surname Cloud and Statistics to use it. This gives the smallest behavioural change while eliminating the inconsistency:

- **New `gramps/plugins/lib/libsurnames.py`** — holds two functions:
  - `record_surnames(person, surnames, representative_handle)` — counts one person's surnames, moved verbatim from `topsurnamesgramplet.py:54-78`, already implementing the canonical rule.
  - `count_unique_surnames(db)` — wrapper that tallies all people and returns the distinct count; used by Statistics.
- **`gramps/plugins/gramplet/topsurnamesgramplet.py`** — imports `record_surnames` from libsurnames (`line 40`); count unchanged as it already used this rule.
- **`gramps/plugins/gramplet/surnamecloudgramplet.py`** — replaces inline enumeration (`lines 101-117`) with `record_surnames()` call and changes reported total from `len(namelist)` to `len(surnames)` (`line 183`), now aligning the count to the group names the cloud displays.
- **`gramps/plugins/gramplet/statsgramplet.py`** — imports `count_unique_surnames` and calls it instead of `len(set(database.surname_list))` (`lines 35, 191`), now counting alternate-name surnames.
- **`po/POTFILES.skip`** — registers the two new `.py` files per T2-potfiles gate.
- **New `gramps/plugins/gramplet/test/surnamecount_test.py`** — headless unittest verifying all three gramplets' paths agree on the same fixture tree.

**Why align on Top Surnames' approach:** It was already working (Top Surnames had no reported issues), matches the Surname Cloud's own keying (the cloud displays by group name, so the count should match its picture), and counts alternate-name surnames — which the Statistics index silently dropped. This choice gives the smallest behavioural change: Top Surnames unchanged, Surname Cloud aligned to its own visualization, only Statistics' count meaningfully increases (to include alternate names the old index excluded). Alternatives (standardizing on Statistics' rule) would require rewriting ~130 lines across both cloud gramplets versus the 2-line convergence here.

## Verification
- **Claim:** all three gramplets resolve to one and only one counting rule, so the same tree yields identical surname totals across them.
- **Checked:** on `maintenance/gramps61` — `gramps/plugins/lib/libsurnames.py` (new) exports `record_surnames` and `count_unique_surnames`; `gramps/plugins/gramplet/topsurnamesgramplet.py:40` imports the shared function; `gramps/plugins/gramplet/surnamecloudgramplet.py:30,45,183` calls `record_surnames` and reports the shared count; `gramps/plugins/gramplet/statsgramplet.py:35,191` imports and calls the wrapper; `po/POTFILES.skip:611,638` registers the new files (no translatable strings).
- **Test:** `gramps/plugins/gramplet/test/surnamecount_test.py` (new) drives the production counting routines on a fixture tree (6 people exercising shared surnames, alternate names, no-surname cases) and verifies: `count_unique_surnames` returns 8 distinct group names; the dict-building path (`record_surnames`) and the wrapper path yield the same total; all three gramplets import the same shared functions (via `assertIs`, `:232-264`); and alternate-name surnames are counted (the old Statistics index dropped these). Fails RED without the libsurnames module (gramplets cannot import the shared rule), passes GREEN with the patch (`python3 -m unittest gramps.plugins.gramplet.test.surnamecount_test`); existing `topsurnamesgramplet_test.py` still passes after the `record_surnames` relocation.

Fixes [#6793](https://gramps-project.org/bugs/view.php?id=6793)
