### PR TITLE
Fix misspelling in Media Manager help text

### DIFF
--- a/gramps/plugins/tool/mediamanager.py
+++ b/gramps/plugins/tool/mediamanager.py
@@ -637,7 +637,7 @@ class Convert2Rel(BatchOp):
     description = _(
         "This tool allows converting absolute media paths "
         "to a relative path. The relative path is relative "
-        "viz-a-viz the base path as given in the Preferences, "
+        "vis-à-vis the base path as given in the Preferences, "
         "or if that is not set, user's directory. "
         "A relative path allows to tie the file location to "
         "a base path that can change to your needs."

--- a/gramps/plugins/tool/test/mediamanager_test.py
+++ b/gramps/plugins/tool/test/mediamanager_test.py
@@ -1,0 +1,53 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Eduard Ralph
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Unittest for the Media Manager "absolute to relative" help text (bug 13354).
+
+The Convert2Rel batch-op's ``description`` is the tooltip/help shown for the
+"Convert paths from absolute to relative" step. It contained the misspelling
+"viz-a-viz"; the correct form is "vis-à-vis". This asserts the corrected word
+on the production class attribute, so a regression that reintroduces the typo
+fails the build.
+"""
+
+import unittest
+
+from gramps.plugins.tool.mediamanager import Convert2Rel
+
+
+# ------------------------------------------------------------
+#
+# Convert2RelHelpTextTest
+#
+# ------------------------------------------------------------
+class Convert2RelHelpTextTest(unittest.TestCase):
+    """The 'absolute -> relative' help text is spelled correctly (bug 13354)."""
+
+    def test_no_viz_a_viz_typo(self):
+        """The misspelling 'viz-a-viz' is gone from the help text."""
+        self.assertNotIn("viz-a-viz", Convert2Rel.description)
+
+    def test_uses_vis_a_vis(self):
+        """The help text uses the correct word 'vis-à-vis'."""
+        self.assertIn("vis-à-vis", Convert2Rel.description)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -688,6 +688,8 @@ gramps/plugins/thumbnailer/imagethumb.py
 # Development tools
 #
 gramps/plugins/tool/__init__.py
+gramps/plugins/tool/test/__init__.py
+gramps/plugins/tool/test/mediamanager_test.py
 #
 # plugins/view directory
 #


### PR DESCRIPTION
## Summary
**User impact:** A tooltip in the Media Manager tool has a misspelled word — "viz-a-viz" instead of the correct "vis-à-vis" — which users see and translators have to carry.

This corrects the single misspelled word in the tooltip text.

Reported in Mantis [#13354](https://gramps-project.org/bugs/view.php?id=13354).

## What to look at
Open the Media Manager tool and read the Convert2Rel batch operation's tooltip: the loanword is now spelled correctly. The change is a one-word edit to the English source string, with a test asserting the correct spelling ships.

## Root cause
The Convert2Rel batch-op's `description` attribute (the tooltip shown in the Media Manager tool) contains a misspelling: "viz-a-viz" instead of the correct loanword "vis-à-vis". This is a purely translatable English-source string defect with no behavioral impact.

## Fix
Changed the single misspelled word in `gramps/plugins/tool/mediamanager.py:640`:
- `"viz-a-viz the base path as given in the Preferences, "`
+ `"vis-à-vis the base path as given in the Preferences, "`

The canonical accented form "vis-à-vis" (UTF-8 `à` U+00E0) is used, consistent with Gramps' existing typography. The surrounding tooltip text was left untouched per scope. Two new test files are registered in `po/POTFILES.skip`.

## Verification
- **Claim:** the shipped tooltip no longer contains "viz-a-viz" and does contain "vis-à-vis".
- **Checked:** `gramps/plugins/tool/mediamanager.py:640` (the misspelled help string) and `:635–644` (the `Convert2Rel` class carrying the `description` class variable) on `maintenance/gramps61`; `po/POTFILES.skip` — new test files registered following the existing `gramps/plugins/tool/__init__.py` entry.
- **Test:** new package `gramps/plugins/tool/test/` — `__init__.py` (empty package marker) and `mediamanager_test.py` (`:65–71`) reads the shipped `Convert2Rel.description` class attribute directly and asserts "viz-a-viz" is NOT present and "vis-à-vis" IS present. With the fix both assertions pass; reverting `mediamanager.py` (keeping the test) makes both fail, so the test detects the regression. Follows the core convention (`*_test.py` in a `test/` package), discovered by `run-unit.sh -p "*_test.py"`.

Fixes [#13354](https://gramps-project.org/bugs/view.php?id=13354)
