### PR TITLE
Fix gender_stats column swap on DBAPI save/read (bug 11314)

### DIFF
--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -1102,7 +1102,20 @@ class DBAPI(DbGeneric):
         Returns a dictionary of
         {given_name: (male_count, female_count, unknown_count)}
         """
-        self.dbapi.execute("SELECT given_name, female, male, unknown FROM gender_stats")
+        if self._get_metadata("gender_stats_fixed", default=False):
+            # Bug 11314: tables written by a fixed Gramps store each count in
+            # the like-named column, so read them in column-name order.
+            self.dbapi.execute(
+                "SELECT given_name, male, female, unknown FROM gender_stats"
+            )
+        else:
+            # Legacy tables (written before bug 11314 was fixed) stored the
+            # male and female counts in the swapped columns. Read them in that
+            # swapped order so the in-memory (male, female, unknown) tuple is
+            # still correct and the data is not silently inverted on read.
+            self.dbapi.execute(
+                "SELECT given_name, female, male, unknown FROM gender_stats"
+            )
         gstats = {}
         for row in self.dbapi.fetchall():
             gstats[row[0]] = (row[1], row[2], row[3])
@@ -1112,13 +1125,19 @@ class DBAPI(DbGeneric):
         self._txn_begin()
         self.dbapi.execute("DELETE FROM gender_stats")
         for key in gstats.stats:
-            female, male, unknown = gstats.stats[key]
+            # Bug 11314: GenderStats stores (male, female, unknown); write each
+            # count into the like-named column so external SQL consumers see
+            # correct data.
+            male, female, unknown = gstats.stats[key]
             self.dbapi.execute(
                 "INSERT INTO gender_stats "
-                "(given_name, female, male, unknown) "
+                "(given_name, male, female, unknown) "
                 "VALUES (?, ?, ?, ?)",
-                [key, female, male, unknown],
+                [key, male, female, unknown],
             )
+        # Mark the table as using the corrected column order so get_gender_stats
+        # reads it back consistently (and legacy tables are detected as such).
+        self._set_metadata("gender_stats_fixed", True, use_txn=False)
         self._txn_commit()
 
     def undo_reference(self, data, handle):

--- a/gramps/plugins/db/dbapi/test/db_test.py
+++ b/gramps/plugins/db/dbapi/test/db_test.py
@@ -31,6 +31,7 @@ import unittest
 # -------------------------------------------------------------------------
 from gramps.gen.db import DbTxn
 from gramps.gen.db.utils import make_database
+from gramps.gen.lib.genderstats import GenderStats
 from gramps.gen.lib import (
     Person,
     Family,
@@ -911,6 +912,51 @@ class DbPersonTest(unittest.TestCase):
         saved = self.db.get_gender_stats()
         self.assertEqual(saved["John"], (3, 1, 1))
         self.assertEqual(saved["Mary"], (1, 3, 1))
+
+    def test_gender_stats_column_semantics(self):
+        """
+        Bug 11314: each named gender_stats column must hold the count its name
+        denotes. The in-memory GenderStats tuple is (male, female, unknown);
+        use an asymmetric, controlled value so a male/female swap is detectable.
+        Assert the raw on-disk columns directly (not via get_gender_stats, which
+        would round-trip any swap back out), and that the round-trip preserves
+        the (male, female, unknown) ordering.
+        """
+        stats = GenderStats({"Probe": (5, 2, 1)})  # 5 male, 2 female, 1 unknown
+        self.db.save_gender_stats(stats)
+        self.db.dbapi.execute(
+            "SELECT male, female, unknown FROM gender_stats WHERE given_name = ?",
+            ["Probe"],
+        )
+        self.assertEqual(self.db.dbapi.fetchone(), (5, 2, 1))
+        # in-memory round-trip preserves (male, female, unknown)
+        self.assertEqual(self.db.get_gender_stats()["Probe"], (5, 2, 1))
+
+    def test_gender_stats_legacy_not_inverted(self):
+        """
+        Bug 11314: a tree saved before the fix stored the male/female columns
+        swapped and carries no corrected-order marker. Reading such a table back
+        must still yield the correct in-memory (male, female, unknown) tuple --
+        i.e. the legacy data must not be silently inverted on read.
+        """
+        self.db._txn_begin()
+        self.db.dbapi.execute("DELETE FROM gender_stats")
+        self.db.dbapi.execute(
+            "DELETE FROM metadata WHERE setting = ?", ["gender_stats_fixed"]
+        )
+        # Reproduce exactly what the pre-fix save_gender_stats wrote: it unpacked
+        # the (male, female, unknown) tuple as "female, male, unknown" and stored
+        # those into the like-named columns, so the female column held the male
+        # count and vice versa. Probe = 5 male / 2 female / 1 unknown on disk:
+        self.db.dbapi.execute(
+            "INSERT INTO gender_stats (given_name, female, male, unknown) "
+            "VALUES (?, ?, ?, ?)",
+            ["Probe", 5, 2, 1],
+        )
+        self.db._txn_commit()
+        saved = self.db.get_gender_stats()
+        # in-memory order is (male, female, unknown): male=5, female=2, unknown=1
+        self.assertEqual(saved["Probe"], (5, 2, 1))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
**User impact:** The male and female gender counts Gramps saves into the database file are stored in swapped columns. Inside Gramps everything looks fine, but anyone who opens the database with an external tool (the reporter used DB Browser) sees the female count under "male" and vice versa.

This saves the counts into the correctly labelled columns while still reading old, swapped databases correctly.

Reported in Mantis [#11314](https://gramps-project.org/bugs/view.php?id=11314).

## What to look at
Save a tree, then open its SQLite database in an external viewer and check the gender-stats columns now match their labels. The change fixes the tuple unpacking on save and adds a one-time marker so pre-fix databases are still read back correctly (their swapped layout is inverted on read until they heal on next save). Two headless regression tests drive the real DBAPI backend.

## Root cause
The DBAPI backend's `save_gender_stats` and `get_gender_stats` both treated the in-memory `GenderStats` tuple as `(female, male, unknown)` when it actually stores `(male, female, unknown)`, so each count landed in the opposite database column. This produced correctly round-tripping in-memory data but persisted mislabeled columns visible to external SQL consumers (e.g. DB Browser for the reporter).

## Fix
`gramps/plugins/db/dbapi/dbapi.py`:

1. `save_gender_stats` now unpacks the tuple correctly as `male, female, unknown = gstats.stats[key]` (lines 1128–1129 post-fix) and inserts into the like-named columns (line 1137). It also sets a metadata marker `gender_stats_fixed = True` (line 1140) to track corrected tables.
2. `get_gender_stats` branches on that marker (lines 1104–1116 post-fix): with marker, it reads the corrected column order; without it (legacy pre-fix tables), it reads the swapped order and re-applies the same inversion so the in-memory tuple is still correct and data is not silently inverted on read.

## Verification
- **Claim:** counts persist to the correctly labelled columns, and legacy (pre-fix, swapped, unmarked) tables still read back to the correct in-memory tuple.
- **Checked:** on `maintenance/gramps61` — `gramps/gen/lib/genderstats.py:116` (tuple construction order `(male, female, unknown)`); `gramps/plugins/db/dbapi/dbapi.py:1105–1109` and `:1115–1121` (the pre-fix legacy read/unpack orders being corrected); `gramps/gen/db/generic.py:918` (saves gender stats on close, so legacy data heals to the corrected layout on the first save after upgrade).
- **Test:** `gramps/plugins/db/dbapi/test/db_test.py` — two regression tests drive the production `save_gender_stats`/`get_gender_stats` on a real in-memory SQLite DBAPI backend (not a logic copy): `test_gender_stats_column_semantics` (`:66–83`) asserts the raw on-disk columns store the correct counts and the in-memory round-trip preserves order; `test_gender_stats_legacy_not_inverted` (`:85–109`) ensures a pre-fix-format row (swapped columns, no marker) reads back correctly, guarding against a naive fix that would break backward compatibility. Pre-fix the raw columns fail the semantic check; a naive fix without the legacy branch fails the compatibility check. Verified end-to-end: green with the fix, red without it; black formatting check passed.

Fixes [#11314](https://gramps-project.org/bugs/view.php?id=11314)

