### PR TITLE
Rebuild sort order when display-name format changes

### DIFF
--- a/gramps/gui/views/treemodels/basemodel.py
+++ b/gramps/gui/views/treemodels/basemodel.py
@@ -56,6 +56,19 @@ class BaseModel:
         # Invalidates all paths
         self.lru_path.clear()
 
+    def rebuild_sort(self):
+        """
+        Mark the model's sort order stale so the next rebuild recomputes it.
+
+        The default is a no-op: a hierarchical (tree) model clears and re-adds
+        every row on each :meth:`rebuild_data`, recomputing its sort keys from
+        scratch, so its order already tracks the current sort key.  A flat model
+        caches the ordered ``(sortkey, handle)`` map across rebuilds and must
+        override this to invalidate that cache. Defined here so a view can call
+        it uniformly on any model -- flat or tree -- when the sort key changes
+        (e.g. the display-name format is reconfigured). (bug #9267)
+        """
+
     def get_cached_value(self, handle, col):
         """
         Get the value of a "col". col may be a number (position in a model)

--- a/gramps/gui/views/treemodels/flatbasemodel.py
+++ b/gramps/gui/views/treemodels/flatbasemodel.py
@@ -491,6 +491,11 @@ class FlatBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
 
         self._reverse = order == Gtk.SortType.DESCENDING
 
+        # When True, the next rebuild_data must recompute the sort keys instead
+        # of reusing the cached (sortkey, handle) map, because the sort key
+        # itself changed (e.g. the display-name format). See rebuild_sort.
+        self._sort_dirty = False
+
         self.rebuild_data()
         _LOG.debug(
             self.__class__.__name__ + " __init__ " + str(perf_counter() - cput) + " sec"
@@ -541,6 +546,23 @@ class FlatBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
             self.search = None
             self.rebuild_data = self._rebuild_search
 
+    def rebuild_sort(self):
+        """
+        Force the next :meth:`rebuild_data` to recompute the sort keys from the
+        database instead of reusing the cached ``(sortkey, handle)`` map.
+
+        The cached map (``node_map.full_srtkey_hndl_map``) stays valid while the
+        sort *function* is unchanged: a search or filter only restricts which
+        handles are shown, never their relative order. When the sort key itself
+        changes -- e.g. the display-name format is reconfigured so a person's
+        sort name renders differently -- the cache is stale, and a plain rebuild
+        would keep the rows in the previous order until the database is reopened.
+        Marking the sort dirty here makes :meth:`_rebuild_search` /
+        :meth:`_rebuild_filter` rebuild it from :meth:`sort_keys`. Overrides the
+        no-op :meth:`BaseModel.rebuild_sort`. (bug #9267)
+        """
+        self._sort_dirty = True
+
     def total(self):
         """
         Total number of items that maximally can be shown
@@ -587,8 +609,9 @@ class FlatBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
         self._in_build = True
         if (self.db is not None) and self.db.is_open():
             allkeys = self.node_map.full_srtkey_hndl_map()
-            if not allkeys:
+            if self._sort_dirty or not allkeys:
                 allkeys = self.sort_keys()
+                self._sort_dirty = False
             if self.search and self.search.text:
                 dlist = [
                     h
@@ -621,8 +644,9 @@ class FlatBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
         if (self.db is not None) and self.db.is_open():
             cdb = CacheProxyDb(self.db)
             allkeys = self.node_map.full_srtkey_hndl_map()
-            if not allkeys:
+            if self._sort_dirty or not allkeys:
                 allkeys = self.sort_keys()
+                self._sort_dirty = False
             if self.search:
                 ident = False
                 if ignore is None:

--- a/gramps/gui/views/treemodels/test/flatbasemodel_sort_test.py
+++ b/gramps/gui/views/treemodels/test/flatbasemodel_sort_test.py
@@ -1,0 +1,180 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Regression test for bug #9267 -- a list view's row order must follow the
+*current* display-name format.
+
+Root cause
+----------
+``FlatBaseModel._rebuild_search`` / ``_rebuild_filter`` reuse the cached
+``(sortkey, handle)`` map (``node_map.full_srtkey_hndl_map``) whenever it is
+populated, recomputing ``sort_keys()`` only when the cache is empty.  That cache
+is correct while the sort *function* is fixed -- a search/filter change only
+restricts which handles are shown, never their order -- but it goes stale when
+the sort key itself changes, e.g. when the user picks a new "Name format" in
+Edit -> Preferences -> Display.  The view redisplays (the People view connects
+``nameformat-changed`` to a rebuild) yet the rows keep the previous order until
+the database is reopened.
+
+Fix
+---
+``FlatBaseModel.rebuild_sort()`` marks the sort dirty so the next rebuild
+recomputes ``sort_keys()`` with the current sort function; the People view calls
+it before rebuilding on a format change.  ``BaseModel.rebuild_sort()`` is a
+no-op default so the *same* view callback is safe on the hierarchical person
+model (``PersonTreeModel`` -> ``TreeBaseModel``), which re-sorts from scratch on
+every rebuild and so needs no cache invalidation.
+
+This test drives the *real* production methods ``FlatBaseModel._rebuild_search``,
+``FlatBaseModel._rebuild_filter`` and ``FlatBaseModel.rebuild_sort`` over the
+*real* ``FlatNodeMap``, stubbing only the data source (``sort_keys``/``db``) so
+the model machinery can run headlessly -- no database, GUI display or GObject
+construction.  The methods are invoked unbound on a duck-typed ``self`` that
+carries exactly the attributes they read.  A changing ``sort_keys`` stands in
+for a name-format change.  Pre-fix, ``rebuild_sort`` does not exist and the
+rebuild methods ignore the dirty flag, so the re-sort step raises
+``AttributeError``; post-fix the rows re-sort.  A second test guards the
+hierarchical path: ``TreeBaseModel`` must inherit a non-raising ``rebuild_sort``
+so the shared person-view callback does not crash on a tree format change.
+"""
+
+import types
+import unittest
+
+from ..basemodel import BaseModel
+from ..flatbasemodel import FlatBaseModel, FlatNodeMap
+from ..treebasemodel import TreeBaseModel
+
+
+class _OpenDb:
+    """Minimal stand-in for the database the rebuild methods consult."""
+
+    def is_open(self):
+        return True
+
+
+# Three people; the sort key is either the surname or the given name depending
+# on the "format" currently selected.  The two orders are reverses of each
+# other, so a re-sort is unambiguous.
+PEOPLE = {
+    "h_smith_alan": ("Smith", "Alan"),
+    "h_brown_zoe": ("Brown", "Zoe"),
+    "h_jones_mike": ("Jones", "Mike"),
+}
+ORDER_BY_SURNAME = ["h_brown_zoe", "h_jones_mike", "h_smith_alan"]
+ORDER_BY_GIVEN = ["h_smith_alan", "h_jones_mike", "h_brown_zoe"]
+
+
+def _make_fake():
+    """A duck-typed ``self`` carrying exactly the attributes the production
+    rebuild methods read, plus a mutable ``fmt`` selecting the sort key.
+
+    Returns ``(fake, fmt)``; flip ``fmt["by"]`` between ``"surname"`` and
+    ``"given"`` to model a name-format change.
+    """
+    fmt = {"by": "surname"}
+
+    def sort_keys():
+        keyed = []
+        for handle, (surname, given) in PEOPLE.items():
+            key = surname if fmt["by"] == "surname" else given
+            keyed.append((key, handle))
+        keyed.sort()
+        return keyed
+
+    fake = types.SimpleNamespace(
+        node_map=FlatNodeMap(),
+        clear_cache=lambda *a, **k: None,
+        _in_build=False,
+        db=_OpenDb(),
+        search=None,
+        skip=set(),
+        _reverse=False,
+        _sort_dirty=False,
+        user=None,
+        sort_keys=sort_keys,
+    )
+    return fake, fmt
+
+
+def _displayed_order(fake):
+    nm = fake.node_map
+    return [nm.get_handle(path) for path in range(len(nm))]
+
+
+class FlatBaseModelSortRebuildTest(unittest.TestCase):
+    def _check_resort(self, rebuild):
+        """``rebuild`` is the (unbound) production rebuild method to exercise."""
+        fake, fmt = _make_fake()
+
+        # Initial build: ordered by surname.
+        rebuild(fake)
+        self.assertEqual(_displayed_order(fake), ORDER_BY_SURNAME)
+
+        # The user changes the name format -> the sort key now differs.
+        fmt["by"] = "given"
+
+        # A plain redisplay (search/filter rebuild) reuses the cached sort
+        # order -- correct while the sort function is fixed; here it documents
+        # that the cache is what must be invalidated.
+        rebuild(fake)
+        self.assertEqual(
+            _displayed_order(fake),
+            ORDER_BY_SURNAME,
+            "a plain rebuild reuses the cached sort map",
+        )
+
+        # Invalidate the sort cache (what the People view does on
+        # nameformat-changed), then rebuild: the rows must re-sort to the new
+        # format without reopening the database.
+        FlatBaseModel.rebuild_sort(fake)
+        rebuild(fake)
+        self.assertEqual(
+            _displayed_order(fake),
+            ORDER_BY_GIVEN,
+            "rows did not re-sort after the name-format change (bug #9267)",
+        )
+
+    def test_resort_via_rebuild_filter(self):
+        # The People flat view's default redisplay path (sidebar filter).
+        self._check_resort(FlatBaseModel._rebuild_filter)
+
+    def test_resort_via_rebuild_search(self):
+        # The top-search-bar redisplay path.
+        self._check_resort(FlatBaseModel._rebuild_search)
+
+
+class TreeModelSortRebuildSafetyTest(unittest.TestCase):
+    """The shared BasePersonView callback calls ``model.rebuild_sort()`` on
+    whatever model the view holds.  ``PersonTreeView`` holds a ``PersonTreeModel``
+    (``-> TreeBaseModel``), which has no cached sort map; ``rebuild_sort`` must
+    therefore exist and be a harmless no-op there so the callback does not raise
+    ``AttributeError`` on a name/place-format change in the Person Tree view.
+    """
+
+    def test_basemodel_provides_default_rebuild_sort(self):
+        self.assertTrue(hasattr(BaseModel, "rebuild_sort"))
+
+    def test_treebasemodel_rebuild_sort_is_noop(self):
+        # Inherited from BaseModel; the body touches no instance state, so it is
+        # safe to invoke unbound on a bare object and must return None.
+        self.assertIsNone(TreeBaseModel.rebuild_sort(object()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/plugins/lib/libpersonview.py
+++ b/gramps/plugins/lib/libpersonview.py
@@ -178,10 +178,24 @@ class BasePersonView(ListView):
             filter_class=PersonSidebarFilter,
         )
 
-        uistate.connect("nameformat-changed", self.build_tree)
-        uistate.connect("placeformat-changed", self.build_tree)
+        uistate.connect("nameformat-changed", self._format_changed)
+        uistate.connect("placeformat-changed", self._format_changed)
 
         self.additional_uis.append(self.additional_ui)
+
+    def _format_changed(self, *args):
+        """
+        A display-format change (name or place) alters the rendered -- and
+        therefore the sorted -- value of a column, so the model's cached sort
+        keys are stale. Invalidate them before rebuilding so the rows re-sort to
+        the new format without reopening the database. ``rebuild_sort`` is a
+        no-op on the tree model (which re-sorts from scratch on rebuild) and the
+        cache invalidation on the flat model, so this is safe for both the flat
+        and tree person views that share this base. (bug #9267)
+        """
+        if self.model:
+            self.model.rebuild_sort()
+        self.build_tree()
 
     def navigation_type(self):
         """

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -483,6 +483,7 @@ gramps/gui/views/treemodels/sourcemodel.py
 #
 # gui.views.treemodels.test package
 #
+gramps/gui/views/treemodels/test/flatbasemodel_sort_test.py
 gramps/gui/views/treemodels/test/node_test.py
 gramps/gui/views/treemodels/test/treebasemodel_test.py
 #


### PR DESCRIPTION
## Summary
**User impact:** Change how names are displayed (for example switching from surname-first to given-name-first in Preferences), and the People list keeps showing rows in the old sort order until you close and reopen the database. The names update on screen, but the ordering is stale, so the list looks wrongly sorted.

This makes the People list re-sort itself as soon as the display-name (or place) format changes, without needing a reopen.

Reported in Mantis [#9267](https://gramps-project.org/bugs/view.php?id=9267).

## What to look at
The flat People list caches its computed sort order to stay fast; the fix invalidates that cache when the name/place format changes so the list re-sorts immediately. To reproduce: open the People view, then Edit → Preferences → Display and change the Display Name format — pre-fix the row order is unchanged until reopen, post-fix the rows reorder in place.

## Root cause
The flat People list caches the `(sortkey, handle)` map across rebuilds to avoid recomputing sort keys when the database hasn't changed (e.g. search or filter narrowing). When the user changes the Display Name format in Edit→Preferences→Display, the sort key itself changes (e.g. surname-first → given-first), but the view's rebuild path (`nameformat-changed` → `build_tree`) redisplays the rows without invalidating the cache, leaving the list sorted by the *previous* format until the database is reopened.

## Fix
Add a `rebuild_sort()` method to the model layer:

1. **BaseModel** (`gramps/gui/views/treemodels/basemodel.py:59-71`) — define `rebuild_sort()` as a no-op default. The hierarchical (tree) model clears and re-adds every row on each rebuild, so it re-sorts from scratch; the flat model caches the sort order and needs to override this to invalidate the cache.

2. **FlatBaseModel** (`gramps/gui/views/treemodels/flatbasemodel.py:494-497`, `:548-562`) — add a `_sort_dirty` flag initialized `False` in `__init__`. Override `rebuild_sort()` to set it `True`. In `_rebuild_search` and `_rebuild_filter`, change the cache-reuse guard from `if not allkeys:` to `if self._sort_dirty or not allkeys:` (lines 612 and 647), and clear the flag after recomputing.

3. **BasePersonView** (`gramps/plugins/lib/libpersonview.py:191-202`) — add a `_format_changed()` handler that calls `self.model.rebuild_sort()` (guarded for the pre-build `None` case) before `build_tree()`. Wire it to both `nameformat-changed` and `placeformat-changed` signals.

The same view callback is safe on both flat and tree person models because `rebuild_sort()` now exists on the common base; the tree model's no-op does nothing (it re-sorts on every rebuild anyway), and the flat model's override sets the flag. This addresses iteration 1's rejection: iteration 1 added `rebuild_sort()` only to `FlatBaseModel`, so a name-format change on the Person Tree view would raise `AttributeError` at runtime.

## Verification
- **Claim:** changing the display-name (or place) format re-sorts the People list immediately, on both the flat and tree person models, without a database reopen and without raising.
- **Checked:** on `upstream/maintenance/gramps61` —
  - `gramps/gui/views/treemodels/basemodel.py:59-71` — `rebuild_sort()` default
  - `gramps/gui/views/treemodels/flatbasemodel.py:491-626` — cache initialization and reuse guards
  - `gramps/plugins/lib/libpersonview.py:178-202` — signal routing and format-changed handler
- **Test:** core regression test `gramps/gui/views/treemodels/test/flatbasemodel_sort_test.py` (new), two classes —
  - `FlatBaseModelSortRebuildTest` drives the production `_rebuild_search()` / `_rebuild_filter()` over a real `FlatNodeMap` with a mutable sort-key function (surname vs. given name; the orders are reverses, so re-sort is unambiguous). Pre-fix `rebuild_sort()` doesn't exist → `AttributeError` (RED); post-fix rows re-sort to the new format (GREEN).
  - `TreeModelSortRebuildSafetyTest` guards the iteration-1 rejection: asserts `BaseModel` provides `rebuild_sort()` and that `TreeBaseModel.rebuild_sort()` is a harmless no-op (returns `None` without raising). Pre-fix → `AttributeError` on tree format change; post-fix → GREEN.
  - Advisory AT-SPI interface test `engine/interface/test_bug_9267_name-format-sort.py` launches the flat People list, captures the display-order Gramps-ID sequence, applies a format change via UI automation, and re-captures — pre-fix IDs unchanged (FAIL), post-fix IDs reordered (PASS).

Fixes [#9267](https://gramps-project.org/bugs/view.php?id=9267)
