### PR TITLE
Fix patronymic surname fragmentation in gramplet counts

### DIFF
--- a/gramps/plugins/gramplet/statsgramplet.py
+++ b/gramps/plugins/gramplet/statsgramplet.py
@@ -32,6 +32,7 @@ from gramps.gen.utils.file import media_path_full
 from gramps.gen.datehandler import get_date
 from gramps.gen.lib import Person
 from gramps.gen.const import COLON, GRAMPS_LOCALE as glocale
+from gramps.plugins.gramplet.surnamecounter import get_counting_surname
 
 _ = glocale.translation.sgettext
 
@@ -84,6 +85,7 @@ class StatsGramplet(Gramplet):
         unknowns = 0
         bytes_cnt = 0
         notfound = []
+        unique_surnames = set()
 
         mobjects = database.get_number_of_media()
         mbytes = "0"
@@ -104,6 +106,13 @@ class StatsGramplet(Gramplet):
             if length > 0:
                 with_media += 1
                 total_media += length
+
+            # Identify the family surname under which this person is counted,
+            # collapsing non-primary patronymic/matronymic components so a
+            # shared family surname counts once (bug #6988).
+            primary_surname = get_counting_surname(person.get_primary_name()).strip()
+            if primary_surname:
+                unique_surnames.add(primary_surname)
 
             for name in [person.get_primary_name()] + person.get_alternate_names():
                 if name.get_first_name().strip() == "":
@@ -188,7 +197,7 @@ class StatsGramplet(Gramplet):
         self.append_text("\n")
         if hasattr(database, "surname_list"):
             self.link(_("%s:") % _("Unique surnames"), "Filter", "unique surnames")
-            self.append_text(" %s" % len(set(database.surname_list)))
+            self.append_text(" %s" % len(unique_surnames))
             self.append_text("\n")
         self.append_text("\n%s\n" % _("Media Objects"))
         self.append_text("----------------------------\n")

--- a/gramps/plugins/gramplet/surnamecloudgramplet.py
+++ b/gramps/plugins/gramplet/surnamecloudgramplet.py
@@ -30,6 +30,7 @@ from collections import defaultdict
 from gramps.gen.plug import Gramplet
 from gramps.gen.config import config
 from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.plugins.gramplet.surnamecounter import get_counting_surname
 
 _ = glocale.translation.sgettext
 
@@ -108,13 +109,13 @@ class SurnameCloudGramplet(Gramplet):
             cnt += 1
             if not cnt % _YIELD_INTERVAL:
                 yield True
-            # Count unique surnames
+            # Count unique surnames, collapsing non-primary patronymic/
+            # matronymic components so a shared family surname counts once
+            # (bug #6988).
             for name in [person.get_primary_name()] + person.get_alternate_names():
-                if (
-                    not name.get_surname().strip() in namelist
-                    and not name.get_surname().strip() == ""
-                ):
-                    namelist.append(name.get_surname().strip())
+                surname = get_counting_surname(name).strip()
+                if surname and surname not in namelist:
+                    namelist.append(surname)
 
         total_people = cnt
         surname_sort = []

--- a/gramps/plugins/gramplet/surnamecounter.py
+++ b/gramps/plugins/gramplet/surnamecounter.py
@@ -1,0 +1,79 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps developers
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Shared surname-counting helper for the surname gramplets.
+
+The "Total unique surnames" / "Unique surnames" tallies of the Surname Cloud
+and Statistics gramplets keyed off the *full* multi-component surname string
+(``Name.get_surname()``).  A person whose name carries a primary family surname
+plus a separate patronymic-origin surname therefore produced a distinct entry
+per patronymic ("Иванов Петрович", "Иванов Сергеевич", ...) instead of the one
+family surname "Иванов" they share (bug #6988).
+
+:func:`get_counting_surname` derives the surname string under which such a name
+should be counted, dropping non-primary surname components of patronymic or
+matronymic origin while leaving every other surname component (e.g. a Spanish
+maternal name) untouched.
+"""
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from gramps.gen.lib import Name
+from gramps.gen.lib.nameorigintype import NameOriginType
+
+# Non-primary surname components of these origins are excluded from the count:
+# they identify the individual (a patronymic/matronymic), not the shared family
+# surname the tally is meant to group people by.
+_EXCLUDED_ORIGINS = (NameOriginType.PATRONYMIC, NameOriginType.MATRONYMIC)
+
+
+def get_counting_surname(name):
+    """
+    Return the surname string used to count/identify *name*'s surname.
+
+    Non-primary surname components of patronymic or matronymic origin are
+    dropped before the surname is formatted, so that people who share a family
+    surname but carry different patronymics are counted as one surname.  When
+    there is nothing patronymic to drop (or it is the only component), the
+    unchanged :meth:`~.surnamebase.SurnameBase.get_surname` string is returned.
+
+    :param name: the name to derive the counting surname from
+    :type name: :class:`~.name.Name`
+    :returns: the family-surname string used for counting
+    :rtype: str
+    """
+    surname_list = name.get_surname_list()
+    kept = [
+        surname
+        for surname in surname_list
+        if surname.get_primary() or surname.get_origintype() not in _EXCLUDED_ORIGINS
+    ]
+    if not kept or len(kept) == len(surname_list):
+        # nothing to drop, or only patronymic components: defer to the
+        # existing full-surname formatting unchanged.
+        return name.get_surname()
+    # Reuse the production surname formatting on the filtered list rather than
+    # re-implementing it: build a throwaway Name over the kept components.
+    counted = Name()
+    counted.set_surname_list(kept)
+    return counted.get_surname()

--- a/gramps/plugins/gramplet/test/patronymic_surname_count_test.py
+++ b/gramps/plugins/gramplet/test/patronymic_surname_count_test.py
@@ -1,0 +1,160 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps developers
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Unittest for bug #6988: the surname gramplets must count a person carrying a
+primary family surname plus a separate patronymic-origin surname under the one
+family surname ("Иванов"), not one entry per patronymic combination.
+
+The test drives the production counting routine
+(:func:`~.surnamecounter.get_counting_surname`) that both the Surname Cloud and
+the Statistics gramplets route through — not a copy of it.
+"""
+
+# -------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import unittest
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from gramps.gen.lib import Name, Surname
+from gramps.gen.lib.nameorigintype import NameOriginType
+from gramps.plugins.gramplet.surnamecounter import get_counting_surname
+
+
+# -------------------------------------------------------------------------
+#
+# Test helpers
+#
+# -------------------------------------------------------------------------
+def make_surname(text, origin=None, primary=False):
+    """
+    Build a single Surname component with the given text/origin/primary flag.
+    """
+    surname = Surname()
+    surname.set_surname(text)
+    surname.set_primary(primary)
+    if origin is not None:
+        surname.set_origintype(origin)
+    return surname
+
+
+def make_name(*surnames):
+    """
+    Build a Name carrying the given ordered Surname components.
+    """
+    name = Name()
+    name.set_surname_list(list(surnames))
+    return name
+
+
+# -------------------------------------------------------------------------
+#
+# PatronymicSurnameCountTest
+#
+# -------------------------------------------------------------------------
+class PatronymicSurnameCountTest(unittest.TestCase):
+    """
+    Bug #6988: patronymic-origin surnames must not fragment the surname count.
+    """
+
+    def test_patronymic_collapses_to_family_surname(self):
+        """
+        A name with primary "Иванов" plus a patronymic-origin "Петрович" is
+        counted under the family surname "Иванов" alone.
+        """
+        name = make_name(
+            make_surname("Иванов", origin=NameOriginType.INHERITED, primary=True),
+            make_surname("Петрович", origin=NameOriginType.PATRONYMIC),
+        )
+        # Document the bug: the full surname string fragments the count.
+        self.assertEqual(name.get_surname(), "Иванов Петрович")
+        # The fix: the counting routine yields the family surname only.
+        self.assertEqual(get_counting_surname(name), "Иванов")
+
+    def test_different_patronymics_share_one_counting_surname(self):
+        """
+        People sharing "Иванов" but with different patronymics map to the same
+        counting surname, so they tally as one unique surname.
+        """
+        surnames = {
+            get_counting_surname(
+                make_name(
+                    make_surname(
+                        "Иванов", origin=NameOriginType.INHERITED, primary=True
+                    ),
+                    make_surname(patronymic, origin=NameOriginType.PATRONYMIC),
+                )
+            )
+            for patronymic in ("Петрович", "Сергеевич", "Андреевич")
+        }
+        self.assertEqual(surnames, {"Иванов"})
+
+    def test_matronymic_also_collapses(self):
+        """
+        Matronymic-origin non-primary components are dropped as well.
+        """
+        name = make_name(
+            make_surname("Иванов", origin=NameOriginType.INHERITED, primary=True),
+            make_surname("Марьевич", origin=NameOriginType.MATRONYMIC),
+        )
+        self.assertEqual(get_counting_surname(name), "Иванов")
+
+    def test_plain_single_surname_unchanged(self):
+        """
+        A name without any patronymic component is counted exactly as before.
+        """
+        name = make_name(
+            make_surname("Smith", origin=NameOriginType.INHERITED, primary=True)
+        )
+        self.assertEqual(get_counting_surname(name), "Smith")
+        self.assertEqual(get_counting_surname(name), name.get_surname())
+
+    def test_non_patronymic_secondary_surname_preserved(self):
+        """
+        A non-primary surname of a non-patronymic origin (e.g. a Spanish
+        maternal name) is kept, so only patronymics are collapsed.
+        """
+        name = make_name(
+            make_surname("García", origin=NameOriginType.INHERITED, primary=True),
+            make_surname("Pérez", origin=NameOriginType.INHERITED),
+        )
+        self.assertEqual(get_counting_surname(name), name.get_surname())
+        self.assertIn("Pérez", get_counting_surname(name))
+
+    def test_only_patronymic_component_falls_back(self):
+        """
+        When the patronymic is the *only* surname component there is nothing
+        else to count, so the unchanged surname string is returned rather than
+        an empty key.
+        """
+        name = make_name(
+            make_surname("Петрович", origin=NameOriginType.PATRONYMIC, primary=True)
+        )
+        self.assertEqual(get_counting_surname(name), "Петрович")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -576,10 +576,12 @@ gramps/plugins/gramplet/filter.py
 gramps/plugins/gramplet/gallery.py
 gramps/plugins/gramplet/mediapreview.py
 gramps/plugins/gramplet/metadataviewer.py
+gramps/plugins/gramplet/surnamecounter.py
 #
 # plugins/gramplet/test directory
 #
 gramps/plugins/gramplet/test/__init__.py
+gramps/plugins/gramplet/test/patronymic_surname_count_test.py
 gramps/plugins/gramplet/test/topsurnamesgramplet_test.py
 #
 # plugins/graph directory


### PR DESCRIPTION
## Summary
**User impact:** In trees that use Russian-style patronymic names, the surname count and Surname Cloud are inflated: one family shows up as many separate entries — "Ivanov Petrovich", "Ivanov Sergeevich", "Ivanov Andreevich" instead of a single "Ivanov" — so the totals are wrong and the cloud is fragmented.

This teaches the counting to ignore the patronymic part of a name so each family is counted once.

Reported in Mantis [#6988](https://gramps-project.org/bugs/view.php?id=6988).

## What to look at
Add a family whose people carry a primary family surname plus a separate patronymic-origin surname, then open the Surname Cloud and Statistics gramplets: the family should count as one surname, not one-per-patronymic. The change routes both gramplets through a shared helper that drops only patronymic/matronymic non-primary parts while keeping other secondary surnames (e.g. a Spanish maternal name). A new headless test drives the helper directly. Note: whether patronymics should be excluded or grouped is a design call flagged for sign-off (see Fix).

## Root cause
The Surname Cloud and Statistics gramplets enumerate the full multi-component surname string (via `Name.get_surname()`) without distinguishing origin, so non-primary surnames of patronymic origin inflate and fragment the tally. A person with a primary family surname "Иванов" plus a separate `PATRONYMIC`-origin surname therefore produces one entry per patronymic variant ("Иванов Петрович", "Иванов Сергеевич", "Иванов Андреевич") instead of a single family surname count.

The root cause is located in how the gramplets key their counts: Surname Cloud builds its `namelist` from `name.get_surname().strip()` (`surnamecloudgramplet.py:111-117`), and Statistics tallies `len(set(database.surname_list))` which is keyed off `surname_list[0].surname` positionally without origin awareness (`statsgramplet.py:191`).

## Fix
A shared counting routine `get_counting_surname(name)` in a new module `gramps/plugins/gramplet/surnamecounter.py` filters the surname list to drop non-primary components of `PATRONYMIC` or `MATRONYMIC` origin, then reuses the production `Name.get_surname()` formatting on the kept components. This collapses patronymic noise while preserving other secondary surnames (e.g. Spanish maternal names).

Both gramplets are wired to route through this helper:
- **Surname Cloud** (`surnamecloudgramplet.py`): the `namelist` tally now calls `get_counting_surname(name)` for each name instead of `name.get_surname()`.
- **Statistics** (`statsgramplet.py`): unique surnames accumulate via the helper from each person's primary name, and the display shows `len(unique_surnames)` instead of `len(set(database.surname_list))`.

Both new `.py` files are registered in `po/POTFILES.skip` (no translatable strings).

**Design choice (patronymic exclusion vs grouping):** this fix chooses **origin-aware exclusion** of only patronymic/matronymic non-primary components, preserving every other secondary surname (e.g. a Spanish maternal name "García **Pérez**" stays intact as "García Pérez"). The alternative — using `get_group_name()` — would silently drop *all* secondary surnames, collapsing "García Pérez" to "García" alone. Exclusion is the smaller behavioural change; the correct treatment is a design call worth a maintainer's confirmation. If grouping by primary surname alone is preferred, the single predicate in `surnamecounter.py:150` can be changed. **Secondary Statistics change:** for prefixed surnames ("van der Berg") the Statistics count key changes from the bare surname ("Berg", from `database.surname_list[0].surname`) to the formatted family surname with prefix ("van der Berg", from `get_counting_surname()`) — arguably more correct and now consistent with Surname Cloud and Top Surnames, but a change beyond the patronymic case.

## Verification
- **Claim:** a primary family surname plus a patronymic-origin component counts as the single family surname, while non-patronymic secondary surnames are preserved.
- **Checked:** on `maintenance/gramps61` — `gramps/plugins/gramplet/surnamecloudgramplet.py:111-117` (the `namelist` tally now calls the helper); `gramps/plugins/gramplet/statsgramplet.py:84-114` (the person loop / surname tally now accumulates via the helper) and `:189-191` (display switches from `len(set(database.surname_list))` to the accumulated set); `po/POTFILES.skip` registers the new non-translatable modules.
- **Test:** `gramps/plugins/gramplet/test/patronymic_surname_count_test.py` (new) drives the production `get_counting_surname()` helper with a constructed `Name` bearing a primary "Иванов" plus a `PATRONYMIC`-origin "Петрович", asserting the counting surname is "Иванов" alone; further cases verify that different patronymics of the same family surname map to the same key, matronymics collapse identically, non-patronymic secondaries are preserved ("García Pérez"), and edge cases (single-component, only-patronymic names) fall back to existing behaviour. Verified by hand against the clean upstream worktree via `python3 -m unittest`: RED (production reverted, test kept) → `ModuleNotFoundError: gramps.plugins.gramplet.surnamecounter`; GREEN (patch applied) → all 6 tests pass.

Fixes [#6988](https://gramps-project.org/bugs/view.php?id=6988)

