### PR TITLE
Apply Filter gramplet in Bottombar when sidebar hidden

### DIFF
--- a/gramps/gui/views/listview.py
+++ b/gramps/gui/views/listview.py
@@ -332,7 +332,7 @@ class ListView(NavigationView):
             self.list.save_column_info(self.list)
         if self.active:
             cput0 = perf_counter()
-            if not self.search_bar.is_visible():
+            if self.generic_filter is not None or not self.search_bar.is_visible():
                 filter_info = (True, self.generic_filter, False)
             else:
                 filter_info = self.search_bar.get_value()
@@ -783,7 +783,7 @@ class ListView(NavigationView):
         self.sort_order = order
         handle = self.first_selected()
 
-        if not self.search_bar.is_visible():
+        if self.generic_filter is not None or not self.search_bar.is_visible():
             filter_info = (True, self.generic_filter, False)
         else:
             filter_info = self.search_bar.get_value()


### PR DESCRIPTION
## Summary
**User impact:** If you move the Filter gramplet down into the Bottombar and then hide the sidebar, applying a filter does nothing — the list stays unfiltered. It only works while the sidebar is showing. This affects every list view (People, Events, Sources, Places, and so on).

This makes an explicitly chosen filter apply whether the sidebar is shown or hidden, so the Bottombar Filter gramplet works again.

Reported in Mantis [#8617](https://gramps-project.org/bugs/view.php?id=8617).

## What to look at
The list view now checks for an explicitly-set filter before falling back to the Search bar, so a filter set via the gramplet wins regardless of sidebar visibility. To reproduce pre-fix: open the People view, add the Filter gramplet to the Bottombar, hide the sidebar (View → Sidebar), type a surname in the gramplet's Name field, and press Find — pre-fix the list is unchanged, post-fix it filters to only matching rows.

## Root cause
The Filter gramplet (the same UI component whether docked in the sidebar or Bottombar) sets `view.generic_filter` and calls `build_tree()` to apply the user's chosen filter. However, `build_tree()` and `column_clicked()` decided whether to use that `generic_filter` or the Search bar's value **purely on Search-bar visibility**. The sidebar toggle directly couples Search-bar visibility to sidebar visibility: the Search bar is shown exactly when the sidebar is hidden. So: sidebar hidden → Search bar visible → `build_tree` uses the empty Search value and the gramplet's filter is silently dropped.

## Fix
Change the filter-selection condition at both sites to check whether `generic_filter is not None` before checking Search-bar visibility. This makes an explicitly-set filter win over Search-bar visibility, restoring the invariant that a filter the user has explicitly set via the gramplet must be applied to the list, whichever bar hosts it.

The change is in the shared `ListView` base class (`gramps/gui/views/listview.py`), so it applies to every `ListView` subclass (People, PersonTree, Events, Sources, Places, Citations, Repositories, Media, Notes, Families) rather than being a single-view special case.

## Verification
- **Claim:** an explicitly-set `generic_filter` is applied to the list whether the sidebar is shown or hidden, across every `ListView` subclass.
- **Checked:** on maintenance/gramps61 —
  - `gramps/gui/views/listview.py:335` — the filter-selection condition in `build_tree()` that decides between `generic_filter` and Search-bar value
  - `gramps/gui/views/listview.py:786` — the identical filter-selection condition in `column_clicked()` for re-sort model rebuilds
  - `gramps/plugins/gramplet/filter.py:76-77` — the Filter gramplet sets `self.gui.view.generic_filter` and calls `self.gui.view.build_tree()` to apply the user's selection
  - `gramps/gui/views/listview.py:432-440` — `sidebar_toggled()` coupling Search-bar visibility to sidebar visibility
- **Test:** `engine/interface/test_bug_0008617_bottombar_filter.py` (`Bug8617BottombarFilterTest`, AT-SPI/dogtail repro in the testbed) — RED (unpatched worktree): sidebar hidden, Filter gramplet in Bottombar, apply "Warner" surname filter → list unchanged, status bar `People: 100/100`. GREEN (patched worktree): same sequence → list filtered, status bar `People: 14/100`. The oracle is the status-bar filter label, which reflects the actual count of model rows displayed — immune to GtkTreeView row virtualization and valid for the grouped default People view.

Fixes [#8617](https://gramps-project.org/bugs/view.php?id=8617)
