### PR TITLE
Fix get_age returning None when primary birth event has no date

### DIFF
--- a/gramps/gen/utils/db.py
+++ b/gramps/gen/utils/db.py
@@ -50,42 +50,68 @@ PRIMARY_EVENT_ROLES = [EventRoleType.FAMILY, EventRoleType.PRIMARY]
 # Fallback functions
 #
 # -------------------------------------------------------------------------
-def get_birth_or_fallback(db, person, format=None):
+def _has_usable_date(event):
+    """
+    Return True when *event* carries a date usable for age computation,
+    i.e. a date that is valid and not empty (the same test ``get_age``
+    applies before it computes a span).
+    """
+    date = event.get_date_object()
+    return bool(date) and date.get_valid() and not date.is_empty()
+
+
+def get_birth_or_fallback(db, person, format=None, require_date=False):
     """
     Get BIRTH event from a person, or fallback to an event around
     the time of birth.
+
+    :param require_date: when True, a primary Birth event without a usable
+        date is skipped so that a dated birth-fallback event (e.g. Baptism)
+        can be returned instead. Defaults to False, preserving the original
+        behaviour for callers that want the primary event regardless of its
+        date (e.g. to display a birth place).
     """
     birth_ref = person.get_birth_ref()
     if birth_ref:  # regular birth found
         event = db.get_event_from_handle(birth_ref.ref)
-        if event:
+        if event and (not require_date or _has_usable_date(event)):
             return event
 
     # now search the event list for fallbacks
     for event_ref in person.get_primary_event_ref_list():
         event = db.get_event_from_handle(event_ref.ref)
         if event and event.type.is_birth_fallback() and event_ref.role.is_primary():
+            if require_date and not _has_usable_date(event):
+                continue
             if format:
                 event.date.format = format
             return event
     return None
 
 
-def get_death_or_fallback(db, person, format=None):
+def get_death_or_fallback(db, person, format=None, require_date=False):
     """
     Get a DEATH event from a person, or fallback to an
     event around the time of death.
+
+    :param require_date: when True, a primary Death event without a usable
+        date is skipped so that a dated death-fallback event (e.g. Burial)
+        can be returned instead. Defaults to False, preserving the original
+        behaviour for callers that want the primary event regardless of its
+        date.
     """
     death_ref = person.get_death_ref()
     if death_ref:  # regular death found
         event = db.get_event_from_handle(death_ref.ref)
-        if event:
+        if event and (not require_date or _has_usable_date(event)):
             return event
 
     # now search the event list for fallbacks
     for event_ref in person.get_primary_event_ref_list():
         event = db.get_event_from_handle(event_ref.ref)
         if event and event.type.is_death_fallback() and event_ref.role.is_primary():
+            if require_date and not _has_usable_date(event):
+                continue
             if format:
                 event.date.format = format
             return event
@@ -106,8 +132,8 @@ def get_age(db, person, fallback=True, calendar="gregorian"):
         # a handle is passed
         person = db.get_person_from_handle(person)
     if fallback:
-        birth = get_birth_or_fallback(db, person)
-        death = get_death_or_fallback(db, person)
+        birth = get_birth_or_fallback(db, person, require_date=True)
+        death = get_death_or_fallback(db, person, require_date=True)
     else:
         birth_ref = person.get_birth_ref()
         if birth_ref:  # regular birth found

--- a/gramps/gen/utils/test/db_test.py
+++ b/gramps/gen/utils/test/db_test.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Tests for the get_age birth/death date-fallback behaviour
+(gramps.gen.utils.db.get_age).
+"""
+
+import unittest
+
+from ...db import DbTxn
+from ...db.utils import make_database
+from ...lib import Date, Event, EventRef, EventType, Person, Place
+from ..db import get_age
+
+
+def _make_db():
+    """Create and return a fresh in-memory SQLite database."""
+    db = make_database("sqlite")
+    db.load(":memory:")
+    return db
+
+
+def _add_event(db, trans, event_type, year=0, month=0, day=0, place=None):
+    """Create an event of *event_type* with the given date; return its handle."""
+    event = Event()
+    event.set_type(EventType(event_type))
+    date = Date()
+    if year or month or day:
+        date.set_yr_mon_day(year, month, day)
+    event.set_date_object(date)
+    if place is not None:
+        event.set_place_handle(place)
+    return db.add_event(event, trans)
+
+
+class TestGetAgeFallback(unittest.TestCase):
+    """
+    A dateless primary Birth event must not mask a dated Baptism
+    (birth-fallback) event when computing a person's age.
+    """
+
+    def setUp(self):
+        self.db = _make_db()
+
+    def tearDown(self):
+        self.db.close()
+
+    def _age(self, person_handle):
+        return get_age(self.db, self.db.get_person_from_handle(person_handle))
+
+    def test_dateless_birth_falls_back_to_dated_baptism(self):
+        """
+        Person with a dateless (place-only) Birth event, a dated Baptism
+        event, and a dated Death event: get_age must compute the age from the
+        Baptism date rather than returning None.
+        """
+        with DbTxn("test", self.db) as trans:
+            place = Place()
+            place.set_title("Somewhere")
+            place_handle = self.db.add_place(place, trans)
+
+            # Primary Birth event: a place, but no date.
+            birth_handle = _add_event(
+                self.db, trans, EventType.BIRTH, place=place_handle
+            )
+            birth_ref = EventRef()
+            birth_ref.set_reference_handle(birth_handle)
+
+            # Baptism (birth-fallback) event with a usable date.
+            baptism_handle = _add_event(
+                self.db, trans, EventType.BAPTISM, year=1850, month=3, day=15
+            )
+            baptism_ref = EventRef()
+            baptism_ref.set_reference_handle(baptism_handle)
+
+            # Dated Death event.
+            death_handle = _add_event(
+                self.db, trans, EventType.DEATH, year=1900, month=3, day=15
+            )
+            death_ref = EventRef()
+            death_ref.set_reference_handle(death_handle)
+
+            person = Person()
+            person.set_birth_ref(birth_ref)
+            person.add_event_ref(baptism_ref)
+            person.set_death_ref(death_ref)
+            handle = self.db.add_person(person, trans)
+
+        age = self._age(handle)
+        self.assertIsNotNone(age, "Expected age from dated baptism fallback, got None")
+        # 1850-03-15 .. 1900-03-15 == 50 years.
+        self.assertEqual(age[0], 50)
+
+    def test_dated_primary_birth_unaffected(self):
+        """A person whose primary Birth event has a date is unaffected."""
+        with DbTxn("test", self.db) as trans:
+            birth_handle = _add_event(
+                self.db, trans, EventType.BIRTH, year=1850, month=3, day=15
+            )
+            birth_ref = EventRef()
+            birth_ref.set_reference_handle(birth_handle)
+
+            # A baptism with a *different* date that must NOT be used.
+            baptism_handle = _add_event(
+                self.db, trans, EventType.BAPTISM, year=1849, month=1, day=1
+            )
+            baptism_ref = EventRef()
+            baptism_ref.set_reference_handle(baptism_handle)
+
+            death_handle = _add_event(
+                self.db, trans, EventType.DEATH, year=1900, month=3, day=15
+            )
+            death_ref = EventRef()
+            death_ref.set_reference_handle(death_handle)
+
+            person = Person()
+            person.set_birth_ref(birth_ref)
+            person.add_event_ref(baptism_ref)
+            person.set_death_ref(death_ref)
+            handle = self.db.add_person(person, trans)
+
+        age = self._age(handle)
+        self.assertIsNotNone(age)
+        self.assertEqual(age[0], 50)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -327,6 +327,7 @@ gramps/gen/utils/docgen/tabbeddoc.py
 #
 gramps/gen/utils/test/alive_test.py
 gramps/gen/utils/test/callback_test.py
+gramps/gen/utils/test/db_test.py
 gramps/gen/utils/test/file_test.py
 gramps/gen/utils/test/grampslocale_test.py
 gramps/gen/utils/test/keyword_test.py


### PR DESCRIPTION
## Summary
**User impact:** When a person's birth record has no date but a dated baptism is recorded, their age shows as blank instead of being worked out from the baptism date. The fallback that is supposed to fill in for a missing birth date is ignored.

This lets age calculation skip a dateless birth event and use the dated baptism (or burial, for death) fallback instead.

Reported in Mantis [#7832](https://gramps-project.org/bugs/view.php?id=7832).

## What to look at
Give a person a birth event with a place but no date, plus a dated baptism and a dated death, and confirm their age is now computed (from the baptism) rather than left blank. The change adds an opt-in "require a usable date" mode to the birth/death fallback lookup so a dateless primary event no longer masks a dated fallback. A new headless test drives the production `get_age` path.

## Root cause
`get_birth_or_fallback` and `get_death_or_fallback` (`gramps/gen/utils/db.py:53–74`) return the primary Birth/Death event as soon as one exists, regardless of whether it has a usable date. When a person has a dateless primary Birth event and a dated Baptism fallback, `get_age` (`gramps/gen/utils/db.py:95`) receives the dateless event and, after finding its date invalid (line 120: `birth_date.get_valid() and not birth_date.is_empty()`), returns `None` instead of consulting the dated fallback.

## Fix
Add an opt-in `require_date=False` parameter to `get_birth_or_fallback` (line 53) and `get_death_or_fallback` (line 74), plus a shared `_has_usable_date(event)` helper. When `require_date=True`, a primary event without a usable date is skipped, allowing a dated fallback (e.g. Baptism for birth, Burial for death) to be returned instead. `get_age` now calls both helpers with `require_date=True` (lines 109–110 on the fallback path), while existing callers default to `require_date=False` and see no behaviour change.

## Verification
- **Claim:** a dateless primary birth/death event no longer masks a dated fallback in age calculation, and dated-primary paths are unchanged.
- **Checked:** `gramps/gen/utils/db.py:53–74` (`get_birth_or_fallback`/`get_death_or_fallback` signatures and fallback-selection logic), `:95–126` (`get_age`, including the validity check at `:120–122`), and `:109–110` (the fallback branch calls with `require_date=True`) on `maintenance/gramps61`; `po/POTFILES.skip` — existing `*_test.py` entries matched.
- **Test:** `gramps/gen/utils/test/db_test.py` (new) — a headless unittest (no `gi`/`gramps.gui`) with two cases: `test_dateless_birth_falls_back_to_dated_baptism` verifies a person with a dateless place-only Birth, a dated Baptism, and a dated Death yields an age (50 years) computed from the Baptism, not `None`; `test_dated_primary_birth_unaffected` verifies a dated primary Birth still computes age from that birth (not from a differently-dated Baptism), so the fix does not regress the dated-primary path. The test drives the production `get_age` path (the same function fanchartview calls), not a re-implementation — fails pre-fix, passes post-fix.

Fixes [#7832](https://gramps-project.org/bugs/view.php?id=7832)
