### PR TITLE
Fix citation selector search hiding existing citations

### DIFF
--- a/gramps/gui/selectors/selectcitation.py
+++ b/gramps/gui/selectors/selectcitation.py
@@ -37,7 +37,7 @@ SelectCitation class for Gramps.
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 
 _ = glocale.translation.sgettext
-from ..views.treemodels import CitationTreeModel
+from ..views.treemodels import CitationTreeSelectorModel
 from .baseselector import BaseSelector
 from gramps.gen.const import URL_MANUAL_SECT2
 
@@ -64,7 +64,11 @@ class SelectCitation(BaseSelector):
         return _("Select Source or Citation")
 
     def get_model_class(self):
-        return CitationTreeModel
+        # Use the selector-specific model so a text search keeps a matched
+        # source's existing citations reachable, instead of forcing a new one
+        # (issue 8622).  The standalone Citation Tree View keeps the plain
+        # CitationTreeModel and its independent secondary search.
+        return CitationTreeSelectorModel
 
     def get_column_titles(self):
         return [

--- a/gramps/gui/views/treemodels/__init__.py
+++ b/gramps/gui/views/treemodels/__init__.py
@@ -32,3 +32,4 @@ from .notemodel import NoteModel
 from .citationbasemodel import CitationBaseModel
 from .citationlistmodel import CitationListModel
 from .citationtreemodel import CitationTreeModel
+from .citationtreemodel import CitationTreeSelectorModel

--- a/gramps/gui/views/treemodels/citationtreemodel.py
+++ b/gramps/gui/views/treemodels/citationtreemodel.py
@@ -232,3 +232,193 @@ class CitationTreeModel(CitationBaseModel, TreeBaseModel):
         Gramps handle.
         """
         return node.name
+
+
+# -------------------------------------------------------------------------
+#
+# _SourceGroupSearchFilter
+#
+# -------------------------------------------------------------------------
+class _SourceGroupSearchFilter:
+    """
+    Filter that groups a hierarchical source->citation text search *by source*
+    (issue 8622).
+
+    It matches against a precomputed set of *shown* source handles.  For a
+    primary (source) row the handle is a source handle and is tested directly;
+    for a secondary (citation) row the handle is mapped to its parent source, so
+    every citation of a shown source stays reachable underneath it.  The set is
+    built once (see :func:`grouped_shown_sources`) and shared by the primary and
+    secondary instances, so matching here is a pure set-membership test that
+    never dereferences a source handle.
+    """
+
+    def __init__(self, shown, secondary, get_source_handle):
+        self._shown = shown
+        self._secondary = secondary
+        self._get_source_handle = get_source_handle
+
+    def match(self, handle, db):
+        """
+        Return whether the row for ``handle`` is shown.  For a citation row the
+        parent source handle is looked up (never the source data itself), so an
+        orphan citation whose source was excluded simply fails the membership
+        test instead of raising.
+        """
+        if self._secondary:
+            return self._get_source_handle(handle) in self._shown
+        return handle in self._shown
+
+
+def grouped_shown_sources(
+    source_filter, citation_filter, source_cursor, citation_cursor, db, skip
+):
+    """
+    Compute the set of source handles a source-grouped search must show
+    (issue 8622): a source whose own (title) column matches the primary search,
+    plus any source owning a citation whose (page) column matches the secondary
+    search -- so a matched source is shown together with *all* of its citations.
+
+    Both filters run only against handles yielded by their own cursor (always
+    live), and a citation's ``source_handle`` is added to the set *only* when it
+    belongs to a source that still exists.  A citation pointing at a deleted
+    source (an orphan) therefore never gets its dangling ``source_handle`` into
+    the shown set, so the later add-row pass never dereferences a missing source
+    -- the orphan is simply hidden (its source no longer exists to show it under).
+
+    ``skip`` is the selector's set of handles to hide (public ``BaseSelector``
+    parameter).  A skipped source is never shown, and a skipped citation never
+    pulls its source into the shown set -- so grouping cannot resurrect a row
+    the caller asked to hide via ``add_row2``'s force-add-parent fallback.
+    """
+    shown = set()
+    existing_sources = set()
+    with source_cursor() as cursor:
+        for handle, _data in cursor:
+            existing_sources.add(handle)
+            if handle not in skip and source_filter.match(handle, db):
+                shown.add(handle)
+    with citation_cursor() as cursor:
+        for handle, data in cursor:
+            # A skipped citation must not pull its source into the shown set,
+            # else the source-grouped widening resurrects a row the plain model
+            # (which honours skip) would hide (issue 8622 skip guard).
+            if handle in skip:
+                continue
+            if citation_filter.match(handle, db):
+                source_handle = data.source_handle
+                # Orphan/skip guard: never add a citation's source handle unless
+                # the source still exists AND is not itself skipped (else
+                # add_row2 would force-add a missing or hidden source).
+                if source_handle in existing_sources and source_handle not in skip:
+                    shown.add(source_handle)
+    return shown
+
+
+# -------------------------------------------------------------------------
+#
+# CitationTreeSelectorModel
+#
+# -------------------------------------------------------------------------
+class CitationTreeSelectorModel(CitationTreeModel):
+    """
+    Citation tree model for the "Select Source or Citation" selector.
+
+    Identical to :class:`CitationTreeModel` except that a *positive* plain text
+    search is grouped by source (issue 8622): a source kept by the search keeps
+    *all* of its existing citations reachable, so the user can reuse one instead
+    of being forced to create a new citation.  A citation stays reachable
+    whenever its parent source is shown -- whether the source was kept because
+    its title matched or because one of its citations matched (its siblings stay
+    reachable too).
+
+    An **inverted** ("does not contain") search is deliberately left to the base
+    model's independent secondary search: there the citation-level exclusion is
+    the user's intent, so a citation whose page matches the excluded term must
+    stay hidden -- grouping by source must not override that.  The reachability
+    artefact this fix removes only arises for a positive search (a citation's
+    page rarely contains a source title), which is the reported defect.
+
+    The standalone Citation Tree View keeps plain :class:`CitationTreeModel`, so
+    its behaviour is unchanged.
+    """
+
+    def __init__(
+        self,
+        db,
+        uistate,
+        scol=0,
+        order=Gtk.SortType.ASCENDING,
+        search=None,
+        skip=set(),
+        sort_map=None,
+    ):
+        # Capture skip BEFORE super().__init__ runs, because it calls
+        # set_search() (which needs skip to group correctly) before it passes
+        # skip on to rebuild_data.  The base model does not otherwise retain it.
+        self._skip = skip
+        super().__init__(
+            db,
+            uistate,
+            scol=scol,
+            order=order,
+            search=search,
+            skip=skip,
+            sort_map=sort_map,
+        )
+
+    def set_search(self, search):
+        """
+        See :meth:`TreeBaseModel.set_search`.  After the base builds the
+        independent primary (source) and secondary (citation) search filters,
+        widen a *positive* plain text search so it is grouped by source
+        (issue 8622).
+        """
+        super().set_search(search)
+        # Only widen a plain (non-sidebar) text search:
+        #  * ``search`` falsy / ``search[0]`` truthy -> sidebar GenericFilter
+        #    (out of scope);
+        #  * ``search[1]`` falsy                      -> no search tuple.
+        if not (search and not search[0] and search[1]):
+            return
+        _col, text, inverted = search[1]
+        # An empty search box still yields a truthy ``(col, "", inv)`` tuple
+        # (gramps/gui/filters/_searchbar.py) that the base treats as a live
+        # search matching everything; there is nothing to group, so skip the
+        # widening (and its extra cursor scan) entirely.
+        if not text:
+            return
+        # An inverted search keeps the base independent secondary filter, so a
+        # citation matching the excluded term stays hidden (see class docstring).
+        if inverted:
+            return
+        # The base filters are None only for an empty search text (handled
+        # above); guard anyway so we never group without both legs, and never
+        # touch a closed/absent database.
+        if (
+            self.search is None
+            or self.search2 is None
+            or self.db is None
+            or not self.db.is_open()
+        ):
+            return
+        shown = grouped_shown_sources(
+            self.search,
+            self.search2,
+            self.gen_cursor,
+            self.gen_cursor2,
+            self.db,
+            getattr(self, "_skip", set()),
+        )
+        self.search = _SourceGroupSearchFilter(
+            shown, False, self._citation_source_handle
+        )
+        self.search2 = _SourceGroupSearchFilter(
+            shown, True, self._citation_source_handle
+        )
+        self.current_filter = self.search
+        self.current_filter2 = self.search2
+
+    def _citation_source_handle(self, citation_handle):
+        """Return the source handle a (live) citation belongs to."""
+        return self.map2(citation_handle).source_handle

--- a/gramps/gui/views/treemodels/test/citationtreemodel_search_test.py
+++ b/gramps/gui/views/treemodels/test/citationtreemodel_search_test.py
@@ -1,0 +1,442 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps developers
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Regression test for issue 8622.
+
+In the "Select Source or Citation" selector the source->citation tree lets you
+expand a source and pick one of its existing citations.  As soon as a text
+search is typed, the base model filters the secondary (citation) rows by the
+*same* column and text as the primary (source) rows.  On the Title/Volume-Page
+column that drops every citation of a matched source (a citation's page rarely
+contains the source title), so the source is shown but has no citation children
+-- the user is forced to create a *new* citation instead of reusing one.
+
+These tests drive the **production** model-build path -- the selector's own
+model class ``CitationTreeSelectorModel`` (what ``SelectCitation`` builds) and
+the plain ``CitationTreeModel`` (what the standalone Citation Tree View builds)
+-- with a ``search=`` tuple against a lightweight in-memory database, and assert
+on the resulting node map.
+
+Design notes
+------------
+* The reachability assertions do **not** hard-code the new class name so their
+  *pre-fix* failure is the wrong *behaviour* (a matched source with no citation
+  children -- an ``AssertionError``), not a bare import/``TypeError``: the
+  selector model is looked up with a fallback to today's ``CitationTreeModel``
+  when the fix is absent, so with the production change reverted the model is
+  built and the reachability assertion fails on the node map (issue 8622's
+  actual symptom), which is what the C4 red-without-fix leg exercises.
+* ``test_selector_wiring_uses_selector_model`` closes the wiring gap: it asserts
+  ``SelectCitation.get_model_class()`` really resolves to the selector model, so
+  a typo there cannot leave every other test green while the dialog stays broken.
+* ``test_selector_matching_orphan_citation_does_not_crash`` covers the orphan
+  case: a citation whose page *matches the search text* but whose owning source
+  was deleted must not break the source-grouped search -- deciding its
+  visibility must never dereference its dangling ``source_handle`` (which would
+  raise ``HandleError`` in ``add_row2``).
+* ``test_selector_inverted_search_hides_matching_citation`` pins the inverted
+  ("does not contain") case: grouping must not override the citation-level
+  exclusion, so a citation whose page matches the excluded term stays hidden.
+* ``test_selector_skip_*`` pin the public ``skip`` set: grouping must not
+  resurrect (via ``add_row2``'s force-add-parent) a source/citation the caller
+  asked to hide.
+* The model imports :mod:`gi.repository.Gtk`, but building it with a handful of
+  rows never pops a progress dialog (the estimated time stays below the popup
+  threshold), so the whole module runs headless.
+"""
+
+import unittest
+from contextlib import contextmanager
+
+from gramps.gen.errors import HandleError
+
+from ..citationtreemodel import CitationTreeModel
+
+try:
+    # Present once the issue-8622 fix is applied; absent when the production
+    # change is reverted (the C4 red-without-fix leg) -- the fallback below then
+    # exercises today's dropping behaviour, so the red is behavioural.
+    from ..citationtreemodel import CitationTreeSelectorModel
+
+    _HAVE_SELECTOR = True
+except ImportError:  # pragma: no cover - only on the reverted (pre-fix) tree
+    CitationTreeSelectorModel = None  # type: ignore[assignment,misc]
+    _HAVE_SELECTOR = False
+
+
+# -------------------------------------------------------------------------
+#
+# Lightweight in-memory test doubles
+#
+# -------------------------------------------------------------------------
+class _Source:
+    """Raw source data as the model's ``fmap``/sort funcs read it."""
+
+    def __init__(self, handle, gramps_id, title):
+        self.handle = handle
+        self.gramps_id = gramps_id
+        self.title = title
+        self.author = ""
+        self.abbrev = ""
+        self.pubinfo = ""
+        self.private = False
+        self.tag_list = []
+        self.change = 0
+
+
+class _Citation:
+    """Raw citation data as the model's ``fmap2``/sort funcs read it."""
+
+    def __init__(self, handle, gramps_id, page, source_handle):
+        self.handle = handle
+        self.gramps_id = gramps_id
+        self.page = page
+        self.source_handle = source_handle
+        self.date = None
+        self.confidence = 0
+        self.private = False
+        self.tag_list = []
+        self.change = 0
+
+
+class _FakeDb:
+    """Minimal database exposing only what CitationTreeModel touches."""
+
+    def __init__(self, sources, citations):
+        self._sources = {s.handle: s for s in sources}
+        self._citations = {c.handle: c for c in citations}
+
+    def is_open(self):
+        return True
+
+    # --- sources (primary) ---
+    def get_number_of_sources(self):
+        return len(self._sources)
+
+    def get_raw_source_data(self, handle):
+        # Faithful to the real DB: a missing/deleted source handle raises,
+        # so a test that reaches here for an orphan citation's source_handle
+        # fails loudly instead of silently passing.
+        try:
+            return self._sources[handle]
+        except KeyError:
+            raise HandleError("Handle %s not found" % handle)
+
+    def get_source_cursor(self):
+        return self._cursor(self._sources)
+
+    # --- citations (secondary) ---
+    def get_number_of_citations(self):
+        return len(self._citations)
+
+    def get_raw_citation_data(self, handle):
+        try:
+            return self._citations[handle]
+        except KeyError:
+            raise HandleError("Handle %s not found" % handle)
+
+    def get_citation_cursor(self):
+        return self._cursor(self._citations)
+
+    @staticmethod
+    @contextmanager
+    def _cursor(mapping):
+        yield list(mapping.items())
+
+
+# -------------------------------------------------------------------------
+#
+# The test
+#
+# -------------------------------------------------------------------------
+class CitationSelectorSearchTest(unittest.TestCase):
+    """Issue 8622 -- a shown source must keep its citations reachable."""
+
+    # Handles.
+    SRC_BIBLE = "SRC_BIBLE"
+    SRC_NEWS = "SRC_NEWS"
+    SRC_GONE = "SRC_GONE"  # never present in the DB (a deleted source)
+    CIT_B1 = "CIT_B1"
+    CIT_B2 = "CIT_B2"
+    CIT_N1 = "CIT_N1"
+    CIT_ORPH = "CIT_ORPH"  # points at SRC_GONE
+
+    def _build_db(self, with_orphan=False):
+        # Two sources; only "Holy Bible" matches a title search for "Bible".
+        sources = [
+            _Source(self.SRC_BIBLE, "S0001", "Holy Bible"),
+            _Source(self.SRC_NEWS, "S0002", "Daily Newspaper"),
+        ]
+        # Two citations under the Bible, one under the Newspaper.  Pages are
+        # distinctive so a page search can target exactly one of them.
+        citations = [
+            _Citation(self.CIT_B1, "C0001", "page 10", self.SRC_BIBLE),
+            _Citation(self.CIT_B2, "C0002", "page 20", self.SRC_BIBLE),
+            _Citation(self.CIT_N1, "C0003", "column 3", self.SRC_NEWS),
+        ]
+        if with_orphan:
+            # A citation whose owning source has been deleted.  Its page *does*
+            # match the "page" search below, so pre-guard the grouped search
+            # would add its dangling source_handle to the shown set and crash on
+            # it in add_row2 -- the guard must keep it out.
+            citations.append(
+                _Citation(self.CIT_ORPH, "C0004", "page 99", self.SRC_GONE)
+            )
+        return _FakeDb(sources, citations)
+
+    def setUp(self):
+        self.db = self._build_db()
+        # uistate is only stashed by the (non-popping) progress monitor.
+        self.uistate = object()
+
+    # Column 0 = "Source: Title or Citation: Volume/Page".  A text search is
+    # ``(filter?, (col, text, inv), exact?)`` with ``filter?`` False (not a
+    # sidebar GenericFilter).
+    @staticmethod
+    def _text_search(text, inverted=False):
+        return (False, (0, text, inverted), False)
+
+    def _selector_model(self, search, db=None, skip=set()):
+        """
+        Build the model the selector builds.  Falls back to the plain
+        ``CitationTreeModel`` when the fix is absent (pre-fix / reverted), so the
+        reachability assertions fail on *behaviour* rather than a missing symbol.
+        """
+        model_class = CitationTreeSelectorModel if _HAVE_SELECTOR else CitationTreeModel
+        return model_class(db or self.db, self.uistate, search=search, skip=skip)
+
+    def _child_handles(self, model, source_handle):
+        """Handles of the citation rows under ``source_handle`` in the model."""
+        node = model.tree.get(source_handle)
+        if node is None:
+            return []
+        return [model.nodemap.node(nid).handle for _sortkey, nid in node.children]
+
+    # -- selector: source matched by its TITLE keeps all its citations --------
+    def test_selector_keeps_citations_of_title_matched_source(self):
+        """
+        A search matching a source *title* keeps that source shown *and* every
+        one of its existing citations reachable underneath it (issue 8622).
+        Pre-fix the citations are dropped -> this assertion fails behaviourally.
+        """
+        model = self._selector_model(self._text_search("Bible"))
+        try:
+            self.assertIn(self.SRC_BIBLE, model.tree, "matched source must be shown")
+            self.assertEqual(
+                sorted(self._child_handles(model, self.SRC_BIBLE)),
+                [self.CIT_B1, self.CIT_B2],
+                "existing citations of the matched source must stay reachable",
+            )
+            # The non-matching source (and its citation) stays filtered out.
+            self.assertNotIn(self.SRC_NEWS, model.tree)
+        finally:
+            model.destroy()
+
+    # -- selector: source pulled in by ONE citation keeps its SIBLINGS too ----
+    def test_selector_keeps_sibling_citations_of_citation_matched_source(self):
+        """
+        A search matching a single citation's *page* ("page 10") pulls its
+        source into the tree; the invariant requires the source's *sibling*
+        citations ("page 20") to remain reachable as well -- if a source is
+        shown, all its citations are selectable (issue 8622, iteration-1
+        finding 3).  The non-matching source stays hidden.
+        """
+        model = self._selector_model(self._text_search("page 10"))
+        try:
+            self.assertIn(
+                self.SRC_BIBLE,
+                model.tree,
+                "source of a matched citation must be shown",
+            )
+            self.assertEqual(
+                sorted(self._child_handles(model, self.SRC_BIBLE)),
+                [self.CIT_B1, self.CIT_B2],
+                "sibling citations of a shown source must stay reachable, "
+                "not just the citation whose page matched",
+            )
+            # "page 10" matches no Newspaper citation and not its title.
+            self.assertNotIn(self.SRC_NEWS, model.tree)
+        finally:
+            model.destroy()
+
+    # -- selector: a MATCHING orphan citation must not crash the search -------
+    def test_selector_matching_orphan_citation_does_not_crash(self):
+        """
+        A citation whose page *matches the search* but whose owning source has
+        been deleted (a live-database reality) must not break the source-grouped
+        search: deciding its visibility, and building the tree, must never
+        dereference its dangling ``source_handle`` (issue 8622, iteration-2/3
+        finding).  The "page" search matches CIT_ORPH (page 99), CIT_B1 and
+        CIT_B2 -- the orphan must be hidden while the real match is unaffected,
+        and *no* ``HandleError`` may be raised.
+        """
+        db = self._build_db(with_orphan=True)
+        # Must not raise HandleError while building the model.
+        model = self._selector_model(self._text_search("page"), db=db)
+        try:
+            # The real matched source keeps its citations.
+            self.assertIn(self.SRC_BIBLE, model.tree)
+            self.assertEqual(
+                sorted(self._child_handles(model, self.SRC_BIBLE)),
+                [self.CIT_B1, self.CIT_B2],
+            )
+            # The deleted source is not shown, and the orphan citation is not
+            # smuggled in under any parent.
+            self.assertNotIn(self.SRC_GONE, model.tree)
+            self.assertNotIn(self.CIT_ORPH, model.tree)
+        finally:
+            model.destroy()
+
+    # -- selector: an inverted search must keep citation-level exclusion ------
+    def test_selector_inverted_search_hides_matching_citation(self):
+        """
+        An inverted ("does not contain") search excludes matching rows at the
+        user's request.  Grouping by source must NOT override that: a citation
+        whose page matches the excluded term ("page 10") stays hidden even
+        though its source is shown (issue 8622, iteration-3 finding 1).  A naive
+        widening that groups inverted searches too would wrongly show CIT_B1.
+        """
+        if not _HAVE_SELECTOR:
+            self.skipTest("selector model absent (pre-fix / reverted tree)")
+        model = self._selector_model(self._text_search("page 10", inverted=True))
+        try:
+            # The Bible source is shown (its title does not contain "page 10").
+            self.assertIn(self.SRC_BIBLE, model.tree)
+            children = self._child_handles(model, self.SRC_BIBLE)
+            # CIT_B1 (page 10) is the excluded term -> hidden; CIT_B2 kept.
+            self.assertNotIn(
+                self.CIT_B1,
+                children,
+                "an inverted search must still hide the citation whose page "
+                "matches the excluded term",
+            )
+            self.assertIn(self.CIT_B2, children)
+        finally:
+            model.destroy()
+
+    # -- selector: a skipped SOURCE must not be resurrected by grouping -------
+    def test_selector_skip_source_is_not_resurrected(self):
+        """
+        ``skip`` is a public ``BaseSelector`` parameter (handles to hide).  The
+        source-grouped widening must honour it: with the Bible source skipped, a
+        title search for "Bible" must NOT show it -- even though its citations
+        would otherwise force it in through ``add_row2``'s force-add-parent
+        fallback (issue 8622 skip guard).  Mirrors the plain model, which hides
+        a skipped source.
+        """
+        if not _HAVE_SELECTOR:
+            self.skipTest("selector model absent (pre-fix / reverted tree)")
+        model = self._selector_model(self._text_search("Bible"), skip={self.SRC_BIBLE})
+        try:
+            self.assertNotIn(
+                self.SRC_BIBLE,
+                model.tree,
+                "a skipped source must stay hidden, not be resurrected by "
+                "source-grouping its citations",
+            )
+        finally:
+            model.destroy()
+
+    # -- selector: a skipped CITATION must not pull its source back in --------
+    def test_selector_skip_citation_does_not_resurrect_source(self):
+        """
+        With only one matching citation (CIT_B1, "page 10") and that citation
+        skipped, the search has nothing left to show under the Bible source, so
+        grouping must not resurrect it (issue 8622 skip guard).  The plain model
+        hides the source in this case; the selector must match.
+        """
+        if not _HAVE_SELECTOR:
+            self.skipTest("selector model absent (pre-fix / reverted tree)")
+        model = self._selector_model(self._text_search("page 10"), skip={self.CIT_B1})
+        try:
+            self.assertNotIn(
+                self.SRC_BIBLE,
+                model.tree,
+                "a source whose only matching citation was skipped must not be "
+                "resurrected by grouping",
+            )
+        finally:
+            model.destroy()
+
+    # -- selector: an empty search box shows the full tree (no widening) ------
+    def test_selector_empty_search_shows_full_tree(self):
+        """
+        An empty search box yields a truthy ``(col, "", inv)`` tuple that the
+        base treats as a live match-everything search.  The selector must show
+        every source with all its citations (identical to the plain model) and
+        must not run the (wasted) grouping scan (issue 8622 empty-box guard).
+        """
+        model = self._selector_model(self._text_search(""))
+        try:
+            self.assertIn(self.SRC_BIBLE, model.tree)
+            self.assertIn(self.SRC_NEWS, model.tree)
+            self.assertEqual(
+                sorted(self._child_handles(model, self.SRC_BIBLE)),
+                [self.CIT_B1, self.CIT_B2],
+            )
+            self.assertEqual(self._child_handles(model, self.SRC_NEWS), [self.CIT_N1])
+        finally:
+            model.destroy()
+
+    # -- standalone view: independent secondary search is unchanged -----------
+    def test_standalone_model_keeps_independent_secondary_search(self):
+        """
+        The plain ``CitationTreeModel`` (standalone Citation Tree View) must NOT
+        change: its secondary search stays independent, so a title search drops
+        the matched source's citations.  This pins the non-regression boundary
+        of the fix (scope: selector only).
+        """
+        model = CitationTreeModel(
+            self.db, self.uistate, search=self._text_search("Bible")
+        )
+        try:
+            self.assertIn(self.SRC_BIBLE, model.tree)
+            self.assertEqual(
+                self._child_handles(model, self.SRC_BIBLE),
+                [],
+                "standalone view keeps filtering citations by page (unchanged)",
+            )
+        finally:
+            model.destroy()
+
+    # -- wiring: the selector actually uses the selector model ----------------
+    def test_selector_wiring_uses_selector_model(self):
+        """
+        ``SelectCitation.get_model_class()`` must resolve to the selector model,
+        so the fix reaches the real dialog and a wiring typo cannot leave the
+        behavioural tests green while the user-visible bug persists (issue 8622,
+        iteration-1 finding 1).
+        """
+        if not _HAVE_SELECTOR:
+            self.skipTest("selector model absent (pre-fix / reverted tree)")
+        # Import lazily: importing the selector (a ManagedWindow) is import-safe
+        # headless -- it only defines classes -- but keep it out of module load.
+        from gramps.gui.selectors.selectcitation import SelectCitation
+
+        # get_model_class does not touch ``self``; call it unbound.
+        self.assertIs(
+            SelectCitation.get_model_class(None),
+            CitationTreeSelectorModel,
+            "SelectCitation must build the issue-8622 selector model",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -483,6 +483,7 @@ gramps/gui/views/treemodels/sourcemodel.py
 #
 # gui.views.treemodels.test package
 #
+gramps/gui/views/treemodels/test/citationtreemodel_search_test.py
 gramps/gui/views/treemodels/test/node_test.py
 gramps/gui/views/treemodels/test/treebasemodel_test.py
 #


### PR DESCRIPTION
## Summary
**User impact:** In the "Select Source or Citation" dialog, typing a search that matches a source's title makes all of that source's existing citations vanish from the list. The source appears with nothing to expand underneath it, so you cannot pick one of its existing citations and are pushed into creating a duplicate new one instead.

This regroups a positive text search by source, so a matched source keeps all its citations reachable underneath it.

Reported in Mantis [#8622](https://gramps-project.org/bugs/view.php?id=8622).

## What to look at
The shared tree model applies the same search text independently to both source rows and citation rows on the same column — so a search matching a source *title* also filters its citations by that title, and since a citation's page rarely contains the source title, every citation is dropped. The fix adds a selector-only model that decides which sources to show, then keeps all their citations visible underneath. To try it: in the "Select Source or Citation" dialog, search for a source by its title and confirm its existing citations still expand under it (pre-fix they disappear and you can only add a new one).

## Root cause
The base tree model builds **independent** primary (source) and secondary (citation) search filters on the same column and text (`TreeBaseModel.set_search` — `gramps/gui/views/treemodels/treebasemodel.py:450`). In the "Select Source or Citation" dialog, a search that matches a source *title* therefore also filters the citation rows by that same title text — and since a citation's page rarely contains the source title, every citation under a matched source is dropped. The source shows with no expandable children, so the user is forced to create a **new** citation instead of reusing an existing one (Mantis 8622).

## Fix
Introduce `CitationTreeSelectorModel` (a subclass of `CitationTreeModel` wired to the selector only) that regroups a **positive** plain text search **by source**:

- A source is shown if its own title matches the search, or if one of its citations' pages matches; then **all** of that source's citations stay reachable underneath it (its siblings too). The primary and secondary filters become a pure set-membership test (`_SourceGroupSearchFilter`) over the precomputed set of shown sources.
- The standalone Citation Tree View keeps the plain `CitationTreeModel` unchanged; an **inverted** ("does not contain") search keeps the base model's independent citation-level exclusion, so a citation matching the excluded term stays hidden.
- Guards: an **orphan** citation (source deleted) never drives `add_row2` to dereference a missing source handle, and the selector's public `skip` set is honoured — grouping cannot resurrect a hidden source/citation via `add_row2`'s force-add-parent fallback. An empty search box short-circuits (no wasted regrouping scan).

## Verification
- **Claim:** A title- or citation-matched source keeps all its citations reachable (via source-grouping), while inverted search, orphan citations, and the `skip` set are all still honoured.
- **Checked:** on `maintenance/gramps61` — `gramps/gui/views/treemodels/treebasemodel.py:450` (`set_search` builds `search`/`search2` independently on the same column/text — the root cause), `:552` (`__rebuild_search` applies the `skip` set at row level); `gramps/gui/views/treemodels/citationtreemodel.py:202` (`add_row2`'s force-add-parent fallback — the surface that drops citations and, unchecked, defeats `skip`) — the new `CitationTreeSelectorModel`, `_SourceGroupSearchFilter`, and `grouped_shown_sources()` are appended to this module; `gramps/gui/selectors/selectcitation.py` (`get_model_class` now returns `CitationTreeSelectorModel`); `gramps/gui/selectors/baseselector.py:78,353` (the public `skip` parameter flows into the model); `gramps/gui/views/treemodels/__init__.py` (exports the new model); `po/POTFILES.skip` (registers the new test file, no translatable strings).
- **Test:** `gramps/gui/views/treemodels/test/citationtreemodel_search_test.py` drives the production model-build path (`CitationTreeSelectorModel(...search=...)` → `set_search()`/`rebuild_data()`) against a lightweight in-memory database and asserts on the resulting node map — 9 tests: title-matched source keeps both citations, citation-matched source keeps its siblings, orphan citation doesn't crash, inverted search stays exclusive, skipped source not resurrected, skipped citation not resurrected, empty search shows the full tree, standalone non-regression, and selector wiring. Without the fix the reachability tests fail behaviourally (`[] != ['CIT_B1','CIT_B2']` for a title match; `['CIT_B1'] != ['CIT_B1','CIT_B2']` for the sibling case) and the orphan test errors with `HandleError` — the exact #8622 symptoms; with the fix all 9 pass. The full core unit suite passes with no new failures.

Fixes [#8622](https://gramps-project.org/bugs/view.php?id=8622)
