### PR TITLE
Add regression test for Note preview length config (issue 8597)

### DIFF
--- a/gramps/gen/lib/test/note_test.py
+++ b/gramps/gen/lib/test/note_test.py
@@ -1,0 +1,76 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025  Gramps developers
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""unittest for Note.get_preview()
+
+Regression coverage for bug 8597: the Note preview was truncated at a
+hardcoded 79 characters.  It must instead honour the configurable
+``interface.note-preview-length`` setting.
+"""
+
+import unittest
+
+from gramps.gen.config import config
+from ..note import Note
+
+
+class NotePreviewTest(unittest.TestCase):
+    """Exercise the production ``Note.get_preview`` truncation."""
+
+    def setUp(self):
+        self._saved = config.get("interface.note-preview-length")
+
+    def tearDown(self):
+        config.set("interface.note-preview-length", self._saved)
+
+    def _note(self, text):
+        note = Note()
+        note.set(text)
+        return note
+
+    def test_honours_configured_length(self):
+        """get_preview truncates at the configured length, not a constant."""
+        config.set("interface.note-preview-length", 20)
+        note = self._note("x" * 100)
+        self.assertEqual(note.get_preview(), "x" * 20 + "...")
+
+    def test_not_hardcoded_79(self):
+        """A length above the old hardcoded 79 is respected (defect gone)."""
+        config.set("interface.note-preview-length", 120)
+        note = self._note("y" * 200)
+        preview = note.get_preview()
+        # Under the old hardcoded-79 behaviour this would have been
+        # "y" * 79 + "..."; it must now follow the config value.
+        self.assertEqual(preview, "y" * 120 + "...")
+
+    def test_short_text_not_truncated(self):
+        """Text shorter than the limit is returned unchanged."""
+        config.set("interface.note-preview-length", 50)
+        note = self._note("short note")
+        self.assertEqual(note.get_preview(), "short note")
+
+    def test_newlines_flattened(self):
+        """Newlines are replaced by spaces in the preview."""
+        config.set("interface.note-preview-length", 80)
+        note = self._note("line one\nline two")
+        self.assertEqual(note.get_preview(), "line one line two")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -198,6 +198,7 @@ gramps/gen/lib/test/date_test.py
 gramps/gen/lib/test/grampstype_test.py
 gramps/gen/lib/test/handleref_test.py
 gramps/gen/lib/test/merge_test.py
+gramps/gen/lib/test/note_test.py
 gramps/gen/lib/test/schema_test.py
 gramps/gen/lib/test/serialize_test.py
 gramps/gen/lib/test/styledtext_test.py


### PR DESCRIPTION
## Summary
**User impact:** In the Notes list, the preview of each note's text used to be cut off at a fixed length (about 79 characters) no matter how much room there was, so longer notes were needlessly clipped. That fixed cut-off has since been replaced by a setting users can adjust; this PR adds an automated test so the adjustable behaviour can't silently regress back to the old hardcoded limit.

This is a test-only change: it locks in the already-fixed, configurable note-preview length with a regression guard.

Reported in Mantis [#8597](https://gramps-project.org/bugs/view.php?id=8597).

## What to look at
The guard exercises the real `Note.get_preview()` and confirms it honours the `interface.note-preview-length` preference rather than a magic constant. To try the underlying feature: Preferences > Display > note preview length, change it, and watch the Notes list previews respect the new value. A residual, unrelated 40-character limit on the status-bar navigation label is noted below as out of scope.

## Root cause
The original defect reported hardcoded 79-character truncation of note preview text in the Note view, plus a separate 40-character limit in the status-bar navigation label. The hardcoded preview limit has been resolved upstream: `Note.get_preview()` now reads the configurable `interface.note-preview-length` setting instead of a magic constant.

The configurable limit was introduced by #2044 ("Notes: display more than 80 characters"), merged into the 6.1 line — so `interface.note-preview-length` is present in 6.1 but not in 6.0.x. This PR adds regression coverage for that behaviour on `maintenance/gramps61`.

## Fix
This patch adds a regression test (`gramps/gen/lib/test/note_test.py`) to document and verify the resolved behaviour:

- **test_honours_configured_length**: sets config to 20, verifies truncation at 20 (not hardcoded 79).
- **test_not_hardcoded_79**: sets config to 120 with a 200-character note; under the old hardcoded-79 behaviour this would have produced 79 chars + "…", proving this is the regression that documents the fix.
- **test_short_text_not_truncated**: verifies text shorter than the limit is returned unchanged.
- **test_newlines_flattened**: verifies newlines are replaced by spaces.

The test runs headless (imports only `gramps.gen.config` and `gramps.gen.lib.note`, no GUI) and passes all four cases in ~0.000s. It is registered in `po/POTFILES.skip` per the T2 potfiles gate.

## Verification
- **Claim:** the note preview length is driven by the `interface.note-preview-length` setting, not a hardcoded constant, and this behaviour is protected by a regression guard.
- **Checked:** on maintenance/gramps61 —
  - `gramps/gen/lib/note.py:275-287` — `Note.get_preview()` reads `config.get("interface.note-preview-length")` (line 282), not a hardcoded constant.
  - `gramps/gen/config.py:280` — the setting is registered with default 80.
  - `gramps/gui/configure.py:2381` — the preference is user-editable in Preferences > Display.
  - A residual 40-character hardcoded limit remains in `gramps/gen/utils/db.py:360` (navigation status-bar path); per issue scope it is out of band and reported for follow-up — a separate surface, and a design decision whether to share the note-preview setting, create its own, or keep the constant.
- **Test:** `gramps/gen/lib/test/note_test.py` (new) — this is a test-only PR guarding an already-resolved fix. It exercises the production `Note.get_preview()` directly (`python3 -m unittest gramps.gen.lib.test.note_test`). All four cases pass; `test_not_hardcoded_79` is RED under the old hardcoded-79 behaviour and GREEN with the configurable behaviour, documenting the regression the fix closes.

Fixes [#8597](https://gramps-project.org/bugs/view.php?id=8597)
