### PR TITLE
fix(styled-text): skip applying default-valued style tags

### DIFF
--- a/gramps/gui/widgets/styledtextbuffer.py
+++ b/gramps/gui/widgets/styledtextbuffer.py
@@ -474,13 +474,13 @@ class StyledTextBuffer(UndoableBuffer):
             else:
                 self.remove_tag_by_name(str(style), start, end)
         elif StyledTextTagType.STYLE_TYPE[style] == str:
-            tag = self._find_tag_by_name(style, value)
             self._remove_style_from_selection(style)
-            self._apply_tag_to_selection(tag)
+            if value != StyledTextTagType.STYLE_DEFAULT[style]:
+                self._apply_tag_to_selection(self._find_tag_by_name(style, value))
         elif StyledTextTagType.STYLE_TYPE[style] == int:
-            tag = self._find_tag_by_name(style, value)
             self._remove_style_from_selection(style)
-            self._apply_tag_to_selection(tag)
+            if value != StyledTextTagType.STYLE_DEFAULT[style]:
+                self._apply_tag_to_selection(self._find_tag_by_name(style, value))
         else:
             # we should never get until here
             return

--- a/gramps/gui/widgets/test/styledtextbuffer_test.py
+++ b/gramps/gui/widgets/test/styledtextbuffer_test.py
@@ -1,0 +1,134 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Eduard Ralph
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Unit test for ``StyledTextBuffer._apply_style_to_selection`` — Mantis 3214.
+
+Mantis 0003214: in the Note editor, changing a (preformatted) note's font
+size away from the default (10) and then back to 10 does **not** clear the
+FONTSIZE style. ``_apply_style_to_selection`` removed the old FONTSIZE tag
+and then *unconditionally* applied a new explicit ``FONTSIZE=10`` tag — even
+though 10 is ``StyledTextTagType.STYLE_DEFAULT[FONTSIZE]``. The note looks
+fine in the editor, but reports apply that explicit size as an absolute
+override on top of the report's Preformatted paragraph style, so the rendered
+size differs from a note whose size was never touched, and the user can never
+get back to the original.
+
+The fix upholds the same invariant the buffer's own clear path already honours
+(``clear_selection`` removes a tag only when ``value != STYLE_DEFAULT[style]``,
+``gramps/gui/widgets/styledtextbuffer.py``): the apply path removes any prior
+tag for the style and then applies an explicit tag **only** when the value
+differs from the style default. Setting a value equal to the default therefore
+leaves the selection in the same tagged state as if the style had never been
+applied.
+
+The test drives the production public apply path
+(``StyledTextBuffer.apply_style`` → ``_apply_style_to_selection``) on a real
+buffer and inspects the resulting :class:`.StyledText` tags. A ``StyledTextBuffer``
+is a ``Gtk.TextBuffer`` subclass (not a widget), so it constructs without a
+display; no GTK main loop or X server is required.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+# Gramps targets GTK 3 throughout (see ``gramps/grampsapp.py``). Pin the
+# introspected version BEFORE any ``gramps.gui`` import so the widgets module
+# chain loads against the right ABI on a headless runner.
+import gi  # noqa: E402
+
+gi.require_version("Gtk", "3.0")  # noqa: E402
+
+from gramps.gen.lib import StyledText, StyledTextTagType  # noqa: E402
+from gramps.gui.widgets.styledtextbuffer import StyledTextBuffer  # noqa: E402
+
+FONTSIZE = StyledTextTagType.FONTSIZE
+FONTFACE = StyledTextTagType.FONTFACE
+
+
+# -----------------------------------------------------------
+#
+# StyledTextBufferDefaultStyleTest
+#
+# -----------------------------------------------------------
+class StyledTextBufferDefaultStyleTest(unittest.TestCase):
+    """Regression test for Mantis 3214 — default value must leave no tag."""
+
+    def _new_buffer(self, text: str = "hello world") -> StyledTextBuffer:
+        buf = StyledTextBuffer()
+        buf.set_text(StyledText(text))
+        buf.select_range(buf.get_start_iter(), buf.get_end_iter())
+        return buf
+
+    def _tags_for(self, buf: StyledTextBuffer, style: int):
+        """Explicit :class:`.StyledTextTag`s for ``style`` in the buffer's text."""
+        return [tag for tag in buf.get_text().get_tags() if int(tag.name) == style]
+
+    def test_fontsize_default_leaves_no_explicit_tag(self):
+        """FONTSIZE bumped away and back to the default clears the tag (the bug)."""
+        default = StyledTextTagType.STYLE_DEFAULT[FONTSIZE]
+        buf = self._new_buffer()
+
+        # Away from the default, then back to it — the Mantis 3214 sequence.
+        buf.apply_style(FONTSIZE, 12)
+        buf.apply_style(FONTSIZE, default)
+
+        msg = (
+            f"setting FONTSIZE back to its default ({default}) must leave no "
+            "explicit FONTSIZE tag — an override that differs from an unchanged note"
+        )
+        self.assertEqual(self._tags_for(buf, FONTSIZE), [], msg)
+
+    def test_fontsize_default_matches_untouched_note(self):
+        """A back-to-default note carries the same tags as one never changed."""
+        default = StyledTextTagType.STYLE_DEFAULT[FONTSIZE]
+
+        touched = self._new_buffer()
+        touched.apply_style(FONTSIZE, 18)
+        touched.apply_style(FONTSIZE, default)
+
+        untouched = self._new_buffer()
+
+        self.assertEqual(
+            [(int(t.name), t.value) for t in touched.get_text().get_tags()],
+            [(int(t.name), t.value) for t in untouched.get_text().get_tags()],
+        )
+
+    def test_fontsize_nondefault_still_tagged(self):
+        """A genuine (non-default) size is still recorded — no over-removal."""
+        buf = self._new_buffer()
+        buf.apply_style(FONTSIZE, 12)
+
+        tags = self._tags_for(buf, FONTSIZE)
+        self.assertEqual([(int(t.name), t.value) for t in tags], [(FONTSIZE, 12)])
+
+    def test_fontface_default_leaves_no_explicit_tag(self):
+        """The str-typed branch upholds the same invariant (FONTFACE)."""
+        default = StyledTextTagType.STYLE_DEFAULT[FONTFACE]
+        buf = self._new_buffer()
+
+        buf.apply_style(FONTFACE, "Serif")
+        buf.apply_style(FONTFACE, default)
+
+        self.assertEqual(self._tags_for(buf, FONTFACE), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -515,6 +515,7 @@ gramps/gui/widgets/validatedcomboentry.py
 gramps/gui/widgets/test/__init__.py
 gramps/gui/widgets/test/fanchart_test.py
 gramps/gui/widgets/test/selectionwidget_test.py
+gramps/gui/widgets/test/styledtextbuffer_test.py
 #
 # plugins
 #


### PR DESCRIPTION
## Summary
**User impact:** Change a preformatted note's font size and then set it back to the default, and it looks right in the editor but prints at the wrong size in reports — with no way to undo it. A note whose size was never touched prints correctly; one that was changed and reset does not.

This makes resetting a size to the default actually clear it, so the note behaves like one that was never changed.

Reported in Mantis [#3214](https://gramps-project.org/bugs/view.php?id=3214).

## What to look at
The whole change is one guard: when the size (or font, colour, highlight) you pick is already the default, don't leave a hidden override behind. To try it: in a preformatted note, set the font size to 12, then back to 10, and confirm no size override remains. A new headless test does exactly this.

## Root cause
The apply path removes any prior tag for a style, then unconditionally applies a fresh tag — even when `value == StyledTextTagType.STYLE_DEFAULT[style]` (FONTSIZE default = 10, `gramps/gen/lib/styledtexttagtype.py:99`). The buffer already honours this invariant in the other write paths — `clear_selection` removes a tag only when `value != STYLE_DEFAULT[style]` (`gramps/gui/widgets/styledtextbuffer.py:519`), and `after_insert_text` re-applies only when `value and value != STYLE_DEFAULT[style]` (`:354`). The apply path was the one place that broke it.

## Fix
`StyledTextBuffer._apply_style_to_selection` now guards both the int (FONTSIZE) and str (FONTFACE, FONTCOLOR, HIGHLIGHT) branches (`gramps/gui/widgets/styledtextbuffer.py:476–483`) to skip tagging when the value equals the default, so applying a default value removes any prior tag without re-applying one.

## Verification
- **Claim:** setting a style back to its default leaves the text in the same tagged state as if the style had never been applied.
- **Checked:** `gramps/gui/widgets/styledtextbuffer.py:476–483` on `maintenance/gramps61` — apply now guards on `value != STYLE_DEFAULT[style]`, matching `clear_selection`/`after_insert_text`.
- **Test:** `gramps/gui/widgets/test/styledtextbuffer_test.py` (new) — FONTSIZE 12 → 10 leaves no explicit tag; a back-to-default note (18 → 10) carries identical tags to an untouched note; a genuine non-default size (12) is still recorded; and the str-typed branch (FONTFACE) upholds the same invariant. Red with the production change reverted, green with the fix.

Fixes [#3214](https://gramps-project.org/bugs/view.php?id=3214)

