### PR TITLE
Fix crash in EditLink when new-object callback emits handle string

### DIFF
--- a/gramps/gui/editors/editlink.py
+++ b/gramps/gui/editors/editlink.py
@@ -154,11 +154,20 @@ class EditLink(ManagedWindow):
         return self.simple_access.display(obj_class, prop, value)
 
     def _on_new_callback(self, obj):
-        object_class = obj.__class__.__name__
-        self.selected.set_text(self.display_link(object_class, "handle", obj.handle))
-        self.url_link.set_text(
-            "gramps://%s/%s/%s" % (object_class, "handle", obj.handle)
-        )
+        # The "new object created" callback may emit either the saved object or
+        # just its handle string: most editors pass the object, but some (e.g.
+        # EditCitation) pass ``self.obj.get_handle()``. Read the value as the
+        # reference type it actually is rather than assuming an object with a
+        # ``.handle`` attribute (bug #12260). When only a handle is supplied the
+        # object's class is taken from the type the user selected to create.
+        if isinstance(obj, str):
+            object_class = OBJECT_MAP[self.uri_list.get_active()]
+            handle = obj
+        else:
+            object_class = obj.__class__.__name__
+            handle = obj.handle
+        self.selected.set_text(self.display_link(object_class, "handle", handle))
+        self.url_link.set_text("gramps://%s/%s/%s" % (object_class, "handle", handle))
 
     def _on_new(self, widget):
         from ..editors import EditObject

--- a/gramps/gui/editors/test/editlink_test.py
+++ b/gramps/gui/editors/test/editlink_test.py
@@ -1,0 +1,79 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps developers
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Regression test for bug #12260.
+
+Creating a *new* linked object from the Link Editor must not crash when the
+inner editor's "new object created" callback emits a bare handle *string*
+instead of an object.  EditCitation (``editcitation.py`` ``save`` →
+``self.callback(self.obj.get_handle())``) does exactly that, so driving
+``EditLink._on_new_callback`` with a ``str`` reproduced
+``AttributeError: 'str' object has no attribute 'handle'``.
+
+The test exercises the *production* ``EditLink._on_new_callback`` directly (an
+instance built with ``__new__`` so no GTK toplevel is realised), not a copy of
+it.
+"""
+
+import unittest
+from unittest.mock import Mock
+
+from gramps.gen.lib import Note
+from gramps.gui.editors.editlink import EditLink, NOTE
+
+
+def _make_editlink(active):
+    """Build an EditLink without running its GTK __init__.
+
+    Only the attributes ``_on_new_callback`` touches are stubbed, so the test
+    drives the real method on a real EditLink instance.
+    """
+    link = EditLink.__new__(EditLink)
+    link.uri_list = Mock()
+    link.uri_list.get_active.return_value = active
+    link.selected = Mock()
+    link.url_link = Mock()
+    link.simple_access = Mock()
+    link.simple_access.display.return_value = "displayed"
+    return link
+
+
+class TestOnNewCallback(unittest.TestCase):
+    def test_handle_string_callback_builds_link(self):
+        """A handle *string* (as EditCitation/EditNote emit) must not raise."""
+        link = _make_editlink(NOTE)
+        # Pre-fix this raised AttributeError: 'str' object has no attribute
+        # 'handle'.
+        link._on_new_callback("abc123handle")
+        link.url_link.set_text.assert_called_once_with(
+            "gramps://Note/handle/abc123handle"
+        )
+        link.selected.set_text.assert_called_once_with("displayed")
+
+    def test_object_callback_still_builds_link(self):
+        """Object-passing editors (the majority) keep working unchanged."""
+        link = _make_editlink(NOTE)
+        note = Note()
+        note.set_handle("objhandle")
+        link._on_new_callback(note)
+        link.url_link.set_text.assert_called_once_with("gramps://Note/handle/objhandle")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -395,6 +395,7 @@ gramps/gui/editors/displaytabs/test/gallerytab_test.py
 #
 # gui.editors.test package
 #
+gramps/gui/editors/test/editlink_test.py
 gramps/gui/editors/test/editreference_test.py
 #
 # gui.filters package


### PR DESCRIPTION
## Summary
**User impact:** When you use the Link editor to create a brand-new item to link to — for example while editing a citation — Gramps crashes instead of creating the link.

This adds a small check so the Link editor handles that case correctly, and the new-object link is created without crashing.

Reported in Mantis [#12260](https://gramps-project.org/bugs/view.php?id=12260).

## What to look at
The Link editor accepts the newly-created item whether the editor hands it back as a plain reference or as a full object, instead of assuming it is always a full object. To try it: open the Link editor from a place that creates a new object (e.g. the Citation editor), create a new linked object, and confirm the link is built with no crash.

## Root cause
The `EditLink._on_new_callback` method (gramps/gui/editors/editlink.py:156-160) assumes its callback parameter is always an object with a `.handle` attribute. However, some editors including `EditCitation` (editcitation.py:400-401) pass only the handle string via `self.obj.get_handle()`, causing `AttributeError: 'str' object has no attribute 'handle'` when creating a new linked object through the Link Editor.

## Fix
Add a type check at the callback boundary in `_on_new_callback` to distinguish string handles from objects:
- If the callback emits a string: derive the object class from the Link Editor's active selection (`OBJECT_MAP[self.uri_list.get_active()]`)
- If the callback emits an object: extract the class name and handle as before (preserving existing behavior for the majority of editors)

This restores the invariant that the callback reads the value as the reference type it actually is—a handle string or an object—without requiring changes to any editor's save signature. The fix is localized to the single consumer boundary where the type ambiguity occurs.

## Verification
- **Claim:** `_on_new_callback` correctly builds the link whether the editor emits a handle string or a full object.
- **Checked:** `gramps/gui/editors/editlink.py:156-160` (the pre-fix `_on_new_callback` assuming `.handle` on all inputs), `gramps/gui/editors/editcitation.py:400-401` (the real editor emitting `self.obj.get_handle()`, a string), and `gramps/gui/editors/editnote.py:381-383` (the Note editor emitting `self.obj`, an object) on maintenance/gramps61; the type-guarded fix is applied in-place to the production method (`patch.diff:20-27`).
- **Test:** `gramps/gui/editors/test/editlink_test.py` (new) — drives the **real** `EditLink._on_new_callback` on a real instance (no GTK widget realisation). `test_handle_string_callback_builds_link` feeds a handle string as EditCitation emits: red pre-fix with `AttributeError: 'str' object has no attribute 'handle'`, green post-fix with the link correctly built. `test_object_callback_still_builds_link` guards the object-passing majority: green both sides.

Fixes [#12260](https://gramps-project.org/bugs/view.php?id=12260)
