### PR TITLE
fix(cairo): restore table cells split at page boundaries

### DIFF
--- a/gramps/plugins/lib/libcairodoc.py
+++ b/gramps/plugins/lib/libcairodoc.py
@@ -549,7 +549,25 @@ class GtkDocParagraph(GtkDocBaseElement):
                 self._text, -1, "\000"
             )
 
-    def divide(self, layout, width, height, dpi_x, dpi_y):
+    def divide(
+        self,
+        layout,
+        width,
+        height,
+        dpi_x,
+        dpi_y,
+        force_split=False,
+        allow_overflow=False,
+    ):
+        # bug 6324: 'force_split' (set when moving this paragraph whole to the
+        # next page would make no progress -- a wrapping cell on the last line of
+        # a page, or the paginator's no-progress guard) overrides the "keep a
+        # short cell paragraph together" rule below, so at least its first lines
+        # render here instead of the cell being dropped.  'allow_overflow' is the
+        # stronger signal the paginator's no-progress guard adds when even a
+        # fresh empty page cannot hold the content: only then may a line that
+        # does not fit be placed here (accepting overflow) rather than moved --
+        # otherwise pagination would loop forever.
         self.__parse_text()
 
         l_margin = self._style.get_left_margin() * dpi_x / 2.54
@@ -615,9 +633,22 @@ class GtkDocParagraph(GtkDocBaseElement):
 
         # we need to cut paragraph:
 
+        # bug 6324: place this paragraph as-is on the current page, accepting
+        # overflow.  Used only when the paginator's no-progress guard has
+        # established the page is already as large as it will get (a single line
+        # taller than a whole page); the alternative is dropping the line or
+        # looping forever.
+        def _place_whole():
+            para_h = layout_height + spacing + t_margin + (2 * v_padding)
+            if height - para_h > b_margin:
+                para_h += b_margin
+            return (self, None), para_h
+
         # 1. if paragraph part of a cell, we do not divide if only small part,
-        # of paragraph can be shown, instead move to next page
-        if line_count < 4 and self._parent._type == "CELL":
+        # of paragraph can be shown, instead move to next page -- UNLESS the
+        # caller forced a split (bug 6324: the row/page is already as large as it
+        # gets, so moving whole would drop the cell or loop).
+        if not force_split and line_count < 4 and self._parent._type == "CELL":
             return (None, self), 0
 
         lineiter = layout.get_iter()
@@ -627,7 +658,13 @@ class GtkDocParagraph(GtkDocBaseElement):
         # 2. if nothing fits, move to next page without split
         #  there is a spacing above and under the text
         if linerange[1] - linerange[0] + 2.0 * spacing > text_height * Pango.SCALE:
-            return (None, self), 0
+            if not force_split:
+                return (None, self), 0
+            # bug 6324: forced, but not even the first line fits here.  If it is
+            # the only line and moving makes no progress (allow_overflow), place
+            # it here (overflow); otherwise move it to the next page.
+            if lineiter.at_last_line():
+                return _place_whole() if allow_overflow else ((None, self), 0)
 
         # 3. split the paragraph
         startheight = linerange[0]
@@ -635,6 +672,8 @@ class GtkDocParagraph(GtkDocBaseElement):
         splitline = -1
         if lineiter.at_last_line():
             # only one line of text that does not fit
+            if force_split and allow_overflow:
+                return _place_whole()
             return (None, self), 0
 
         while not lineiter.at_last_line():
@@ -647,6 +686,8 @@ class GtkDocParagraph(GtkDocBaseElement):
                 break
             endheight = linerange[1]
         if splitline == -1:
+            if force_split and allow_overflow:
+                return _place_whole()
             print("CairoDoc STRANGE ")
             return (None, self), 0
         # we split at splitline
@@ -843,7 +884,16 @@ class GtkDocTable(GtkDocBaseElement):
     _type = "TABLE"
     _allowed_children = ["ROW"]
 
-    def divide(self, layout, width, height, dpi_x, dpi_y):
+    def divide(
+        self,
+        layout,
+        width,
+        height,
+        dpi_x,
+        dpi_y,
+        force_split=False,
+        allow_overflow=False,
+    ):
         # calculate real table width
         table_width = width * self._style.get_width() / 100
 
@@ -852,7 +902,33 @@ class GtkDocTable(GtkDocBaseElement):
         row_index = 0
         while row_index < len(self._children):
             row = self._children[row_index]
-            (r1, r2), row_height = row.divide(layout, table_width, height, dpi_x, dpi_y)
+            # bug 6324: only the FIRST row can legitimately be forced (it is the
+            # one sitting at the top of an already-full/empty page); later rows
+            # have committed rows above them and may still be kept together.
+            (r1, r2), row_height = row.divide(
+                layout,
+                table_width,
+                height,
+                dpi_x,
+                dpi_y,
+                force_split and row_index == 0,
+                allow_overflow and row_index == 0,
+            )
+            if r1 is None:
+                # bug 6324: the row could place none of its content here and asks
+                # to move whole to the next page (keep-together).  Hand it and
+                # every following row to a continuation table so the row is not
+                # duplicated across the break.  If rows above it already fit that
+                # is real progress; if NOTHING fits, return the continuation only
+                # (first half None) so the paginator moves it to a fresh page --
+                # where, if it still does not fit, allow_overflow guarantees it is
+                # placed rather than looping.
+                new_table = GtkDocTable(self._style)
+                list(map(new_table.add_child, self._children[row_index:]))
+                del self._children[row_index:]
+                if not self._children:
+                    return (None, new_table), 0
+                return (self, new_table), table_height
             if r2 is not None:
                 # break the table in two parts
                 break
@@ -900,10 +976,20 @@ class GtkDocTableRow(GtkDocBaseElement):
     _type = "ROW"
     _allowed_children = ["CELL"]
 
-    def divide(self, layout, width, height, dpi_x, dpi_y):
+    def divide(
+        self,
+        layout,
+        width,
+        height,
+        dpi_x,
+        dpi_y,
+        force_split=False,
+        allow_overflow=False,
+    ):
         # the highest cell gives the height of the row
         cell_heights = []
         dividedrow = False
+        cell_split = False
         cell_width_iter = self._style.__iter__()
         new_row = GtkDocTableRow(self._style)
         for cell in self._children:
@@ -914,12 +1000,41 @@ class GtkDocTableRow(GtkDocBaseElement):
             (c1, c2), cell_height = cell.divide(
                 layout, cell_width, height, dpi_x, dpi_y
             )
+            if c1 is None and not force_split and not cell_split:
+                # bug 6324: this cell can place none of its content in the space
+                # left, no earlier cell in the row has committed content yet, and
+                # we are allowed to move the whole row to the next page (where it
+                # gets a full page of room).  Keep the row together and move it
+                # whole rather than tearing this cell -- leaving it blank here
+                # while its text lands on a later page (the reported defect).
+                return (None, self), 0
+            if c1 is None:
+                # bug 6324: either an earlier cell already split across the page
+                # boundary (cell_split -- so the row spans the break and cannot
+                # move whole), or the paginator forced the split (force_split --
+                # the page is already as large as it will get).  Force this cell
+                # to split too so its first lines render here beside its rowmates
+                # instead of a blank cell.  Overflow of an UNSPLITTABLE cell (an
+                # image taller than the room left) is permitted only under
+                # allow_overflow -- the paginator's genuine no-progress signal --
+                # so a merely-torn row lets such a cell move to the next page
+                # intact rather than clipping it here.
+                (c1, c2), cell_height = cell.divide(
+                    layout,
+                    cell_width,
+                    height,
+                    dpi_x,
+                    dpi_y,
+                    force_split=True,
+                    allow_overflow=allow_overflow,
+                )
             cell_heights.append(cell_height)
             if c2 is None:
                 emptycell = GtkDocTableCell(c1._style, c1.get_span())
                 new_row.add_child(emptycell)
             else:
                 dividedrow = True
+                cell_split = True
                 new_row.add_child(c2)
 
         # save height [inch] of the row to be able to draw exact cell border
@@ -976,7 +1091,16 @@ class GtkDocTableCell(GtkDocBaseElement):
     def get_span(self):
         return self._span
 
-    def divide(self, layout, width, height, dpi_x, dpi_y):
+    def divide(
+        self,
+        layout,
+        width,
+        height,
+        dpi_x,
+        dpi_y,
+        force_split=False,
+        allow_overflow=False,
+    ):
         h_padding = self._style.get_padding() * dpi_x / 2.54
         v_padding = self._style.get_padding() * dpi_y / 2.54
 
@@ -993,8 +1117,28 @@ class GtkDocTableCell(GtkDocBaseElement):
         for child in self._children:
             if new_cell is None:
                 (e1, e2), child_height = child.divide(
-                    layout, width, available_height, dpi_x, dpi_y
+                    layout,
+                    width,
+                    available_height,
+                    dpi_x,
+                    dpi_y,
+                    force_split,
+                    allow_overflow,
                 )
+                # bug 6324: the cell's first child could place none of its
+                # content in the room left (a short paragraph hitting the
+                # keep-together rule).  When we were NOT forced, report that by
+                # returning the cell INTACT (None, self) so the caller
+                # (GtkDocTableRow.divide) can move the whole row or force a
+                # split -- do not fall through to the truncation below, which
+                # empties the cell and leaves it blank while its content is
+                # carried away.  When we WERE forced, fall through: a splittable
+                # child has split (e1 set) and an unsplittable one that still
+                # will not fit (e1 None, e2 the child) is carried to a
+                # continuation cell here -- blank on this page, intact on the
+                # next -- rather than dropped.
+                if e1 is None and e2 is not None and childnr == 0 and not force_split:
+                    return (None, self), 0
                 cell_height += child_height
                 available_height -= child_height
                 if e2 is not None:
@@ -1084,7 +1228,16 @@ class GtkDocPicture(GtkDocBaseElement):
         self._height = height
         self._crop = crop
 
-    def divide(self, layout, width, height, dpi_x, dpi_y):
+    def divide(
+        self,
+        layout,
+        width,
+        height,
+        dpi_x,
+        dpi_y,
+        force_split=False,
+        allow_overflow=False,
+    ):
         img_width = self._width * dpi_x / 2.54
         img_height = self._height * dpi_y / 2.54
 
@@ -1092,8 +1245,15 @@ class GtkDocPicture(GtkDocBaseElement):
         # if it can't fit on the current one
         if img_height <= height:
             return (self, None), img_height
-        else:
-            return (None, self), 0
+        # bug 6324: an image can never be split.  Under allow_overflow the
+        # paginator has established the page is already as large as it will get
+        # (an image taller than a whole page -- moving again would loop forever),
+        # so place it here accepting overflow.  A merely-forced split (force_split
+        # without allow_overflow, e.g. a torn row whose sibling cell split) must
+        # NOT clip a fitting image here -- it moves to the next page intact.
+        if allow_overflow:
+            return (self, None), img_height
+        return (None, self), 0
 
     def draw(self, cr, layout, width, dpi_x, dpi_y):
         from gi.repository import Gtk, Gdk
@@ -1150,7 +1310,16 @@ class GtkDocFrame(GtkDocBaseElement):
     _type = "FRAME"
     _allowed_children = ["LINE", "POLYGON", "BOX", "TEXT"]
 
-    def divide(self, layout, width, height, dpi_x, dpi_y):
+    def divide(
+        self,
+        layout,
+        width,
+        height,
+        dpi_x,
+        dpi_y,
+        force_split=False,
+        allow_overflow=False,
+    ):
         frame_width = round(self._style.width * dpi_x / 2.54)
         frame_height = round(self._style.height * dpi_y / 2.54)
         t_margin = self._style.spacing[2] * dpi_y / 2.54
@@ -1161,6 +1330,12 @@ class GtkDocFrame(GtkDocBaseElement):
         if frame_height + t_margin + b_margin <= height:
             return (self, None), frame_height + t_margin + b_margin
         elif frame_height + t_margin <= height:
+            return (self, None), height
+        # bug 6324: a frame taller than a whole page cannot be split.  Under
+        # allow_overflow the paginator has established the page is already as
+        # large as it will get, so place it here (overflow) rather than loop
+        # forever; a merely-forced split moves it to the next page intact.
+        elif allow_overflow:
             return (self, None), height
         else:
             return (None, self), 0
@@ -1796,9 +1971,33 @@ links (like ODF) and write PDF from that format.
             # this is a self._doc where nothing has been added. Empty page.
             return True
         elem = self._elements_to_paginate.pop(0)
+        # bug 6324: is the current page still empty? (an empty page always has
+        # the full page_height available). Captured BEFORE dividing so the
+        # no-progress guard below can tell "nothing fit on a fresh page" (a loop)
+        # from "nothing fit in the room left below other content" (normal).
+        page_is_empty = len(self._pages[len(self._pages) - 1].get_children()) == 0
         (e1, e2), e1_h = elem.divide(
             layout, page_width, self._available_height, dpi_x, dpi_y
         )
+
+        # bug 6324: the element placed nothing (e1 is None) yet asked to be
+        # carried to the next page (e2) -- and the current page is ALREADY empty.
+        # Moving it to yet another empty page makes no progress, so
+        # paginate_document's `while not paginate()` loop would spin forever.
+        # Re-divide the CONTINUATION (e2, which holds the content -- a table hands
+        # back its rows there and empties itself when nothing fits) forcing the
+        # split AND allowing overflow of anything unsplittable, so pagination
+        # places what it can here and always advances.
+        if e1 is None and e2 is not None and page_is_empty:
+            (e1, e2), e1_h = e2.divide(
+                layout,
+                page_width,
+                self._available_height,
+                dpi_x,
+                dpi_y,
+                force_split=True,
+                allow_overflow=True,
+            )
 
         # if (part of) it fits on current page add it
         if e1 is not None:

--- a/gramps/plugins/test/cairodoc_table_pagination_test.py
+++ b/gramps/plugins/test/cairodoc_table_pagination_test.py
@@ -1,0 +1,501 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps developers
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Regression test for bug 6324 (cairo/PDF table cell dropped at a page break).
+
+In the cairo (print/PDF) document backend a table row that lands near the foot
+of a page with a cell whose short paragraph has to wrap to a second line was
+rendered *torn*: the wrapping cell printed **blank** at the bottom of the page
+while its text was pushed onto the next page beside blank copies of the row's
+other cells (dsblank, Mantis 6324 -- "the cell prints no text at all").
+
+The pagination invariant is that all cells of a table row begin together: a
+cell whose text crosses a page boundary must appear in full across the pages --
+either the whole row moves to the next page, or the row splits with every cell
+rendering its first lines on the same page as its siblings -- and a cell must
+never be left blank while a sibling cell in the same row keeps its text.
+
+This test drives the **production** pagination path -- ``CairoDoc.paginate`` and
+the ``GtkDocTable`` / ``GtkDocTableRow`` / ``GtkDocTableCell`` /
+``GtkDocParagraph`` ``divide`` chain in
+:mod:`gramps.plugins.lib.libcairodoc` -- against a realistic geometry, and
+checks that the wrapping cell begins on the same page as its rowmate, that no
+line is dropped, and that pagination always terminates.  It covers the four
+page-boundary branches the fix touches:
+
+* the wrapping cell is the *last* column (the whole row moves to the next page);
+* an *earlier* column splits across the boundary and the later short column must
+  split too instead of being left blank beside it;
+* a degenerate geometry where the wrapping cell cannot fit even a full empty
+  page -- the paginator must force the split and terminate, not spin forever;
+* an *unsplittable image* cell in a torn row must move to the next page **intact**
+  (never clipped/overflowed into the too-small slot) -- the ``force_split`` vs
+  ``allow_overflow`` distinction.
+
+It is headless: Pango lays text out against an in-memory cairo image surface; no
+X display, GTK main loop, D-Bus or AT-SPI is used.  (``libcairodoc`` imports
+``gramps.gui.utils``, which is explicitly written to import without a DISPLAY.)
+"""
+
+import unittest
+
+import cairo
+import gi
+
+gi.require_version("Pango", "1.0")
+gi.require_version("PangoCairo", "1.0")
+from gi.repository import Pango, PangoCairo
+
+from gramps.gen.plug.docgen import (
+    ParagraphStyle,
+    TableStyle,
+    TableCellStyle,
+    FontStyle,
+    FONT_SANS_SERIF,
+    PARA_ALIGN_LEFT,
+)
+from gramps.plugins.lib.libcairodoc import (
+    CairoDoc,
+    GtkDocDocument,
+    GtkDocTable,
+    GtkDocTableRow,
+    GtkDocTableCell,
+    GtkDocParagraph,
+    GtkDocPicture,
+    fontstyle_to_fontdescription,
+)
+
+DPI = 72.0
+PAGE_WIDTH = 500.0  # points
+FONT_SIZE = 12
+
+# Distinctive opening tokens so a cell's rendered text can be located per page
+# regardless of where Pango happens to wrap it.
+LABEL_TEXT = "Zlabel"
+# A value that wraps to more than one but fewer than four lines in a
+# half-page-wide, single-column cell -- the "short cell paragraph" that hits the
+# keep-together branch of GtkDocParagraph.divide.
+WRAP_TEXT = (
+    "Wstart is a long cell value that will wrap onto a second line for sure "
+    "yes indeed today"
+)
+# A value of four or more lines, so it is genuinely split (not kept together)
+# when it lands at a page boundary.
+TALL_TEXT = (
+    "Talpha bravo charlie delta echo foxtrot golf hotel india juliet kilo "
+    "lima mike november oscar papa quebec romeo sierra tango uniform victor "
+    "whiskey xray yankee zulu one two three four five six seven eight nine ten"
+)
+
+
+class CairoDocTablePaginationTest(unittest.TestCase):
+    """A wrapping table cell at a page boundary must not tear its row."""
+
+    def setUp(self):
+        # Headless Pango context backed by an in-memory image surface.
+        self._surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 4000, 4000)
+        self._cr = cairo.Context(self._surface)
+        self._context = PangoCairo.font_map_get_default().create_context()
+        self._layout = Pango.Layout(self._context)
+        PangoCairo.update_layout(self._cr, self._layout)
+
+        self._font = FontStyle()
+        self._font.set_type_face(FONT_SANS_SERIF)
+        self._font.set_size(FONT_SIZE)
+
+        self._para_style = ParagraphStyle()
+        self._para_style.set_font(self._font)
+        self._para_style.set_alignment(PARA_ALIGN_LEFT)
+
+    # -- builders ---------------------------------------------------------
+
+    def _cell(self, text):
+        """A cell holding one paragraph, or -- if ``text`` is a (w, h) tuple --
+        an unsplittable image of that size in cm."""
+        cell = GtkDocTableCell(TableCellStyle())
+        if isinstance(text, tuple):
+            width_cm, height_cm = text
+            cell.add_child(GtkDocPicture("left", "unused.png", width_cm, height_cm))
+        else:
+            paragraph = GtkDocParagraph(ParagraphStyle(self._para_style))
+            paragraph.add_text(text)
+            cell.add_child(paragraph)
+        return cell
+
+    def _row(self, texts):
+        """A row with one cell per item in ``texts`` (equal column widths)."""
+        widths = [100 // len(texts)] * len(texts)
+        row = GtkDocTableRow(widths)
+        for text in texts:
+            row.add_child(self._cell(text))
+        return row
+
+    def _table(self, rows):
+        columns = len(rows[0])
+        table_style = TableStyle()
+        table_style.set_width(100)
+        table_style.set_columns(columns)
+        for col in range(columns):
+            table_style.set_column_width(col, 100 // columns)
+        table = GtkDocTable(table_style)
+        for texts in rows:
+            table.add_child(self._row(texts))
+        return table
+
+    # -- production-path measurement -------------------------------------
+
+    def _row_height(self, texts):
+        """Full rendered height of a row, via the production ``divide``.
+
+        Dividing with a very large available height fully places the row and
+        returns its true height; this is the same code pagination uses, so the
+        page geometry below is derived from production, not re-implemented.
+        """
+        (r1, r2), height = self._row(texts).divide(
+            self._layout, PAGE_WIDTH, 100000.0, DPI, DPI
+        )
+        self.assertIsNotNone(r1)
+        self.assertIsNone(r2)
+        return height
+
+    def _line_count(self, text, columns=2):
+        """Number of wrapped lines of ``text`` at a cell's text width."""
+        cell_width = PAGE_WIDTH / columns  # table width is 100%; equal columns
+        layout = Pango.Layout(self._context)
+        PangoCairo.update_layout(self._cr, layout)
+        layout.set_width(int(cell_width * Pango.SCALE))
+        layout.set_wrap(Pango.WrapMode.WORD_CHAR)
+        layout.set_font_description(fontstyle_to_fontdescription(self._font))
+        layout.set_text(text, -1)
+        return layout.get_line_count()
+
+    # -- production paginator (bounded) ----------------------------------
+
+    def _paginate(self, table, page_height, max_iterations=200):
+        """Drive the production paginator step in a bounded loop.
+
+        ``CairoDoc.paginate_document`` is ``while not paginate(): pass`` -- an
+        unbounded driver.  We call the production ``CairoDoc.paginate`` step
+        ourselves with a hard iteration cap so a pagination that fails to make
+        progress is REPORTED (``completed`` stays False) instead of hanging the
+        suite forever.
+        """
+        document = GtkDocDocument()
+        document.add_child(table)
+
+        doc = CairoDoc.__new__(CairoDoc)
+        doc._doc = document
+        doc._pages = []
+        doc._elements_to_paginate = []
+
+        completed = False
+        for _ in range(max_iterations):
+            if doc.paginate(self._layout, PAGE_WIDTH, page_height, DPI, DPI):
+                completed = True
+                break
+        return completed, doc._pages
+
+    # -- analysis of the paginated output --------------------------------
+
+    def _page_texts(self, pages):
+        """Concatenated rendered ``_plaintext`` per page.
+
+        We read ``_plaintext`` (what ``divide`` actually places and truncates),
+        NOT ``_text`` (the untouched source), so a dropped or truncated cell is
+        genuinely detectable rather than tautologically present.
+        """
+        out = []
+        for page in pages:
+            words = []
+            for table in page._children:
+                if not isinstance(table, GtkDocTable):
+                    continue
+                for row in table._children:
+                    for cell in row._children:
+                        for child in cell._children:
+                            if isinstance(child, GtkDocParagraph):
+                                words.append(child._plaintext or "")
+            out.append(" ".join(words))
+        return out
+
+    def _image_pages(self, pages):
+        """Indices of pages that actually render an image cell."""
+        found = []
+        for index, page in enumerate(pages):
+            for table in page._children:
+                if not isinstance(table, GtkDocTable):
+                    continue
+                for row in table._children:
+                    for cell in row._children:
+                        if any(
+                            isinstance(child, GtkDocPicture) for child in cell._children
+                        ):
+                            found.append(index)
+        return found
+
+    def _first_page(self, pages, marker):
+        """Index of the first page whose rendered text contains ``marker``."""
+        for index, text in enumerate(self._page_texts(pages)):
+            if marker in text:
+                return index
+        return None
+
+    def _pages_containing(self, pages, marker):
+        return [
+            index
+            for index, text in enumerate(self._page_texts(pages))
+            if marker in text
+        ]
+
+    def _assert_no_dropped_words(self, pages, text):
+        rendered = " ".join(self._page_texts(pages))
+        for word in text.split():
+            self.assertIn(
+                word,
+                rendered,
+                "wrapping cell text was dropped from the paginated output "
+                "(bug 6324): the word %r is missing" % word,
+            )
+
+    # -- the tests --------------------------------------------------------
+
+    def test_wrapping_last_cell_moves_row_whole(self):
+        """Last-column wrapping cell at the page foot: the row moves whole.
+
+        Filler rows fill most of the page; the final ``[LABEL, WRAP]`` row lands
+        where the one-line LABEL cell fits but the wrapping cell does not.  The
+        whole row must move to the next page -- pre-fix the LABEL rendered alone
+        with a blank cell beside it while the WRAP text landed a page later
+        (Mantis 6324, the torn row).
+        """
+        # Sanity: WRAP_TEXT must be the "short (2-3 line) cell paragraph" case
+        # that takes the keep-together branch; a font substitution making it one
+        # line, or four+ lines, would not exercise the bug -- fail loudly.
+        self.assertGreaterEqual(self._line_count(WRAP_TEXT), 2)
+        self.assertLess(self._line_count(WRAP_TEXT), 4)
+
+        filler_h = self._row_height(["filler a", "filler b"])
+        wrap_h = self._row_height([LABEL_TEXT, WRAP_TEXT])
+        self.assertGreater(wrap_h, filler_h)  # the wrapping row is taller
+
+        # Page holds three filler rows plus an amount strictly between one line
+        # (the LABEL cell) and the full wrapping row: LABEL fits at the bottom,
+        # the wrapping cell cannot -- forcing the boundary case.
+        page_height = 3 * filler_h + (filler_h + wrap_h) / 2.0
+
+        table = self._table([["filler a", "filler b"]] * 3 + [[LABEL_TEXT, WRAP_TEXT]])
+        completed, pages = self._paginate(table, page_height)
+
+        self.assertTrue(completed, "pagination did not terminate (bug 6324)")
+        self.assertGreaterEqual(
+            len(pages),
+            2,
+            "geometry did not straddle a page boundary -- the test is not "
+            "exercising the wrapping-cell-at-page-bottom case",
+        )
+
+        # The row's two cells must begin on the same page: pre-fix the LABEL
+        # rendered a page before its wrapping rowmate (the torn row).
+        label_page = self._first_page(pages, LABEL_TEXT)
+        wrap_page = self._first_page(pages, "Wstart")
+        self.assertIsNotNone(label_page)
+        self.assertIsNotNone(wrap_page)
+        self.assertEqual(
+            wrap_page,
+            label_page,
+            "table row torn at the page boundary (bug 6324): the wrapping cell "
+            "begins on page %s but its rowmate LABEL is on page %s"
+            % (wrap_page, label_page),
+        )
+        self._assert_no_dropped_words(pages, WRAP_TEXT)
+
+    def test_wrapping_cell_splits_beside_split_sibling(self):
+        """Earlier column splits: the later short column must split too.
+
+        A ``[TALL, WRAP]`` row lands where the four+-line TALL cell splits across
+        the boundary but the short WRAP cell (kept-together) cannot fit.  The
+        WRAP cell must render its first lines beside TALL rather than blank --
+        pre-fix TALL split alone with a blank cell beside it (the same bug in the
+        multi-column / cell-split branch).
+        """
+        self.assertGreaterEqual(self._line_count(WRAP_TEXT), 2)
+        self.assertLess(self._line_count(WRAP_TEXT), 4)
+        self.assertGreaterEqual(self._line_count(TALL_TEXT), 4)  # genuinely split
+
+        filler_h = self._row_height(["filler a", "filler b"])
+        tall_h = self._row_height([TALL_TEXT, WRAP_TEXT])
+        line_h = (tall_h - filler_h) / (self._line_count(TALL_TEXT) - 1)
+
+        # One filler row plus about two text lines of room: TALL places two lines
+        # and splits, but the three-line WRAP cell cannot fit and would (pre-fix)
+        # be left blank beside it.
+        page_height = filler_h + 2 * line_h
+
+        table = self._table([["filler a", "filler b"], [TALL_TEXT, WRAP_TEXT]])
+        completed, pages = self._paginate(table, page_height)
+
+        self.assertTrue(completed, "pagination did not terminate (bug 6324)")
+        self.assertGreaterEqual(len(pages), 2)
+
+        # Precondition: the TALL cell must genuinely split (span >= 2 pages),
+        # otherwise this is not the cell-split branch.
+        self.assertGreaterEqual(len(self._pages_containing(pages, "Talpha")), 1)
+        self.assertGreaterEqual(len(self._pages_containing(pages, "zulu")), 1)
+        self.assertGreater(
+            self._first_page(pages, "zulu"),
+            self._first_page(pages, "Talpha"),
+            "the TALL cell did not split across a page boundary -- the test is "
+            "not exercising the cell-split branch",
+        )
+
+        # The wrapping cell must begin on the same page as the split TALL cell,
+        # not a page later beside a blank placeholder (bug 6324).
+        tall_page = self._first_page(pages, "Talpha")
+        wrap_page = self._first_page(pages, "Wstart")
+        self.assertIsNotNone(wrap_page)
+        self.assertEqual(
+            wrap_page,
+            tall_page,
+            "table row torn at the page boundary (bug 6324): the wrapping cell "
+            "begins on page %s but its splitting rowmate begins on page %s"
+            % (wrap_page, tall_page),
+        )
+        self._assert_no_dropped_words(pages, WRAP_TEXT)
+
+    def test_wrapping_cell_taller_than_page_terminates(self):
+        """No-progress guard: a cell that cannot fit even a full page must not
+
+        hang.  With a page barely one line tall, the short (kept-together) WRAP
+        cell cannot fit even on a fresh empty page.  Pre-guard the paginator's
+        unbounded ``while not paginate()`` loop re-queued the row onto empty page
+        after empty page forever; the fix must force the cell to split and always
+        terminate, still rendering every word.
+        """
+        self.assertGreaterEqual(self._line_count(WRAP_TEXT, columns=1), 2)
+
+        filler_h = self._row_height(["filler"])
+        wrap_h = self._row_height([WRAP_TEXT])
+        line_h = (wrap_h - filler_h) / (self._line_count(WRAP_TEXT, columns=1) - 1)
+
+        # A page about one and a half text lines tall: the multi-line WRAP cell
+        # cannot be kept together on any page, so keep-together makes no progress.
+        page_height = filler_h + 0.5 * line_h
+
+        table = self._table([[WRAP_TEXT]])
+        completed, pages = self._paginate(table, page_height)
+
+        self.assertTrue(
+            completed,
+            "pagination did not terminate for a cell taller than a page "
+            "(bug 6324: no-progress guard missing -- the paginator loops)",
+        )
+        self._assert_no_dropped_words(pages, WRAP_TEXT)
+
+    def test_image_cell_in_torn_row_moves_intact_not_overflowed(self):
+        """Unsplittable image beside a splitting text cell must not be clipped.
+
+        A ``[TALL, image]`` row lands where the four+-line TALL cell splits at
+        the boundary but the image does not fit the room left.  An image cannot
+        be split; the least-bad rendering is to move it **intact to the next
+        page** (blank beside TALL's first lines, full beside TALL's
+        continuation) -- NOT to force it into the too-small slot where it would
+        overflow/clip past the page edge.
+
+        This guards the ``force_split`` (split splittable content) vs
+        ``allow_overflow`` (place an unsplittable element accepting overflow --
+        only when a fresh page cannot hold it either) distinction: a merely-torn
+        row forces the split but must NOT set allow_overflow, so the image moves
+        rather than clips.  A naive single-flag fix that force-placed the image
+        here regressed exactly this case.
+        """
+        self.assertGreaterEqual(self._line_count(TALL_TEXT), 4)  # genuinely split
+
+        filler_h = self._row_height(["filler a", "filler b"])
+        tall_h = self._row_height([TALL_TEXT, "filler b"])
+        line_h = (tall_h - filler_h) / (self._line_count(TALL_TEXT) - 1)
+
+        # A 2 cm-tall image: larger than the ~2 lines of room left when TALL
+        # splits, but comfortably smaller than a full page.
+        image_cm = 2.0
+        image_pts = image_cm * DPI / 2.54
+
+        # Three filler rows plus ~2 text lines of room: TALL places two lines and
+        # splits, the image does not fit the ~2-line remainder, and a full page
+        # (3 fillers + 2 lines) easily holds the 2 cm image.
+        room = 2 * line_h
+        page_height = 3 * filler_h + room
+        self.assertGreater(
+            page_height,
+            image_pts + filler_h,
+            "geometry error: a full page must comfortably hold the image "
+            "(else this is the taller-than-page case, not the torn-row case)",
+        )
+        self.assertLess(
+            room,
+            image_pts,
+            "geometry error: the image must NOT fit the room left beside the "
+            "split TALL cell (else there is no tear to test)",
+        )
+
+        table = self._table(
+            [["filler a", "filler b"]] * 3 + [[TALL_TEXT, (4.0, image_cm)]]
+        )
+        completed, pages = self._paginate(table, page_height)
+
+        self.assertTrue(completed, "pagination did not terminate (bug 6324)")
+        self.assertGreaterEqual(len(pages), 2)
+
+        # The TALL cell splits: head on its first page, tail on the next.
+        tall_head_page = self._first_page(pages, "Talpha")
+        tall_tail_page = self._first_page(pages, "zulu")
+        self.assertIsNotNone(tall_head_page)
+        self.assertGreater(
+            tall_tail_page,
+            tall_head_page,
+            "the TALL cell did not split -- not exercising the torn-row case",
+        )
+
+        # The image must render on exactly one page, and that page must be the
+        # TALL *continuation* page (moved intact), never the cramped head page
+        # (where placing it would overflow the tiny slot).
+        image_pages = self._image_pages(pages)
+        self.assertEqual(
+            len(image_pages),
+            1,
+            "the image must render on exactly one page (intact), not be "
+            "duplicated or dropped -- got pages %s" % image_pages,
+        )
+        self.assertNotEqual(
+            image_pages[0],
+            tall_head_page,
+            "bug 6324 regression: the image was force-placed into the too-small "
+            "slot on the TALL cell's head page (page %s) where it overflows, "
+            "instead of moving intact to the continuation page" % tall_head_page,
+        )
+        self.assertEqual(
+            image_pages[0],
+            tall_tail_page,
+            "the image should render intact on the TALL continuation page "
+            "(page %s) beside its rowmate, but is on page %s"
+            % (tall_tail_page, image_pages[0]),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -672,6 +672,7 @@ gramps/plugins/sidebar/expandersidebar.py
 #
 # plugins/test directory
 #
+gramps/plugins/test/cairodoc_table_pagination_test.py
 gramps/plugins/test/db_undo_and_signals_test.py
 gramps/plugins/test/exports_test.py
 gramps/plugins/test/imports_test.py


### PR DESCRIPTION
## Summary
**User impact:** In PDF (and other cairo-drawn) reports, when a table row lands at the bottom of a page, one cell of that row can be torn away from its neighbours: it prints blank on the first page while its text jumps to the top of the next page, sitting alone beside blank copies of the row's other cells. The table looks broken and some cell text appears misplaced.

This makes a cell that shares a row with an already-split neighbour split too, so the row's cells start together instead of being dropped.

Reported in Mantis [#6324](https://gramps-project.org/bugs/view.php?id=6324).

## What to look at
The cairo backend has a "keep-together" rule that moves a short cell paragraph whole to the next page rather than splitting it — but when another cell in the same row has already placed content, that rule tears the row. The fix threads two optional flags through the divide chain so a later cell can be force-split beside a split sibling, and adds a paginator guard so pagination always advances. To try it: generate a report whose table has a wrapping cell at the foot of a page, output to PDF/cairo, and check the row's cells begin on the same page instead of one printing blank with its text orphaned overleaf.

## Root cause
In the cairo/PDF backend, `GtkDocParagraph.divide` (`maintenance/gramps61`, `libcairodoc.py:620–621`) implements a keep-together rule: if a cell's paragraph is short (fewer than 4 lines) and cannot fully fit in the space left on the page, move the whole paragraph to the next page instead of splitting it.

The problem occurs when an earlier cell in the same row has already placed content. The keep-together rule then moves the later cell whole to the next page while its rowmates stay behind, tearing the row: the cell renders blank on the first page (placeholder committed, content moved) and its text appears orphaned on the next page beside blank copies of the row's other cells.

## Fix
The divide chain now accepts two optional flags threaded through the entire chain (GtkDocParagraph, GtkDocTable, GtkDocTableRow, GtkDocTableCell, GtkDocPicture, GtkDocFrame):

1. **`force_split=True`**: Override the keep-together rule when the page is already full (another rowmate has split), so the cell's first lines render beside the sibling instead of being dropped.

2. **`allow_overflow=True`**: Paginator-only signal that even an empty page cannot hold the content, so place it accepting overflow rather than loop forever (for images taller than the page).

`GtkDocTableRow.divide` keeps the whole row together when the first cell that cannot fit has no committed sibling, and force-splits later cells so their first lines render beside a split sibling. `CairoDoc.paginate` adds a no-progress guard: if an element placed nothing on an already-empty page, it re-divides with both flags set to ensure pagination always advances.

## Verification
- **Claim:** A later cell force-splits beside a split sibling so the row's cells start together, images in a torn row move intact, and pagination always terminates.
- **Checked:** on `maintenance/gramps61` — `gramps/plugins/lib/libcairodoc.py:620–621` (GtkDocParagraph.divide keep-together rule — now checks `force_split`); `:843–939` (GtkDocTable.divide row continuation — passes force/overflow flags only to first row); `:976–1046` (GtkDocTableRow.divide — tracks cell splits and force-splits later cells); `:1091–1130` (GtkDocTableCell.divide — returns cell whole only when not forced); `:1245–1287` (GtkDocPicture.divide — respects `allow_overflow` only); `:1310–1320` (GtkDocFrame.divide — respects `allow_overflow` only); `:1796–1820` (CairoDoc.paginate — no-progress guard with bounded re-divide). Test file registered in `po/POTFILES.skip:675` to exclude from translation.
- **Test:** New test `gramps/plugins/test/cairodoc_table_pagination_test.py` exercises the production pagination chain against realistic geometries with a bounded loop, and all assertions read `_plaintext` (what divide places/truncates), not `_text`, so dropped/truncated cells are genuinely detectable:
  1. `test_wrapping_last_cell_moves_row_whole` (lines 640–688): last-column wrapping cell at page foot — RED pre-fix (cells on different pages, torn row), GREEN post-fix (cells begin together).
  2. `test_wrapping_cell_splits_beside_split_sibling` (lines 690–741): earlier column splits, later short column must split too — RED pre-fix (later cell blank beside split sibling), GREEN post-fix (both split together).
  3. `test_wrapping_cell_taller_than_page_terminates` (lines 743–770): cell cannot fit on any page — RED pre-fix (unbounded loop never terminates), GREEN post-fix (completes, all words rendered).
  4. `test_image_cell_in_torn_row_moves_intact_not_overflowed` (lines 772–859): image in torn row must move to next page intact — RED pre-fix (image clipped on head page), GREEN post-fix (image on continuation page, intact).

  Full core unit suite (32,977 tests) runs with zero new regressions. Run: `python3 -m unittest gramps.plugins.test.cairodoc_table_pagination_test -v`

Fixes [#6324](https://gramps-project.org/bugs/view.php?id=6324)
