### PR TITLE
Bind Organize Tags dialog's type-ahead search to the Name column

### DIFF
--- a/gramps/gui/views/tags.py
+++ b/gramps/gui/views/tags.py
@@ -482,6 +482,8 @@ class OrganizeTagsDialog(ManagedWindow):
         ]
         self.namelist = Gtk.TreeView()
         self.namemodel = ListModel(self.namelist, name_titles)
+        # Bind type-ahead search to the visible Name column (was inert at -1).
+        self.namelist.set_search_column(2)
 
         slist = Gtk.ScrolledWindow()
         slist.add(self.namelist)


### PR DESCRIPTION
## Summary
**User impact:** In the Organize Tags dialog you can start typing to jump to a tag by name, and a search box pops up — but nothing happens: the selection never moves to the matching tag, so type-ahead search is effectively dead.

This connects the dialog's type-ahead search to the Name column so typing jumps to the matching tag.

Reported in Mantis [#12018](https://gramps-project.org/bugs/view.php?id=12018).

## What to look at
People list → Edit → Tag → Organize Tags…, add several tags, then type a tag's name: the selection should now jump to the matching tag instead of the search box doing nothing. The change is a single line telling the tag list which column to search. Note: this is an enhancement (the search never worked, so it is a missing feature rather than a regression) — hence it targets `master`.

## Root cause
The "Organize Tags" dialog (`gramps/gui/views/tags.py`, `OrganizeTagsDialog`) builds its tag list in a `Gtk.TreeView` that ships GtkTreeView's interactive type-ahead search **enabled by default**, but the dialog never called `set_search_column()`, leaving the search column at GTK's default of `-1`. With no target column, pressing Ctrl-F (or just typing) pops up the search box but never moves the selection to the matching tag — an enabled-but-inert control.

## Fix
One line, in `_create_dialog`, right after the `ListModel` is built:

```python
self.namelist.set_search_column(2)   # the visible Name column
```

The Name column is model index 2 (Priority = 0, Handle = 1, Name = 2, Color = 3). It is a text column, so GtkTreeView's default case-insensitive substring match works against it; typing now jumps the selection to the matching tag.

## Verification
- **Claim:** the Organize Tags dialog's type-ahead search targets the Name column, so typing selects the matching tag.
- **Checked:** `gramps/gui/views/tags.py` `OrganizeTagsDialog._create_dialog` on `master` — the `name_titles` / `Gtk.TreeView()` / `ListModel(...)` block that left the search column unset; `gramps/gui/listmodel.py` — `ListModel` never sets a search column, confirming the default `-1` reaches the dialog.
- **Test:** no automated test ships with this change. The fix is a single GtkTreeView property set inside a `ManagedWindow` dialog whose `Gtk.TreeView` cannot be constructed on a headless runner (GTK aborts without a display connection), and reshaping the dialog purely to create a test seam is out of proportion to a one-line property set. Manual repro: People list → Edit → Tag → Organize Tags…, add several tags, type a tag's name — the selection now jumps to the matching tag instead of the search box doing nothing.

Fixes [#12018](https://gramps-project.org/bugs/view.php?id=12018)
