### PR TITLE
Fix citation deletion in Citation Tree view

### DIFF
--- a/gramps/plugins/lib/libsourceview.py
+++ b/gramps/plugins/lib/libsourceview.py
@@ -98,5 +98,5 @@ class LibSourceView:
             ref_obj = self.dbstate.db.method("get_%s_from_handle", ref_type)(ref_hndl)
             ref_obj.remove_handle_references(obj_type, [handle])
             self.dbstate.db.method("commit_%s", ref_type)(ref_obj, trans)
-        # and delete the source
-        self.dbstate.db.remove_source(handle, trans)
+        # and delete the object (Source or Citation)
+        self.dbstate.db.method("remove_%s", obj_type)(handle, trans)

--- a/gramps/plugins/lib/test/libsourceview_test.py
+++ b/gramps/plugins/lib/test/libsourceview_test.py
@@ -1,0 +1,144 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Gramps developers
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Unit tests for the delete logic shared by SourceView and CitationTreeView.
+
+Regression test for bug 13876: deleting a selected citation row in the
+Citation Tree view mode left the citation in the database, because the shared
+delete helper always called ``remove_source`` regardless of the selected
+object's type.  These tests drive the production ``LibSourceView`` methods
+directly (the module is GUI-free) so they run headlessly.
+"""
+
+# -------------------------------------------------------------------------
+#
+# Standard python modules
+#
+# -------------------------------------------------------------------------
+import unittest
+from types import SimpleNamespace
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from gramps.gen.db import DbTxn
+from gramps.gen.db.utils import make_database
+from gramps.gen.lib import Citation, Source
+from gramps.plugins.lib.libsourceview import LibSourceView
+
+
+# -------------------------------------------------------------------------
+#
+# A minimal, GUI-free carrier of the production delete methods
+#
+# -------------------------------------------------------------------------
+class _Probe(LibSourceView):
+    """
+    Carries the real ``LibSourceView`` methods without the Gtk ``ListView``
+    machinery.  ``selected_handles`` and ``remove_selected_objects`` are the
+    only collaborators ``remove`` needs; the latter is captured rather than
+    run so no confirmation dialog is shown.
+    """
+
+    def __init__(self, db, selected):
+        self.dbstate = SimpleNamespace(db=db)
+        self.uistate = SimpleNamespace(pulse_progressbar=lambda *args: None)
+        self._selected = selected
+        self.captured = None
+
+    def selected_handles(self):
+        return list(self._selected)
+
+    def remove_selected_objects(self, ht_list=None):
+        self.captured = ht_list
+
+
+# -------------------------------------------------------------------------
+#
+# Test class
+#
+# -------------------------------------------------------------------------
+class LibSourceViewDeleteTest(unittest.TestCase):
+    """
+    Exercise the source/citation delete path used by the Citation Tree view.
+    """
+
+    def setUp(self):
+        self.db = make_database("sqlite")
+        self.db.load(":memory:")
+        with DbTxn("Add source and citation", self.db) as trans:
+            source = Source()
+            source.set_title("World of the Wierd")
+            self.source_handle = self.db.add_source(source, trans)
+            citation = Citation()
+            citation.set_page("p. 1")
+            citation.set_reference_handle(self.source_handle)
+            self.citation_handle = self.db.add_citation(citation, trans)
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_remove_resolves_selected_citation_to_citation(self):
+        """
+        A selected citation row is resolved to a ("Citation", handle) pair,
+        not mistaken for a source.
+        """
+        probe = _Probe(self.db, [self.citation_handle])
+        probe.remove()
+        self.assertEqual(probe.captured, [("Citation", self.citation_handle)])
+
+    def test_delete_citation_removes_it_from_db(self):
+        """
+        Deleting a selected citation removes that citation from the database
+        (bug 13876) while leaving its source intact.
+        """
+        self.assertTrue(self.db.has_citation_handle(self.citation_handle))
+        with DbTxn("Delete citation", self.db) as trans:
+            probe = _Probe(self.db, [self.citation_handle])
+            probe.remove_object_from_handle(
+                "Citation", self.citation_handle, trans, in_use_prompt=False
+            )
+        self.assertFalse(
+            self.db.has_citation_handle(self.citation_handle),
+            "citation should be gone from the database after delete",
+        )
+        self.assertTrue(
+            self.db.has_source_handle(self.source_handle),
+            "the citation's source must remain",
+        )
+
+    def test_delete_source_removes_source_and_its_citation(self):
+        """
+        Deleting a source still removes the source and its child citations
+        (the path that already worked must keep working).
+        """
+        with DbTxn("Delete source", self.db) as trans:
+            probe = _Probe(self.db, [self.source_handle])
+            probe.remove_object_from_handle(
+                "Source", self.source_handle, trans, in_use_prompt=False
+            )
+        self.assertFalse(self.db.has_source_handle(self.source_handle))
+        self.assertFalse(self.db.has_citation_handle(self.citation_handle))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -612,6 +612,11 @@ gramps/plugins/lib/libodfbackend.py
 gramps/plugins/lib/libplaceimport.py
 gramps/plugins/lib/librecurse.py
 #
+# plugins/lib/test directory
+#
+gramps/plugins/lib/test/__init__.py
+gramps/plugins/lib/test/libsourceview_test.py
+#
 # plugins/lib/maps directory
 #
 gramps/plugins/lib/maps/__init__.py


### PR DESCRIPTION
## Summary
**User impact:** In the Citation Tree view, deleting a citation silently does nothing — the citation stays in the list and in your data, with no error to tell you the delete failed.

This makes deleting a citation actually remove it, while leaving source deletion unchanged.

Reported in Mantis [#13876](https://gramps-project.org/bugs/view.php?id=13876).

## What to look at
The delete now acts on the actual type of the selected row — Source or Citation — instead of always trying to delete a source. To try it: in the Citation Tree view, select a citation row and delete it; it should disappear from the view and from the database.

## Root cause
Citation Tree view's delete operation routes through the shared helper `LibSourceView.remove_object_from_handle()`, which resolves the selected row to its citation handle and then delegates to the database layer. However, the final deletion statement unconditionally called `remove_source(handle, trans)` (libsourceview.py:102), treating the handle as a source key regardless of the selected object's actual type. For a citation node (selected row representing a Citation, not a Source), this was a silent no-op since no source with that citation handle exists.

## Fix
Replace the hard-coded `remove_source()` call (libsourceview.py:101-102) with a type-aware dispatcher: `self.dbstate.db.method("remove_%s", obj_type)(handle, trans)`. The `obj_type` variable already holds the resolved type ("Source" or "Citation") from the same method's earlier resolution step (libsourceview.py:42-53). For a Source this produces identical behavior to the old code; for a Citation it now correctly calls `remove_citation()`. This is the minimal change that restores the delete invariant (a selected row's delete acts on that row's object type) while preserving the Source branch's existing child-citation and back-reference cleanup logic (libsourceview.py:55-102).

## Verification
- **Claim:** deleting a citation row in the Citation Tree view removes that citation, and source deletion continues to behave as before.
- **Checked:** gramps/plugins/lib/libsourceview.py:42-53 (type resolution, Source vs Citation, in `LibSourceView.remove()`) and :101-102 (the buggy unconditional `remove_source()` call), gramps/gui/views/listview.py:712 (base `ListView.remove_object_from_handle()` using the correct dispatch pattern), and gramps/plugins/view/citationtreeview.py:76 (`CitationTreeView` inherits `LibSourceView.remove_object_from_handle()`) on maintenance/gramps61.
- **Test:** headless unit test `gramps/plugins/lib/test/libsourceview_test.py` drives the production `LibSourceView` methods against an in-memory database — `test_delete_citation_removes_it_from_db` is the red-green leg: before the fix `remove_source(citation_handle)` is a no-op so the citation survives (RED), after the fix `remove_citation()` is called and it is deleted (GREEN); further tests verify the resolution invariant and that source deletion stays unbroken. An advisory AT-SPI repro `engine/interface/test_bug_13876_citation-tree-delete.py` (testbed repo) navigates the Citation Tree view mode, selects a citation row by name, deletes it via the UI, and asserts it no longer appears; it runs under the C4-verify-interface gate on the unpatched (RED) and patched (GREEN) worktrees.

Fixes [#13876](https://gramps-project.org/bugs/view.php?id=13876)
