### PR TITLE
Fan Chart respects active name format preference

### DIFF
--- a/gramps/gen/display/name.py
+++ b/gramps/gen/display/name.py
@@ -390,6 +390,9 @@ class NameDisplay:
 
         # Translators: needed for Arabic, ignore otherwise
         COMMAGLYPH = xlocale.translation.gettext(",")
+        # keep the comma glyph so views can split a format at the
+        # surname/given boundary (e.g. the fan chart's two-line names)
+        self.COMMAGLYPH = COMMAGLYPH
 
         self.STANDARD_FORMATS = [
             (Name.DEF, _("Default format (defined by Gramps preferences)"), "", _ACT),
@@ -1038,6 +1041,51 @@ class NameDisplay:
         """
         name = person.get_primary_name()
         return self.name_formats[num][_F_FN](name)
+
+    def get_two_line_format(self, num=None):
+        """
+        Return a name format split into two format strings at the comma
+        that separates the surname from the given names.
+
+        Used by views that render names on two lines (the fan charts) but
+        must still honour the user's selected name format. A format with no
+        such comma yields the whole format on the first line and an empty
+        second line.
+
+        :param num: index of the format to split; the active default format
+                    is used when None.
+        :type num: int
+        :returns: a (line1_format, line2_format) tuple
+        :rtype: tuple
+        """
+        if num is None:
+            num = self.default_format
+        num = self._is_format_valid(num)
+        fmt_str = self.name_formats[num][_F_FMT]
+        if self.COMMAGLYPH in fmt_str:
+            line1, line2 = fmt_str.split(self.COMMAGLYPH, 1)
+        else:
+            line1, line2 = fmt_str, ""
+        return (line1.strip(), line2.strip())
+
+    def display_two_lines(self, person):
+        """
+        Return a :class:`~.person.Person`'s primary name as a two-line
+        (line1, line2) tuple, derived from the *active* name format split at
+        the surname/given comma.
+
+        This lets two-line renderers (the fan chart views) honour the user's
+        selected name format instead of a fixed layout.
+
+        :param person: :class:`~.person.Person` instance whose primary name
+                       is to be displayed.
+        :type person: :class:`~.person.Person`
+        :returns: a (line1, line2) tuple of formatted name strings
+        :rtype: tuple
+        """
+        name = person.get_primary_name()
+        line1_fmt, line2_fmt = self.get_two_line_format()
+        return (self.format_str(name, line1_fmt), self.format_str(name, line2_fmt))
 
     def display_formal(self, person):
         """

--- a/gramps/gen/display/test/fanchart_name_format_test.py
+++ b/gramps/gen/display/test/fanchart_name_format_test.py
@@ -1,0 +1,112 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps developers
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Regression test for bug #13532.
+
+The fan chart views (Fan Chart, Descendant Fan Chart, 2-way Fan Chart) render
+person names on two lines.  They used to do so through two hard-pinned name
+formats ("%l" and "%f %s"), so the chart always showed surname / given-suffix
+regardless of the user's active "Name format" preference.
+
+The fix routes the two-line rendering through the name displayer's
+``get_two_line_format`` / ``display_two_lines`` helpers, which split the
+*active* name format at the surname/given comma.  This test drives those very
+helpers -- the same production code the chart calls in
+``gramps.gui.widgets.fanchart.FanChartBaseWidget.draw_person`` -- with no GUI
+import, so it runs headlessly.
+"""
+
+import unittest
+
+from gramps.gen.display.name import NameDisplay
+from gramps.gen.lib import Name, Person, Surname
+
+
+def _make_person():
+    """A person whose name has a given name, a surname and a suffix."""
+    name = Name()
+    name.set_first_name("Avis")
+    name.set_suffix("III")
+    surname = Surname()
+    surname.set_surname("Fernandez")
+    name.add_surname(surname)
+    person = Person()
+    person.set_primary_name(name)
+    return person
+
+
+class FanChartNameFormatTest(unittest.TestCase):
+    def setUp(self):
+        self.nd = NameDisplay()
+        self.person = _make_person()
+
+    # -- get_two_line_format -------------------------------------------------
+
+    def test_split_lnfn_at_comma(self):
+        """'Surname, Given Suffix' splits into surname / given-suffix lines."""
+        self.nd.set_default_format(Name.LNFN)
+        self.assertEqual(("%l", "%f %s"), self.nd.get_two_line_format())
+
+    def test_split_given_has_no_second_line(self):
+        """'Given' has no comma, so it stays on the first line only."""
+        self.nd.set_default_format(Name.FN)
+        self.assertEqual(("%f", ""), self.nd.get_two_line_format())
+
+    def test_split_fnln_has_no_second_line(self):
+        """'Given Surname Suffix' has no comma -> single line."""
+        self.nd.set_default_format(Name.FNLN)
+        self.assertEqual(("%f %l %s", ""), self.nd.get_two_line_format())
+
+    def test_explicit_num_overrides_default(self):
+        """A passed-in format index is honoured over the active default."""
+        self.nd.set_default_format(Name.FN)
+        self.assertEqual(("%l", "%f %s"), self.nd.get_two_line_format(Name.LNFN))
+
+    # -- display_two_lines (the rendered chart labels) -----------------------
+
+    def test_two_lines_follow_lnfn(self):
+        self.nd.set_default_format(Name.LNFN)
+        self.assertEqual(
+            ("Fernandez", "Avis III"), self.nd.display_two_lines(self.person)
+        )
+
+    def test_two_lines_follow_given(self):
+        # The reporter's case: with "Given" the chart must show only "Avis",
+        # not "Fernandez ... Avis III".
+        self.nd.set_default_format(Name.FN)
+        self.assertEqual(("Avis", ""), self.nd.display_two_lines(self.person))
+
+    def test_two_lines_follow_fnln(self):
+        self.nd.set_default_format(Name.FNLN)
+        self.assertEqual(
+            ("Avis Fernandez III", ""), self.nd.display_two_lines(self.person)
+        )
+
+    def test_changing_format_changes_labels(self):
+        """The invariant: a format change is reflected in the chart labels."""
+        self.nd.set_default_format(Name.LNFN)
+        lnfn = self.nd.display_two_lines(self.person)
+        self.nd.set_default_format(Name.FN)
+        given = self.nd.display_two_lines(self.person)
+        self.assertNotEqual(lnfn, given)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gui/widgets/fanchart.py
+++ b/gramps/gui/widgets/fanchart.py
@@ -99,11 +99,6 @@ from gramps.gen.utils.symbols import Symbols
 
 _ = glocale.translation.gettext
 
-# following are used in name_displayer format def
-# (must not conflict with standard defs)
-TWO_LINE_FORMAT_1 = 100
-TWO_LINE_FORMAT_2 = 101
-
 # -------------------------------------------------------------------------
 #
 # FanChartBaseWidget
@@ -148,15 +143,6 @@ class FanChartBaseWidget(Gtk.DrawingArea):
         self.last_x, self.last_y = None, None
         self.fontdescr = "Sans"
         self.fontsize = 8
-        # add parts of a two line name format to the displayer.  We add them
-        # as standard names, but set them inactive so they don't show up in
-        # name editor or selector.
-        name_displayer.set_name_format(
-            [
-                (TWO_LINE_FORMAT_1, "fanchart_name_line1", "%l", False),
-                (TWO_LINE_FORMAT_2, "fanchart_name_line2", "%f %s", False),
-            ]
-        )
         self.connect("button_release_event", self.on_mouse_up)
         self.connect("motion_notify_event", self.on_mouse_move)
         self.connect("button-press-event", self.on_mouse_down)
@@ -740,8 +726,10 @@ class FanChartBaseWidget(Gtk.DrawingArea):
                 text_line1 = "(" + person.gramps_id + ") "
             else:
                 text_line1 = ""
-            text_line1 += name_displayer.display_format(person, TWO_LINE_FORMAT_1)
-            text_line2 = name_displayer.display_format(person, TWO_LINE_FORMAT_2)
+            # split the *active* name format over two lines so the chart
+            # honours the user's "Name format" preference (bug 13532)
+            name_line1, text_line2 = name_displayer.display_two_lines(person)
+            text_line1 += name_line1
             if draw_radial:
                 split_frac_line1 = 0.5
                 flipped = can_flip and (

--- a/gramps/plugins/view/fanchart2wayview.py
+++ b/gramps/plugins/view/fanchart2wayview.py
@@ -116,6 +116,7 @@ class FanChart2WayView(fanchart2way.FanChart2WayGrampsGUI, NavigationView):
         self.allfonts = [x for x in enumerate(SystemFonts().get_system_fonts())]
 
         self.uistate.connect("font-changed", self.font_changed)
+        self.uistate.connect("nameformat-changed", self.person_rebuild)
 
     def font_changed(self):
         self.format_helper.reload_symbols()

--- a/gramps/plugins/view/fanchartdescview.py
+++ b/gramps/plugins/view/fanchartdescview.py
@@ -111,6 +111,7 @@ class FanChartDescView(fanchartdesc.FanChartDescGrampsGUI, NavigationView):
         self.allfonts = [x for x in enumerate(SystemFonts().get_system_fonts())]
 
         self.uistate.connect("font-changed", self.font_changed)
+        self.uistate.connect("nameformat-changed", self.person_rebuild)
 
     def font_changed(self):
         self.format_helper.reload_symbols()

--- a/gramps/plugins/view/fanchartview.py
+++ b/gramps/plugins/view/fanchartview.py
@@ -101,6 +101,7 @@ class FanChartView(fanchart.FanChartGrampsGUI, NavigationView):
         self.allfonts = [x for x in enumerate(SystemFonts().get_system_fonts())]
 
         self.uistate.connect("font-changed", self.font_changed)
+        self.uistate.connect("nameformat-changed", self.person_rebuild)
 
     def font_changed(self):
         self.format_helper.reload_symbols()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -98,6 +98,7 @@ gramps/gen/db/conversion_tools/conversion_21.py
 # gen.display package
 #
 gramps/gen/display/__init__.py
+gramps/gen/display/test/fanchart_name_format_test.py
 #
 # gen.filters package
 #


### PR DESCRIPTION
## Summary
**User impact:** The Fan Chart ignores the "Name format" you chose in preferences. It always shows names as surname on one line and given name on the next, so someone who picks the "Given" format (expecting just "Avis") still sees the full "Fernandez ... Avis III". Changing the name format preference also doesn't refresh the chart.

This makes all three fan-chart views honour your active name format, and re-render immediately when you change it.

Reported in Mantis [#13532](https://gramps-project.org/bugs/view.php?id=13532).

## What to look at
The two-line person labels are now built from your active name format instead of two hard-coded formats, and the fan-chart views listen for name-format changes. To try it: set "Name format: Given" in preferences, open the Fan Chart, and confirm labels follow that format (e.g. just the given name); then change the name format and confirm the chart re-renders.

## Root cause
The fan-chart widget renders two-line person labels through hard-pinned name formats registered as `TWO_LINE_FORMAT_1 = "%l"` (surname) and `TWO_LINE_FORMAT_2 = "%f %s"` (given+suffix) in `gramps/gui/widgets/fanchart.py:102-105` on the target branch — so `draw_person` always drew surname / given-suffix regardless of the user's active "Name format" preference. Additionally, none of the three fan-chart views connected the `nameformat-changed` uistate signal, so even the single-line path (which *does* resolve through `name_displayer.display`) never re-rendered when the preference changed.

## Fix
1. **`gramps/gen/display/name.py`** — Add two new public methods to `NameDisplay`:
   - Store the locale comma glyph as `self.COMMAGLYPH` (line 392) so a format can be split at the surname/given boundary
   - `get_two_line_format(num=None)` — returns the active (or given) name format split at the comma into `(line1_fmt, line2_fmt)`
   - `display_two_lines(person)` — renders a person's primary name as a two-line tuple using the active format split at the surname/given comma

2. **`gramps/gui/widgets/fanchart.py`** — Remove the dead `TWO_LINE_FORMAT_1/2` constants (lines 102-105) and the static `name_displayer.set_name_format([...])` registration in `FanChartBaseWidget.__init__`. Update `draw_person` (lines 743-744) to call `name_displayer.display_two_lines(person)` so it always uses the *current* active format. The `showid` gramps-id prefix on line 1 is preserved.

3. **`fanchartview.py`, `fanchartdescview.py`, `fanchart2wayview.py`** — Connect the `nameformat-changed` signal to trigger `person_rebuild` in each view's `__init__`, mirroring the pattern already used for `font-changed`. This ensures all three fan-chart views re-render when the name format preference changes.

4. **`po/POTFILES.skip`** — Register the new core test file (the file has no translatable strings, so it goes to `.skip`).

## Verification
- **Claim:** the fan chart draws two-line labels using the user's active name format, and all three fan-chart views re-render when that preference changes.
- **Checked:** `gramps/gen/display/name.py:392` (`COMMAGLYPH` locale definition), `gramps/gui/widgets/fanchart.py:102-105` (dead `TWO_LINE_FORMAT_1/2` constants) and `:743-744` (`draw_person` call site), and the three view initializers `gramps/plugins/view/fanchartview.py`, `fanchartdescview.py`, `fanchart2wayview.py` (signal connection points) on maintenance/gramps61.
- **Test:** core unit test (headless, red→green) `gramps/gen/display/test/fanchart_name_format_test.py` exercises the new `NameDisplay.get_two_line_format()` and `display_two_lines()` with no GUI import — showing (a) LNFN `"%l, %f %s"` splits into surname / given-suffix lines, (b) the "Given" format `"%f"` yields only the given name on line 1 with an empty line 2 (the reporter's case: "Avis" instead of "Fernandez ... Avis III"), and (c) format changes are reflected in the labels. An advisory AT-SPI repro `engine/interface/test_bug_13532_fanchart-name-format.py` launches Gramps with "Name format: Given" and opens the Fan Chart, but the chart labels are Cairo-drawn and not exposed via AT-SPI, so it skips and is left for manual confirmation; the regression proof is the headless unit test.

Fixes [#13532](https://gramps-project.org/bugs/view.php?id=13532)

