### PR TITLE
Fix date.get_start_stop_range() overpadding compound estimated dates

### DIFF
--- a/gramps/gen/lib/date.py
+++ b/gramps/gen/lib/date.py
@@ -995,7 +995,9 @@ class Date(BaseObject):
                 startmin = date_offset(stopmax, 1)
             fdiff = config.get("behavior.date-after-range")
             stopmax = (startmin[0] + fdiff, startmin[1], startmin[2])
-        elif self.modifier == Date.MOD_ABOUT or self.quality == Date.QUAL_ESTIMATED:
+        elif self.modifier == Date.MOD_ABOUT or (
+            self.quality == Date.QUAL_ESTIMATED and not self.is_compound()
+        ):
             fdiff = config.get("behavior.date-about-range")
             startmin = (startmin[0] - fdiff, startmin[1], startmin[2])
             stopmax = (stopmax[0] + fdiff, stopmax[1], stopmax[2])

--- a/gramps/gen/lib/test/date_test.py
+++ b/gramps/gen/lib/test/date_test.py
@@ -1708,6 +1708,48 @@ class Test_set2(BaseDateTest):
         )
 
 
+class EstimatedCompoundRangeTest(BaseDateTest):
+    """
+    Regression for bug 13387: an *estimated* compound date (RANGE/SPAN) carries
+    explicit bounds, so get_start_stop_range() must return those bounds verbatim
+    -- the Preferences "about" window (behavior.date-about-range, default 50y)
+    must NOT widen them. A single estimated date (no explicit range) is still
+    padded by that window, as before.
+    """
+
+    def test_estimated_range_keeps_explicit_bounds(self):
+        # "estimated between 1968 and 1978"
+        d = Date()
+        d.set(
+            quality=Date.QUAL_ESTIMATED,
+            modifier=Date.MOD_RANGE,
+            value=(0, 0, 1968, False, 0, 0, 1978, False),
+        )
+        start, stop = d.get_start_stop_range()
+        self.assertEqual(start, (1968, 1, 1))
+        self.assertEqual(stop, (1978, 12, 31))
+
+    def test_estimated_span_keeps_explicit_bounds(self):
+        d = Date()
+        d.set(
+            quality=Date.QUAL_ESTIMATED,
+            modifier=Date.MOD_SPAN,
+            value=(0, 0, 1968, False, 0, 0, 1978, False),
+        )
+        start, stop = d.get_start_stop_range()
+        self.assertEqual(start, (1968, 1, 1))
+        self.assertEqual(stop, (1978, 12, 31))
+
+    def test_single_estimated_date_still_padded(self):
+        # A non-compound estimated date keeps the about-range padding.
+        fdiff = config.get("behavior.date-about-range")
+        d = Date()
+        d.set(quality=Date.QUAL_ESTIMATED, value=(0, 0, 1973, False))
+        start, stop = d.get_start_stop_range()
+        self.assertEqual(start, (1973 - fdiff, 1, 1))
+        self.assertEqual(stop, (1973 + fdiff, 12, 31))
+
+
 class Test_set_newyear(BaseDateTest):
     def test_raises_error_iff_calendar_has_fixed_newyear(self):
         for cal in Date.CALENDARS:


### PR DESCRIPTION
## Summary
**User impact:** When a date is entered as an estimated range — for example "estimated between 1968 and 1978" — the Age Calculator stretches those explicit years by a large "about" margin (50 years by default) and reports absurd age spans. A plain estimated date should get that margin, but a date that already states its own start and end years should not.

This stops the "about" padding from being added to estimated ranges and spans, so their stated bounds are used as-is.

Reported in Mantis [#13387](https://gramps-project.org/bugs/view.php?id=13387).

## What to look at
The estimated "about" padding is now only applied to single estimated dates, not to ones that already carry explicit start/end bounds. To reproduce: give someone an estimated "between 1968 and 1978" date and open the Age Calculator — pre-fix the reported span is wildly widened by the ±"about" window, post-fix it uses 1968–1978 verbatim.

## Root cause
`Date.get_start_stop_range()` applies the ±"about" padding (default 50 years) whenever `quality == QUAL_ESTIMATED`, but this incorrectly applies to compound dates with explicit bounds (MOD_RANGE / MOD_SPAN — e.g. "estimated between 1968 and 1978"). The explicit bounds are then widened, causing the Age Calculator to report absurd age spans; an explicit "between" should define its own range without approximation padding.

## Fix
Condition the estimated-quality padding on `not self.is_compound()` at `gramps/gen/lib/date.py:998` so that the ±"about" window applies only to non-compound estimated dates. Compound estimated dates (RANGE/SPAN) now return their explicit bounds verbatim, while single estimated dates (MOD_NONE) retain the padding behavior.

## Verification
- **Claim:** estimated compound dates (RANGE/SPAN) return their explicit bounds without ±"about" padding, while single estimated dates still receive the padding.
- **Checked:** on maintenance/gramps61 —
  - `gramps/gen/lib/date.py:998` — the condition guarding the ±"about" padding branch, modified to add `and not self.is_compound()`
  - `gramps/gen/lib/date.py:1955-1959` — the `is_compound()` method that checks MOD_RANGE/MOD_SPAN
  - `gramps/gen/lib/test/date_test.py:1708+` — `EstimatedCompoundRangeTest` class with three regression tests
- **Test:** `EstimatedCompoundRangeTest` (`gramps/gen/lib/test/date_test.py:1708+`) — three cases: `test_estimated_range_keeps_explicit_bounds` (estimated MOD_RANGE 1968–1978 returns (1968-01-01, 1978-12-31), no padding); `test_estimated_span_keeps_explicit_bounds` (estimated MOD_SPAN 1968–1978 returns (1968-01-01, 1978-12-31), no padding); `test_single_estimated_date_still_padded` (single estimated date 1973 is still padded by `behavior.date-about-range`, preserving existing behavior). Verified locally: pre-fix the compound tests fail with over-padded bounds; post-fix all three pass and single-estimated still receives padding.

Fixes [#13387](https://gramps-project.org/bugs/view.php?id=13387)
