### PR TITLE
Update Dutch translation for 'Transcript'

### DIFF
--- a/po/nl.po
+++ b/po/nl.po
@@ -8935,7 +8935,7 @@ msgstr "Analyse"
 
 #: ../gramps/gen/lib/notetype.py:88
 msgid "Transcript"
-msgstr "Vertaling"
+msgstr "Transcriptie"
 
 #: ../gramps/gen/lib/notetype.py:89
 msgid "Source text"


### PR DESCRIPTION
The previous wordt that was used, "Vertaling" literally means "Translation". 
The word "Transcriptie" is a translation that's closer to the English word "Transcript" and also the common word that is used in the genealogy context.