### PR TITLE
fix: refresh Family Events tab when participant is renamed

### DIFF
--- a/gramps/gui/editors/editfamily.py
+++ b/gramps/gui/editors/editfamily.py
@@ -504,7 +504,7 @@ class EditFamily(EditPrimary):
                 "event-update": self.topdata_updated,  # change eg birth event fath
                 "event-rebuild": self.topdata_updated,
                 "event-delete": self.topdata_updated,  # delete eg birth event fath
-                "person-update": self.topdata_updated,  # change eg name of father
+                "person-update": self.person_updated,  # change eg name of father
                 "person-delete": self.person_delete,  # mother/father deleted?
                 "person-rebuild": self._do_close,
             }
@@ -584,6 +584,22 @@ class EditFamily(EditPrimary):
               tabpage itself tracks it
         """
         self.load_data()
+
+    def person_updated(self, *obj):
+        """
+        Callback method called when a person shown in the family editor is
+        updated (eg the name of the father or mother is changed and saved from
+        within this dialog).
+
+        Besides the top father/mother panel (refreshed by load_data), the
+        embedded Events tab renders participant names derived from the
+        referenced persons in its "Main Participants" column. The event list
+        only tracks event signals, not person-update, so it must be rebuilt
+        here or that column keeps showing the participant's old name (bug 8603).
+        """
+        self.topdata_updated()
+        if hasattr(self, "event_list"):
+            self.event_list.rebuild_callback()
 
     def show_buttons(self):
         """


### PR DESCRIPTION
## Summary
**User impact:** When you rename a family member from inside the Family editor, the editor's Events tab keeps showing that person's old name in the "Main Participants" column. The rename saved correctly, but the list beside it does not refresh, so the editor shows two different names for the same person until you close and reopen it.

This routes the person-changed notification to a handler that also refreshes the event list, so the new name appears immediately.

Reported in Mantis [#8603](https://gramps-project.org/bugs/view.php?id=8603).

## What to look at
The Family editor already refreshes its top father/mother panel when a participant is renamed, but never rebuilds the embedded Events list — so its "Main Participants" column stays stale. The fix adds a dedicated handler that does both, mirroring how the Children tab in the same editor already works. To try it: open a family whose father is a listed main participant (Events tab → "Main Participants"), edit the father from the Family editor (pencil → Edit Person → change name → OK). Pre-fix the Events tab shows the old name; post-fix it shows the new name immediately.

## Root cause
Currently, the `person-update` signal is routed to `topdata_updated` (`editfamily.py:507`), which calls `load_data` (`editfamily.py:579–586`) to refresh only the top father/mother panel and `self.phandles`. The embedded event list (`self.event_list`, an `EventEmbedList` created at `editfamily.py:816`) never listens for `person-update` — it only registers callbacks for `event-update` and `event-delete` (`eventembedlist.py:139–150`).

The "Main Participants" column is derived from the referenced persons' names, computed at model construction time (`eventrefmodel.py:204–205` calls `get_participant_from_event(self.db, ref)` for each row). Since the event list model is never rebuilt when a participant is renamed, the column values remain stale.

## Fix
The fix (in `gramps/gui/editors/editfamily.py`) introduces a new `person_updated` handler, and routes `person-update` to it (`editfamily.py:509`, was `self.topdata_updated`). The handler (`editfamily.py:588–602`):
1. Calls `topdata_updated()` — preserving the existing top-panel refresh.
2. Calls `self.event_list.rebuild_callback()` — triggering a fresh event-list model construction to re-read current participant names from the database (`embeddedlist.py:635–643`).

This pattern mirrors the existing Children tab in the same editor (`editfamily.py:179, 185–190`), which already listens for `person-update` and calls `rebuild()` on change. The fix reuses `rebuild_callback`, the same entry point that `event-update` already uses (`eventembedlist.py:152–158`), so it introduces no new module API. A `hasattr(self, "event_list")` guard protects against `person-update` firing before `_create_tabbed_pages` has constructed the tab.

## Verification
- **Claim:** `person-update` reaches only the top panel, not the event list; the "Main Participants" column is computed at model-build time; and the patch routes the signal to a new handler that refreshes both.
- **Checked:** on `maintenance/gramps61` — `editfamily.py:507` routed `person-update` to `topdata_updated`, which calls `load_data` (`editfamily.py:579–586`) and does not rebuild `self.event_list`; the event list only registered `event-update`/`event-delete` (`eventembedlist.py:139–150`). Column values are computed by `get_participant_from_event(self.db, ref)` during model build (`eventrefmodel.py:204–205`) and reflect current DB state only when `rebuild()` reconstructs the model (`embeddedlist.py:589–625`). Patched: `editfamily.py:509` now sends `person-update` to `self.person_updated`; the new `person_updated` (`editfamily.py:588–602`) calls `topdata_updated()` then `self.event_list.rebuild_callback()` (`embeddedlist.py:635–643`). Consistency: the Children tab (`editfamily.py:179, 185–190`) already uses `person-update` → `rebuild()`. Manual GUI verification: on unpatched `maintenance/gramps61` the Events tab kept the old name after a rename; on the patched tree it shows the new name immediately.
- **Test:** No core unit test ships — the behaviour is a GUI signal-driven refresh, not headless-testable. Coverage is a committed AT-SPI/dogtail regression in the gramps-testbed harness (not part of this PR), `engine/interface/test_bug_0008603_family_event_participant_refresh.py`, which renames a family's father from the Family editor and asserts the Events tab's "Main Participants" column updates. Manual repro: open a family whose father is a listed main participant, rename the father from the Family editor, confirm the Events tab shows the new name immediately (pre-fix: it keeps the old name).

Fixes [#8603](https://gramps-project.org/bugs/view.php?id=8603)
