### PR TITLE
Allow filters to be cancelled

### DIFF
--- a/gramps/cli/test/user_test.py
+++ b/gramps/cli/test/user_test.py
@@ -128,6 +128,24 @@ class TestUser_prompt(unittest.TestCase):
         self.user._input.assert_called_once_with()
 
 
+class TestUser_get_cancelled(unittest.TestCase):
+    def setUp(self):
+        self.user = user.User()
+        self.user._fileout = Mock(spec=sys.stderr)
+
+    def test_default_is_not_cancelled(self):
+        self.assertFalse(self.user.get_cancelled())
+
+    def test_never_cancelled_even_with_can_cancel(self):
+        # The CLI has no way to interactively cancel, so get_cancelled()
+        # must always report False, even when can_cancel=True is passed.
+        self.user.begin_progress("Foo", "Bar", 10, can_cancel=True)
+        for i in range(10):
+            self.user.step_progress()
+            self.assertFalse(self.user.get_cancelled())
+        self.user.end_progress()
+
+
 class TestUser_quiet(unittest.TestCase):
     def setUp(self):
         self.user = user.User(quiet=True)

--- a/gramps/cli/user.py
+++ b/gramps/cli/user.py
@@ -82,7 +82,9 @@ class User(user.UserBase):
                 self._default_callback
             ) = yes
 
-    def begin_progress(self, title, message, steps):
+    def begin_progress(
+        self, title, message, steps, can_cancel=False, cancel_callback=None
+    ):
         """
         Start showing a progress indicator to the user.
 
@@ -100,6 +102,9 @@ class User(user.UserBase):
         self.current_step = 0
         self.display_progress()
         self._fileout.write(message)
+
+    def get_cancelled(self):
+        return False
 
     def step_progress(self):
         """

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -49,6 +49,7 @@ from ..lib.media import Media
 from ..lib.note import Note
 from ..lib.tag import Tag
 from ..const import GRAMPS_LOCALE as glocale
+from ..user import User
 from .rules import Rule
 from .optimizer import Optimizer
 
@@ -97,8 +98,9 @@ class GenericFilter:
         Return True or False depending on whether the handle matches the filter.
         """
         obj = self.get_object(db, handle)
+        user = User()
         for rule in self.flist:
-            rule.requestprepare(db, user=None)
+            rule.requestprepare(db, user)
 
         results = self.apply_to_one(db, obj)
 
@@ -171,7 +173,7 @@ class GenericFilter:
         db,
         possible_handles: Set[PrimaryObjectHandle],
         apply_logical_op,
-        user=None,
+        user: User,
     ):
         LOG.debug(
             "Starting possible_handles: %s",
@@ -187,8 +189,9 @@ class GenericFilter:
         #    len(possible_handles),
         # )
 
-        # if user:
-        #    user.begin_progress(_("Filter"), _("Applying ..."), len(possible_handles))
+        user.begin_progress(
+            _("Filter"), _("Applying ..."), len(possible_handles), can_cancel=True
+        )
 
         # test each value in possible_handles to compute the final_list
         final_list = []
@@ -198,16 +201,16 @@ class GenericFilter:
             if handles_out is not None and handle in handles_out:
                 continue
 
-            if user:
-                user.step_progress()
+            if user.get_cancelled():
+                break
+            user.step_progress()
 
             obj = self.get_object(db, handle)
 
             if apply_logical_op(db, obj, self.flist) != self.invert:
                 final_list.append(obj.handle)
 
-        if user:
-            user.end_progress()
+        user.end_progress()
 
         return final_list
 
@@ -271,19 +274,30 @@ class GenericFilter:
         id_list takes precendence over tree
 
         user is optional. If present it must be an instance of a User class.
+        If the user cancels via the progress dialog, apply stops early,
+        returning an empty list or whatever matches were already found.
 
         :Returns: if id_list given, it is returned with the items that
                 do not match the filter, filtered out.
                 if id_list not given, all items in the database that
                 match the filter are returned as a list of handles
         """
+        if user is None:
+            user = User()
+
         t0 = time.perf_counter()
         for rule in self.flist:
+            if user.get_cancelled():
+                break
             rule.requestprepare(db, user)
         t1 = time.perf_counter()
         LOG.debug("Prepare time: %s seconds", t1 - t0)
-        if user:
-            user.notify("Prepare time: %.3fs" % (t1 - t0))
+        user.notify("Prepare time: %.3fs" % (t1 - t0))
+
+        if user.get_cancelled():
+            for rule in self.flist:
+                rule.requestreset()
+            return []
 
         if self.logical_op == "and":
             apply_logical_op = self.and_test
@@ -314,11 +328,15 @@ class GenericFilter:
             possible_handles = set(self.get_all_handles(db))
 
         t2 = time.perf_counter()
-        res = self.apply_logical_op_to_all(db, possible_handles, apply_logical_op, user)
+        if user.get_cancelled():
+            res = []
+        else:
+            res = self.apply_logical_op_to_all(
+                db, possible_handles, apply_logical_op, user
+            )
         t3 = time.perf_counter()
         LOG.debug("Apply time: %s seconds", t3 - t2)
-        if user:
-            user.notify("Apply time: %.3fs" % (t3 - t2))
+        user.notify("Apply time: %.3fs" % (t3 - t2))
 
         # convert the filtered set of handles to the correct result type
         if id_list is not None and tupleind is not None:

--- a/gramps/gen/filters/_paramfilter.py
+++ b/gramps/gen/filters/_paramfilter.py
@@ -28,6 +28,7 @@ Package providing filtering framework for Gramps.
 # -------------------------------------------------------------------------
 from ._genericfilter import GenericFilter
 from ..errors import FilterError
+from ..user import User
 
 
 # -------------------------------------------------------------------------
@@ -45,6 +46,8 @@ class ParamFilter(GenericFilter):
         self.param_list = [param]
 
     def apply(self, db, id_list=None, user=None):
+        if user is None:
+            user = User()
         for rule in self.flist:
             # rule.set_list(self.param_list)
             #
@@ -61,7 +64,7 @@ class ParamFilter(GenericFilter):
                     "Custom filters can not twice be used" " in a parameter filter"
                 )
             rule.requestprepare(db, user)
-        result = GenericFilter.apply(self, db, id_list)
+        result = GenericFilter.apply(self, db, id_list, user=user)
         for rule in self.flist:
             rule.requestreset()
         return result

--- a/gramps/gen/filters/rules/family/_isancestorof.py
+++ b/gramps/gen/filters/rules/family/_isancestorof.py
@@ -45,6 +45,7 @@ from ....const import GRAMPS_LOCALE as glocale
 from typing import Set
 from ....lib import Family
 from ....db import Database
+from ....user import User
 
 _ = glocale.translation.gettext
 
@@ -64,11 +65,11 @@ class IsAncestorOf(Rule):
     category = _("General filters")
     description = _("Matches ancestor families of the specified family")
 
-    def prepare(self, db: Database, user):
+    def prepare(self, db: Database, user: User):
         self.selected_handles: Set[str] = set()
         first = False if int(self.list[1]) else True
         root_family = db.get_family_from_gramps_id(self.list[0])
-        self.init_list(db, root_family, first)
+        self.init_list(db, root_family, first, user)
 
     def reset(self):
         self.selected_handles.clear()
@@ -76,10 +77,14 @@ class IsAncestorOf(Rule):
     def apply_to_one(self, db: Database, family: Family) -> bool:
         return family.handle in self.selected_handles
 
-    def init_list(self, db: Database, family: Family | None, first: bool) -> None:
+    def init_list(
+        self, db: Database, family: Family | None, first: bool, user: User
+    ) -> None:
         """
         Initialise family handle list.
         """
+        if user.get_cancelled():
+            return
         if not family:
             return
         if family.handle in self.selected_handles:
@@ -97,4 +102,4 @@ class IsAncestorOf(Rule):
                 )
                 if family_handle:
                     parent_family = db.get_family_from_handle(family_handle)
-                    self.init_list(db, parent_family, False)
+                    self.init_list(db, parent_family, False, user)

--- a/gramps/gen/filters/rules/family/_isbookmarked.py
+++ b/gramps/gen/filters/rules/family/_isbookmarked.py
@@ -41,6 +41,7 @@ from .. import Rule
 from typing import Set
 from ....lib import Family
 from ....db import Database
+from ....user import User
 
 
 # -------------------------------------------------------------------------
@@ -55,7 +56,7 @@ class IsBookmarked(Rule):
     category = _("General filters")
     description = _("Matches the families on the bookmark list")
 
-    def prepare(self, db: Database, user):
+    def prepare(self, db: Database, user: User):
         self.selected_handles: Set[str] = set(list(db.get_family_bookmarks().get()))
 
     def apply_to_one(self, db: Database, family: Family) -> bool:

--- a/gramps/gen/filters/rules/family/_isdescendantof.py
+++ b/gramps/gen/filters/rules/family/_isdescendantof.py
@@ -45,6 +45,7 @@ from ....const import GRAMPS_LOCALE as glocale
 from typing import Set
 from ....lib import Family
 from ....db import Database
+from ....user import User
 
 _ = glocale.translation.gettext
 
@@ -64,11 +65,11 @@ class IsDescendantOf(Rule):
     category = _("General filters")
     description = _("Matches descendant families of the specified family")
 
-    def prepare(self, db: Database, user):
+    def prepare(self, db: Database, user: User):
         self.selected_handles: Set[str] = set()
         first = False if int(self.list[1]) else True
         root_family = db.get_family_from_gramps_id(self.list[0])
-        self.init_list(db, root_family, first)
+        self.init_list(db, root_family, first, user)
 
     def reset(self):
         self.selected_handles.clear()
@@ -76,10 +77,14 @@ class IsDescendantOf(Rule):
     def apply_to_one(self, db: Database, family: Family) -> bool:
         return family.handle in self.selected_handles
 
-    def init_list(self, db: Database, family: Family | None, first: bool) -> None:
+    def init_list(
+        self, db: Database, family: Family | None, first: bool, user: User
+    ) -> None:
         """
         Initialise family handle list.
         """
+        if user.get_cancelled():
+            return
         if not family:
             return
         if not first:
@@ -90,4 +95,4 @@ class IsDescendantOf(Rule):
             if child:
                 for family_handle in child.family_list:
                     child_family = db.get_family_from_handle(family_handle)
-                    self.init_list(db, child_family, False)
+                    self.init_list(db, child_family, False, user)

--- a/gramps/gen/filters/rules/person/_deeprelationshippathbetween.py
+++ b/gramps/gen/filters/rules/person/_deeprelationshippathbetween.py
@@ -43,6 +43,7 @@ from ....const import GRAMPS_LOCALE as glocale
 from ....lib import Person
 from ....db import Database
 from ....types import FamilyHandle, PersonHandle
+from ....user import User
 
 _ = glocale.translation.gettext
 # -------------------------------------------------------------------------
@@ -90,7 +91,7 @@ def get_person_family_people(
 
 
 def find_deep_relations(
-    db: Database, user, person: Person | None, target_people: list[str]
+    db: Database, user: User, person: Person | None, target_people: list[str]
 ) -> set[str]:
     """This explores all possible paths between a person and one or more
     targets.  The algorithm processes paths in a breadth first wave, one
@@ -111,10 +112,11 @@ def find_deep_relations(
     done[person.handle] = None
 
     while todo:
+        if user.get_cancelled():
+            break
         handle = todo.popleft()
 
-        if user:
-            user.step_progress()
+        user.step_progress()
 
         if handle in target_people:  # if we found a target
             prev_hndl = handle
@@ -157,7 +159,7 @@ class DeepRelationshipPathBetween(Rule):
         " the shortest path."
     )
 
-    def prepare(self, db: Database, user):
+    def prepare(self, db: Database, user: User):
         root_person_id = self.list[0]
         root_person = db.get_person_from_gramps_id(root_person_id)
 
@@ -168,19 +170,18 @@ class DeepRelationshipPathBetween(Rule):
         filt = self.filt.find_filter()
         target_people = filt.apply(db, user=user) if filt else []
 
-        if user:
-            user.begin_progress(
-                _("Finding relationship paths"),
-                _("Evaluating people"),
-                len(target_people),
-            )
+        user.begin_progress(
+            _("Finding relationship paths"),
+            _("Evaluating people"),
+            len(target_people),
+            can_cancel=True,
+        )
 
         self.selected_handles: set[str] = find_deep_relations(
             db, user, root_person, target_people
         )
 
-        if user:
-            user.end_progress()
+        user.end_progress()
 
     def reset(self):
         self.filt.requestreset()

--- a/gramps/gen/filters/rules/person/_hascommonancestorwithfiltermatch.py
+++ b/gramps/gen/filters/rules/person/_hascommonancestorwithfiltermatch.py
@@ -25,6 +25,7 @@
 from ....const import GRAMPS_LOCALE as glocale
 from ._hascommonancestorwith import HasCommonAncestorWith
 from ._matchesfilter import MatchesFilter
+from ....user import User
 
 _ = glocale.translation.gettext
 
@@ -50,7 +51,7 @@ class HasCommonAncestorWithFilterMatch(HasCommonAncestorWith):
         HasCommonAncestorWith.__init__(self, list, use_regex, use_case)
         self.ancestor_cache = {}
 
-    def prepare(self, db, user):
+    def prepare(self, db, user: User):
         self.db = db
         # For each(!) person we keep track of who their ancestors
         # are, in a set(). So we only have to compute a person's
@@ -63,12 +64,23 @@ class HasCommonAncestorWithFilterMatch(HasCommonAncestorWith):
 
         filt = self.filt.find_filter()
         if filt:
-            for handle in filt.apply(db, user=user):
+            matches = filt.apply(db, user=user)
+            user.begin_progress(
+                self.category,
+                _("Retrieving all sub-filter matches"),
+                len(matches),
+                can_cancel=True,
+            )
+            for handle in matches:
+                if user.get_cancelled():
+                    break
+                user.step_progress()
                 self.with_people.append(handle)
                 # fill list of ancestor of person if not present yet
                 if handle not in self.ancestor_cache:
                     person = db.get_raw_person_data(handle)
                     self.add_ancs(db, person)
+            user.end_progress()
 
     def reset(self):
         self.filt.requestreset()

--- a/gramps/gen/filters/rules/person/_isancestorof.py
+++ b/gramps/gen/filters/rules/person/_isancestorof.py
@@ -42,6 +42,7 @@ from .. import Rule
 from typing import Set
 from ....lib import Person
 from ....db import Database
+from ....user import User
 
 
 # -------------------------------------------------------------------------
@@ -57,7 +58,7 @@ class IsAncestorOf(Rule):
     category = _("Ancestral filters")
     description = _("Matches people that are ancestors of a specified person")
 
-    def prepare(self, db: Database, user):
+    def prepare(self, db: Database, user: User):
         """Assume that if 'Inclusive' not defined, assume inclusive"""
         self.db = db
         self.selected_handles: Set[str] = set()
@@ -67,7 +68,7 @@ class IsAncestorOf(Rule):
             first = True
         try:
             root_person = db.get_person_from_gramps_id(self.list[0])
-            self.init_ancestor_list(db, root_person, first)
+            self.init_ancestor_list(db, root_person, first, user)
         except:
             pass
 
@@ -78,8 +79,10 @@ class IsAncestorOf(Rule):
         return person.handle in self.selected_handles
 
     def init_ancestor_list(
-        self, db: Database, person: Person | None, first: bool
+        self, db: Database, person: Person | None, first: bool, user: User
     ) -> None:
+        if user.get_cancelled():
+            return
         if not person:
             return
         if person.handle in self.selected_handles:
@@ -96,6 +99,10 @@ class IsAncestorOf(Rule):
                 m_id = fam.mother_handle
 
                 if f_id:
-                    self.init_ancestor_list(db, db.get_person_from_handle(f_id), False)
+                    self.init_ancestor_list(
+                        db, db.get_person_from_handle(f_id), False, user
+                    )
                 if m_id:
-                    self.init_ancestor_list(db, db.get_person_from_handle(m_id), False)
+                    self.init_ancestor_list(
+                        db, db.get_person_from_handle(m_id), False, user
+                    )

--- a/gramps/gen/filters/rules/person/_isancestoroffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_isancestoroffiltermatch.py
@@ -27,6 +27,7 @@ from ._isancestorof import IsAncestorOf
 from ._matchesfilter import MatchesFilter
 from ....lib import Person
 from ....db import Database
+from ....user import User
 
 _ = glocale.translation.gettext
 
@@ -47,7 +48,7 @@ class IsAncestorOfFilterMatch(IsAncestorOf):
         "Matches people that are ancestors " "of anybody matched by a filter"
     )
 
-    def prepare(self, db: Database, user):
+    def prepare(self, db: Database, user: User):
         self.db = db
         self.selected_handles: set[str] = set()
         try:
@@ -63,9 +64,20 @@ class IsAncestorOfFilterMatch(IsAncestorOf):
 
         filt = self.filt.find_filter()
         if filt:
-            for handle in filt.apply(db, user=user):
+            matches = filt.apply(db, user=user)
+            user.begin_progress(
+                self.category,
+                _("Retrieving all sub-filter matches"),
+                len(matches),
+                can_cancel=True,
+            )
+            for handle in matches:
+                if user.get_cancelled():
+                    break
+                user.step_progress()
                 person = db.get_raw_person_data(handle)
-                self.init_ancestor_list(db, person, first)
+                self.init_ancestor_list(db, person, first, user)
+            user.end_progress()
 
     def reset(self):
         self.filt.requestreset()

--- a/gramps/gen/filters/rules/person/_isdefaultperson.py
+++ b/gramps/gen/filters/rules/person/_isdefaultperson.py
@@ -41,6 +41,7 @@ from .. import Rule
 from typing import Set
 from ....lib import Person
 from ....db import Database
+from ....user import User
 
 
 # -------------------------------------------------------------------------
@@ -55,7 +56,7 @@ class IsDefaultPerson(Rule):
     category = _("General filters")
     description = _("Matches the Home Person")
 
-    def prepare(self, db: Database, user):
+    def prepare(self, db: Database, user: User):
         self.selected_handles: Set[str] = set()
         p: Person = db.get_default_person()
         if p:

--- a/gramps/gen/filters/rules/person/_isdescendantfamilyof.py
+++ b/gramps/gen/filters/rules/person/_isdescendantfamilyof.py
@@ -47,6 +47,7 @@ from typing import List, Set
 from ....lib import Person
 from ....db import Database
 from ....types import PersonHandle
+from ....user import User
 
 
 # -------------------------------------------------------------------------
@@ -66,11 +67,11 @@ class IsDescendantFamilyOf(Rule):
         "of a descendant of a specified person"
     )
 
-    def prepare(self, db: Database, user):
+    def prepare(self, db: Database, user: User):
         self.db = db
         self.selected_handles: Set[PersonHandle] = set()
         self.root_person = db.get_person_from_gramps_id(self.list[0])
-        self.add_matches(self.root_person)
+        self.add_matches(self.root_person, user)
         try:
             if int(self.list[1]):
                 inclusive = True
@@ -87,7 +88,7 @@ class IsDescendantFamilyOf(Rule):
     def apply_to_one(self, db: Database, person: Person) -> bool:
         return person.handle in self.selected_handles
 
-    def add_matches(self, person: Person | None):
+    def add_matches(self, person: Person | None, user: User):
         if not person:
             return
 
@@ -95,6 +96,8 @@ class IsDescendantFamilyOf(Rule):
         queue: List[Person] = [person]
 
         while queue:
+            if user.get_cancelled():
+                break
             person = queue.pop(0)
             if person is None or person.handle in self.selected_handles:
                 # if we have been here before, skip

--- a/gramps/gen/filters/rules/person/_isdescendantfamilyoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_isdescendantfamilyoffiltermatch.py
@@ -27,6 +27,7 @@ from ._isdescendantfamilyof import IsDescendantFamilyOf
 from ._matchesfilter import MatchesFilter
 from ....types import PersonHandle
 from ....db.generic import Database
+from ....user import User
 
 _ = glocale.translation.gettext
 
@@ -48,7 +49,7 @@ class IsDescendantFamilyOfFilterMatch(IsDescendantFamilyOf):
         "of anybody matched by a filter"
     )
 
-    def prepare(self, db: Database, user):
+    def prepare(self, db: Database, user: User):
         self.db = db
         self.selected_handles: set[PersonHandle] = set()
 
@@ -57,9 +58,20 @@ class IsDescendantFamilyOfFilterMatch(IsDescendantFamilyOf):
 
         filt = self.matchfilt.find_filter()
         if filt:
-            for handle in filt.apply(db, user=user):
+            matches = filt.apply(db, user=user)
+            user.begin_progress(
+                self.category,
+                _("Retrieving all sub-filter matches"),
+                len(matches),
+                can_cancel=True,
+            )
+            for handle in matches:
+                if user.get_cancelled():
+                    break
+                user.step_progress()
                 person = db.get_raw_person_data(handle)
-                self.add_matches(person)
+                self.add_matches(person, user)
+            user.end_progress()
 
     def reset(self):
         self.matchfilt.requestreset()

--- a/gramps/gen/filters/rules/person/_isdescendantof.py
+++ b/gramps/gen/filters/rules/person/_isdescendantof.py
@@ -42,6 +42,7 @@ from .. import Rule
 from typing import Set
 from ....lib import Person
 from ....db import Database
+from ....user import User
 
 
 # -------------------------------------------------------------------------
@@ -58,7 +59,7 @@ class IsDescendantOf(Rule):
     category = _("Descendant filters")
     description = _("Matches all descendants for the specified person")
 
-    def prepare(self, db: Database, user):
+    def prepare(self, db: Database, user: User):
         self.db = db
         self.selected_handles: Set[str] = set()
         try:
@@ -67,7 +68,7 @@ class IsDescendantOf(Rule):
             first = True
         try:
             root_person = db.get_person_from_gramps_id(self.list[0])
-            self.init_list(root_person, first)
+            self.init_list(root_person, first, user)
         except:
             pass
 
@@ -77,7 +78,9 @@ class IsDescendantOf(Rule):
     def apply_to_one(self, db: Database, person: Person) -> bool:
         return person.handle in self.selected_handles
 
-    def init_list(self, person: Person | None, first: bool) -> None:
+    def init_list(self, person: Person | None, first: bool, user: User) -> None:
+        if user.get_cancelled():
+            return
         if not person or person.handle in self.selected_handles:
             # if we have been here before, skip
             return
@@ -88,4 +91,6 @@ class IsDescendantOf(Rule):
             fam = self.db.get_family_from_handle(fam_id)
             if fam:
                 for child_ref in fam.child_ref_list:
-                    self.init_list(self.db.get_person_from_handle(child_ref.ref), False)
+                    self.init_list(
+                        self.db.get_person_from_handle(child_ref.ref), False, user
+                    )

--- a/gramps/gen/filters/rules/person/_isdescendantoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_isdescendantoffiltermatch.py
@@ -27,6 +27,7 @@ from ._isdescendantof import IsDescendantOf
 from ._matchesfilter import MatchesFilter
 from ....lib import Person
 from ....db import Database
+from ....user import User
 
 _ = glocale.translation.gettext
 
@@ -47,7 +48,7 @@ class IsDescendantOfFilterMatch(IsDescendantOf):
         "Matches people that are descendants " "of anybody matched by a filter"
     )
 
-    def prepare(self, db: Database, user):
+    def prepare(self, db: Database, user: User):
         self.db = db
         self.selected_handles: set[str] = set()
         try:
@@ -63,9 +64,20 @@ class IsDescendantOfFilterMatch(IsDescendantOf):
 
         filt = self.filt.find_filter()
         if filt:
-            for handle in filt.apply(db, user=user):
+            matches = filt.apply(db, user=user)
+            user.begin_progress(
+                self.category,
+                _("Retrieving all sub-filter matches"),
+                len(matches),
+                can_cancel=True,
+            )
+            for handle in matches:
+                if user.get_cancelled():
+                    break
+                user.step_progress()
                 person = db.get_raw_person_data(handle)
-                self.init_list(person, first)
+                self.init_list(person, first, user)
+            user.end_progress()
 
     def reset(self):
         self.filt.requestreset()

--- a/gramps/gen/filters/rules/person/_isduplicatedancestorof.py
+++ b/gramps/gen/filters/rules/person/_isduplicatedancestorof.py
@@ -42,6 +42,7 @@ from .. import Rule
 from typing import Set
 from ....lib import Person
 from ....db import Database
+from ....user import User
 
 
 # -------------------------------------------------------------------------
@@ -60,13 +61,13 @@ class IsDuplicatedAncestorOf(Rule):
         "Matches people that are ancestors twice or more " "of a specified person"
     )
 
-    def prepare(self, db: Database, user):
+    def prepare(self, db: Database, user: User):
         self.db = db
         self.cache: Set[str] = set()
         self.selected_handles: Set[str] = set()
         root_person = db.get_person_from_gramps_id(self.list[0])
         if root_person:
-            self.init_ancestor_list(db, root_person)
+            self.init_ancestor_list(db, root_person, user)
 
     def reset(self):
         self.cache.clear()
@@ -75,7 +76,7 @@ class IsDuplicatedAncestorOf(Rule):
     def apply_to_one(self, db: Database, person: Person) -> bool:
         return person.handle in self.selected_handles
 
-    def init_ancestor_list(self, db: Database, person: Person):
+    def init_ancestor_list(self, db: Database, person: Person, user: User):
         fam_id = (
             person.parent_family_list[0] if len(person.parent_family_list) > 0 else None
         )
@@ -85,15 +86,17 @@ class IsDuplicatedAncestorOf(Rule):
                 f_id = fam.father_handle
                 m_id = fam.mother_handle
                 if m_id:
-                    self.go_deeper(db, db.get_person_from_handle(m_id))
+                    self.go_deeper(db, db.get_person_from_handle(m_id), user)
                 if f_id:
-                    self.go_deeper(db, db.get_person_from_handle(f_id))
+                    self.go_deeper(db, db.get_person_from_handle(f_id), user)
 
-    def go_deeper(self, db: Database, person: Person):
+    def go_deeper(self, db: Database, person: Person, user: User):
+        if user.get_cancelled():
+            return
         if person and person.handle in self.cache:
             self.selected_handles.add((person.handle))
             # the following keeps from scanning same parts of tree multiple
             # times and avoids crash on tree loops.
             return
         self.cache.add(person.handle)
-        self.init_ancestor_list(db, person)
+        self.init_ancestor_list(db, person, user)

--- a/gramps/gen/filters/rules/person/_islessthannthgenerationancestorof.py
+++ b/gramps/gen/filters/rules/person/_islessthannthgenerationancestorof.py
@@ -42,6 +42,7 @@ from typing import List, Set, Tuple
 from ....lib import Person
 from ....db import Database
 from ....types import PersonHandle
+from ....user import User
 
 
 # -------------------------------------------------------------------------
@@ -61,20 +62,22 @@ class IsLessThanNthGenerationAncestorOf(Rule):
         "of a specified person not more than N generations away"
     )
 
-    def prepare(self, db: Database, user):
+    def prepare(self, db: Database, user: User):
         self.db = db
         self.selected_handles: Set[str] = set()
         person = db.get_person_from_gramps_id(self.list[0])
         if person:
             root_handle = person.handle
             if root_handle:
-                self.init_ancestor_list(root_handle)
+                self.init_ancestor_list(root_handle, user)
 
-    def init_ancestor_list(self, root_handle: PersonHandle):
+    def init_ancestor_list(self, root_handle: PersonHandle, user: User):
         queue: List[Tuple[PersonHandle, int]] = [
             (root_handle, 1)
         ]  # generation 1 is root
         while queue:
+            if user.get_cancelled():
+                break
             handle, gen = queue.pop(0)
             if handle in self.selected_handles:
                 # if we have been here before, skip

--- a/gramps/gen/filters/rules/person/_islessthannthgenerationancestorofbookmarked.py
+++ b/gramps/gen/filters/rules/person/_islessthannthgenerationancestorofbookmarked.py
@@ -47,6 +47,7 @@ from typing import List, Set
 from ....lib import Person
 from ....db import Database
 from ....types import PersonHandle
+from ....user import User
 
 
 # -------------------------------------------------------------------------
@@ -67,16 +68,18 @@ class IsLessThanNthGenerationAncestorOfBookmarked(Rule):
         "not more than N generations away"
     )
 
-    def prepare(self, db: Database, user):
+    def prepare(self, db: Database, user: User):
         self.db = db
         bookmarks: List[str] = db.get_bookmarks().get()
         self.selected_handles: Set[PersonHandle] = set()
         if len(bookmarks) != 0:
             self.bookmarks: Set[PersonHandle] = set(bookmarks)
             for self.bookmarkhandle in self.bookmarks:
-                self.init_ancestor_list(self.bookmarkhandle, 1)
+                self.init_ancestor_list(self.bookmarkhandle, 1, user)
 
-    def init_ancestor_list(self, handle: PersonHandle, gen: int):
+    def init_ancestor_list(self, handle: PersonHandle, gen: int, user: User):
+        if user.get_cancelled():
+            return
         if not handle or handle in self.selected_handles:
             # if been here already, skip
             return
@@ -95,9 +98,9 @@ class IsLessThanNthGenerationAncestorOfBookmarked(Rule):
             m_id = fam.mother_handle
 
             if f_id:
-                self.init_ancestor_list(f_id, gen + 1)
+                self.init_ancestor_list(f_id, gen + 1, user)
             if m_id:
-                self.init_ancestor_list(m_id, gen + 1)
+                self.init_ancestor_list(m_id, gen + 1, user)
 
     def apply_to_one(self, db: Database, person: Person) -> bool:
         return person.handle in self.selected_handles

--- a/gramps/gen/filters/rules/person/_islessthannthgenerationancestorofdefaultperson.py
+++ b/gramps/gen/filters/rules/person/_islessthannthgenerationancestorofdefaultperson.py
@@ -42,6 +42,7 @@ from typing import Set
 from ....lib import Person
 from ....db import Database
 from ....types import PersonHandle
+from ....user import User
 
 
 # -------------------------------------------------------------------------
@@ -61,14 +62,16 @@ class IsLessThanNthGenerationAncestorOfDefaultPerson(Rule):
         "Matches ancestors of the Home Person " "not more than N generations away"
     )
 
-    def prepare(self, db: Database, user):
+    def prepare(self, db: Database, user: User):
         self.db = db
         self.selected_handles: Set[PersonHandle] = set()
         p: Person = db.get_default_person()
         if p:
-            self.init_ancestor_list(p.handle, 1)
+            self.init_ancestor_list(p.handle, 1, user)
 
-    def init_ancestor_list(self, handle: PersonHandle, gen: int):
+    def init_ancestor_list(self, handle: PersonHandle, gen: int, user: User):
+        if user.get_cancelled():
+            return
         if not handle or handle in self.selected_handles:
             # if we have been here before, skip
             return
@@ -87,9 +90,9 @@ class IsLessThanNthGenerationAncestorOfDefaultPerson(Rule):
             m_id = fam.mother_handle
 
             if f_id:
-                self.init_ancestor_list(f_id, gen + 1)
+                self.init_ancestor_list(f_id, gen + 1, user)
             if m_id:
-                self.init_ancestor_list(m_id, gen + 1)
+                self.init_ancestor_list(m_id, gen + 1, user)
 
     def apply_to_one(self, db: Database, person: Person) -> bool:
         return person.handle in self.selected_handles

--- a/gramps/gen/filters/rules/person/_islessthannthgenerationdescendantof.py
+++ b/gramps/gen/filters/rules/person/_islessthannthgenerationdescendantof.py
@@ -42,6 +42,7 @@ from .. import Rule
 from typing import Set
 from ....lib import Person
 from ....db import Database
+from ....user import User
 
 
 # -------------------------------------------------------------------------
@@ -61,12 +62,12 @@ class IsLessThanNthGenerationDescendantOf(Rule):
         "specified person not more than N generations away"
     )
 
-    def prepare(self, db: Database, user):
+    def prepare(self, db: Database, user: User):
         self.db = db
         self.selected_handles: Set[str] = set()
         try:
             root_person = db.get_person_from_gramps_id(self.list[0])
-            self.init_list(root_person, 0)
+            self.init_list(root_person, 0, user)
         except:
             pass
 
@@ -76,7 +77,9 @@ class IsLessThanNthGenerationDescendantOf(Rule):
     def apply_to_one(self, db: Database, person: Person) -> bool:
         return person.handle in self.selected_handles
 
-    def init_list(self, person: Person | None, gen: int):
+    def init_list(self, person: Person | None, gen: int, user: User):
+        if user.get_cancelled():
+            return
         if not person or person.handle in self.selected_handles:
             # if we have been here before, skip
             return
@@ -90,5 +93,5 @@ class IsLessThanNthGenerationDescendantOf(Rule):
             if fam:
                 for child_ref in fam.child_ref_list:
                     self.init_list(
-                        self.db.get_person_from_handle(child_ref.ref), gen + 1
+                        self.db.get_person_from_handle(child_ref.ref), gen + 1, user
                     )

--- a/gramps/gen/filters/rules/person/_ismorethannthgenerationancestorof.py
+++ b/gramps/gen/filters/rules/person/_ismorethannthgenerationancestorof.py
@@ -42,6 +42,7 @@ from typing import Set
 from ....lib import Person
 from ....db import Database
 from ....types import PersonHandle
+from ....user import User
 
 
 # -------------------------------------------------------------------------
@@ -61,18 +62,20 @@ class IsMoreThanNthGenerationAncestorOf(Rule):
         "of a specified person at least N generations away"
     )
 
-    def prepare(self, db: Database, user):
+    def prepare(self, db: Database, user: User):
         self.db = db
         self.selected_handles: Set[PersonHandle] = set()
         person = db.get_person_from_gramps_id(self.list[0])
         if person:
             root_handle = person.handle
             if root_handle:
-                self.init_ancestor_list(root_handle)
+                self.init_ancestor_list(root_handle, user)
 
-    def init_ancestor_list(self, root_handle: PersonHandle):
+    def init_ancestor_list(self, root_handle: PersonHandle, user: User):
         queue = [(root_handle, 1)]  # generation 1 is root
         while queue:
+            if user.get_cancelled():
+                break
             handle, gen = queue.pop(0)  # pop off front of queue
             if gen > int(self.list[1]):
                 self.selected_handles.add(handle)

--- a/gramps/gen/filters/rules/person/_ismorethannthgenerationdescendantof.py
+++ b/gramps/gen/filters/rules/person/_ismorethannthgenerationdescendantof.py
@@ -41,6 +41,7 @@ from .. import Rule
 from typing import Set
 from ....lib import Person
 from ....db import Database
+from ....user import User
 
 
 # -------------------------------------------------------------------------
@@ -60,12 +61,12 @@ class IsMoreThanNthGenerationDescendantOf(Rule):
         "person at least N generations away"
     )
 
-    def prepare(self, db: Database, user):
+    def prepare(self, db: Database, user: User):
         self.db = db
         self.selected_handles: Set[str] = set()
         try:
             root_person = db._get_raw_person_from_id_data(self.list[0])
-            self.init_list(root_person, 0)
+            self.init_list(root_person, 0, user)
         except:
             pass
 
@@ -75,16 +76,20 @@ class IsMoreThanNthGenerationDescendantOf(Rule):
     def apply_to_one(self, db: Database, person: Person) -> bool:
         return person.handle in self.selected_handles
 
-    def init_list(self, person: Person, gen: int) -> None:
+    def init_list(self, person: Person, gen: int, user: User) -> None:
         if not person:
             return
         if gen >= int(self.list[1]):
             self.selected_handles.add(person.handle)
 
         for fam_id in person.family_list:
+            if user.get_cancelled():
+                break
             fam = self.db.get_family_from_handle(fam_id)
             if fam:
                 for child_ref in fam.child_ref_list:
                     self.init_list(
-                        self.db.get_person_from_handle(child_ref.ref), gen + 1
+                        self.db.get_person_from_handle(child_ref.ref),
+                        gen + 1,
+                        user,
                     )

--- a/gramps/gen/filters/rules/person/_isrelatedwith.py
+++ b/gramps/gen/filters/rules/person/_isrelatedwith.py
@@ -42,6 +42,7 @@ from .. import Rule
 from typing import List, Set
 from ....lib import Person
 from ....db import Database
+from ....user import User
 
 
 # -------------------------------------------------------------------------
@@ -57,7 +58,7 @@ class IsRelatedWith(Rule):
     category = _("Relationship filters")
     description = _("Matches people related to a specified person")
 
-    def prepare(self, db: Database, user):
+    def prepare(self, db: Database, user: User):
         """prepare so the rule can be executed efficiently
         we build the list of people related to <person> here,
         so that apply is only a check into this list
@@ -65,7 +66,7 @@ class IsRelatedWith(Rule):
         self.db = db
 
         self.selected_handles: Set[str] = set()
-        self.add_relative(db.get_person_from_gramps_id(self.list[0]))
+        self.add_relative(db.get_person_from_gramps_id(self.list[0]), user)
 
     def reset(self):
         self.selected_handles.clear()
@@ -73,7 +74,7 @@ class IsRelatedWith(Rule):
     def apply_to_one(self, db: Database, person: Person) -> bool:
         return person.handle in self.selected_handles
 
-    def add_relative(self, start: Person | None):
+    def add_relative(self, start: Person | None, user: User):
         """Non-recursive function that scans relatives and add them to self.selected_handles"""
         if not start:
             return
@@ -81,6 +82,8 @@ class IsRelatedWith(Rule):
         queue: List[Person] = [start]
 
         while queue:
+            if user.get_cancelled():
+                break
             person = queue.pop()
             # Add the relative to the list
             if person is None or (person.handle in self.selected_handles):

--- a/gramps/gen/filters/rules/person/_relationshippathbetween.py
+++ b/gramps/gen/filters/rules/person/_relationshippathbetween.py
@@ -42,6 +42,7 @@ from typing import List, Set, Dict
 from ....lib import Person
 from ....db import Database
 from ....types import PersonHandle
+from ....user import User
 
 
 # -------------------------------------------------------------------------
@@ -62,13 +63,13 @@ class RelationshipPathBetween(Rule):
         "path between two persons."
     )
 
-    def prepare(self, db: Database, user):
+    def prepare(self, db: Database, user: User):
         self.db = db
         self.selected_handles: Set[PersonHandle] = set()
         root1 = db.get_person_from_gramps_id(self.list[0])
         root2 = db.get_person_from_gramps_id(self.list[1])
         if root1 and root2:
-            self.init_list(root1.handle, root2.handle)
+            self.init_list(root1.handle, root2.handle, user)
 
     def reset(self):
         self.selected_handles.clear()
@@ -113,7 +114,7 @@ class RelationshipPathBetween(Rule):
     def apply_to_one(self, db: Database, person: Person) -> bool:
         return person.handle in self.selected_handles
 
-    def init_list(self, p1_handle: PersonHandle, p2_handle: PersonHandle):
+    def init_list(self, p1_handle: PersonHandle, p2_handle: PersonHandle, user: User):
         firstMap: Dict[PersonHandle, int] = {}
         firstSet: Set[PersonHandle] = set()
         secondMap: Dict[PersonHandle, int] = {}
@@ -136,6 +137,8 @@ class RelationshipPathBetween(Rule):
         path2 = set([p2_handle])
 
         for person_handle in common:
+            if user.get_cancelled():
+                return
             new_map: Set[PersonHandle] = set()
             self.desc_list(person_handle, new_map, True)
             path1.update(new_map.intersection(firstMap))

--- a/gramps/gen/filters/rules/person/_relationshippathbetweenbookmarks.py
+++ b/gramps/gen/filters/rules/person/_relationshippathbetweenbookmarks.py
@@ -45,6 +45,7 @@ from typing import List, Set, Dict
 from ....lib import Person
 from ....db import Database
 from ....types import PersonHandle, FamilyHandle
+from ....user import User
 
 
 # -------------------------------------------------------------------------
@@ -67,13 +68,13 @@ class RelationshipPathBetweenBookmarks(Rule):
         "path(s) between bookmarked persons."
     )
 
-    def prepare(self, db: Database, user):
+    def prepare(self, db: Database, user: User):
         self.db = db
         self.selected_handles: Set[PersonHandle] = set()
         bookmarks = db.get_bookmarks().get()
         self.bookmarks: Set[PersonHandle] = set(bookmarks)
         try:
-            self.init_list()
+            self.init_list(user)
         except:
             pass
 
@@ -159,7 +160,7 @@ class RelationshipPathBetweenBookmarks(Rule):
         # print "  In rel_path_for_two, returning rel_path = ", rel_path
         return rel_path
 
-    def init_list(self) -> None:
+    def init_list(self, user: User) -> None:
         self.selected_handles.update(self.bookmarks)
         if len(self.bookmarks) < 2:
             return
@@ -170,6 +171,8 @@ class RelationshipPathBetweenBookmarks(Rule):
         lb = len(bmarks)
         for i in range(lb - 1):
             for j in range(i + 1, lb):
+                if user.get_cancelled():
+                    return
                 try:
                     pathmap = self.rel_path_for_two(bmarks[i], bmarks[j])
                     self.selected_handles.update(pathmap)

--- a/gramps/gen/filters/test/filter_cancel_test.py
+++ b/gramps/gen/filters/test/filter_cancel_test.py
@@ -1,0 +1,153 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026 Doug Blank <doug.blank@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Unittest for filter cancellation support."""
+
+import io
+import os
+import unittest
+
+from ...const import TEST_DIR
+from ...db.utils import import_as_dict
+from ...user import User
+from ....cli.user import User as CliUser
+from .. import GenericFilter, reload_custom_filters
+from ....gen import filters as filters_module
+from ..rules.person import HasIdOf, IsAncestorOfFilterMatch
+
+EXAMPLE = os.path.join(TEST_DIR, "example.gramps")
+
+
+class CancelAfterSteps(CliUser):
+    """
+    Test double, built on the real CLI User (not a bare stub), that
+    reports itself as cancelled once a fixed number of
+    ``step_progress()`` calls have been made, regardless of how many
+    separate ``begin_progress``/``end_progress`` cycles they span.
+    """
+
+    def __init__(self, cancel_after):
+        CliUser.__init__(self)
+        self._fileout = io.StringIO()  # suppress progress output during tests
+        self.cancel_after = cancel_after
+        self.steps_taken = 0
+
+    def step_progress(self):
+        self.steps_taken += 1
+        CliUser.step_progress(self)
+
+    def get_cancelled(self):
+        return self.steps_taken >= self.cancel_after
+
+
+class FilterCancelTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # the test results depend on specific grampsIds, so we need to use
+        # the same prefixes as the example database
+        cls.db = import_as_dict(
+            EXAMPLE,
+            User(),
+            person_prefix="I%04d",
+            media_prefix="O%04d",
+            family_prefix="F%04d",
+            source_prefix="S%04d",
+            citation_prefix="C%04d",
+            place_prefix="P%04d",
+            event_prefix="E%04d",
+            repository_prefix="R%04d",
+            note_prefix="N%04d",
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.db.close()
+        cls.db = None
+
+    def test_uncancelled_user_is_never_cancelled(self):
+        user = User()
+        filt = GenericFilter()
+        results = filt.apply(self.db, user=user)
+        self.assertFalse(user.get_cancelled())
+        self.assertEqual(len(results), self.db.get_number_of_people())
+
+    def test_cancel_before_any_step_returns_empty(self):
+        user = CancelAfterSteps(cancel_after=0)
+        filt = GenericFilter()
+        results = filt.apply(self.db, user=user)
+        self.assertEqual(results, [])
+
+    def test_cancel_stops_apply_after_exact_step_count(self):
+        # An empty rule list matches everyone, so the number of matches
+        # found before cancellation is exactly the number of steps taken,
+        # regardless of handle iteration order.
+        for cancel_after in (1, 5, 50):
+            with self.subTest(cancel_after=cancel_after):
+                user = CancelAfterSteps(cancel_after=cancel_after)
+                filt = GenericFilter()
+                results = filt.apply(self.db, user=user)
+                self.assertEqual(len(results), cancel_after)
+                self.assertTrue(user.get_cancelled())
+
+    def test_cancel_returns_subset_of_uncancelled_results(self):
+        full_filter = GenericFilter()
+        full_results = set(full_filter.apply(self.db))
+
+        user = CancelAfterSteps(cancel_after=50)
+        partial_filter = GenericFilter()
+        partial_results = partial_filter.apply(self.db, user=user)
+
+        self.assertEqual(len(partial_results), 50)
+        self.assertTrue(set(partial_results).issubset(full_results))
+
+    def test_cancel_during_filtermatch_prepare_does_not_raise(self):
+        """
+        Rules such as IsAncestorOfFilterMatch gather their sub-filter
+        matches, then walk each match's ancestor tree during prepare().
+        Cancelling partway through that recursive walk must not raise
+        and must still return a usable (possibly partial) list.
+        """
+        reload_custom_filters()
+        base = GenericFilter()
+        base.set_logical_op("or")
+        base.add_rule(HasIdOf(["I0006"]))
+        base.add_rule(HasIdOf(["I0005"]))
+        base.set_name("Base")
+        filters_module.CustomFilters.get_filters_dict("Person")["Base"] = base
+        try:
+            full_filter = GenericFilter()
+            full_filter.add_rule(IsAncestorOfFilterMatch(["Base"]))
+            full_results = full_filter.apply(self.db)
+            # sanity check: this rule matches a substantial part of the tree
+            self.assertGreater(len(full_results), 10)
+
+            user = CancelAfterSteps(cancel_after=2)
+            cancelled_filter = GenericFilter()
+            cancelled_filter.add_rule(IsAncestorOfFilterMatch(["Base"]))
+            partial_results = cancelled_filter.apply(self.db, user=user)
+
+            self.assertIsInstance(partial_results, list)
+            self.assertLessEqual(len(partial_results), len(full_results))
+            self.assertTrue(user.get_cancelled())
+        finally:
+            reload_custom_filters()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gen/test/user_test.py
+++ b/gramps/gen/test/user_test.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026 Doug Blank <doug.blank@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Unittest for the cancellation support in user.py"""
+
+import unittest
+
+from .. import user
+
+
+class TestUser_get_cancelled(unittest.TestCase):
+    def setUp(self):
+        self.user = user.User()
+
+    def test_default_is_not_cancelled(self):
+        self.assertFalse(self.user.get_cancelled())
+
+    def test_begin_progress_accepts_can_cancel_and_callback(self):
+        # The no-op User must accept the same arguments as every other
+        # User implementation, even though it does nothing with them.
+        called = []
+        self.user.begin_progress(
+            "Title", "Message", 10, can_cancel=True, cancel_callback=called.append
+        )
+        self.user.step_progress()
+        self.user.end_progress()
+        self.assertFalse(self.user.get_cancelled())
+        self.assertEqual(called, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gen/user.py
+++ b/gramps/gen/user.py
@@ -42,7 +42,9 @@ class UserBase(metaclass=ABCMeta):
         self._print_func = lambda msg: None
 
     @abstractmethod
-    def begin_progress(self, title, message, steps):
+    def begin_progress(
+        self, title, message, steps, can_cancel=False, cancel_callback=None
+    ):
         """
         Start showing a progress indicator to the user.
 
@@ -56,7 +58,17 @@ class UserBase(metaclass=ABCMeta):
             a value of 0 indicates that the ending is unknown and the
             meter should just show activity.
         :type steps: int
+        :param can_cancel: whether the user may cancel the operation
+        :type can_cancel: bool
+        :param cancel_callback: called when the user requests cancellation
+        :type cancel_callback: callable or None
         :returns: none
+        """
+
+    @abstractmethod
+    def get_cancelled(self):
+        """
+        Return whether the user has requested cancellation.
         """
 
     @abstractmethod
@@ -223,8 +235,13 @@ class User(UserBase):
     def __cb(self, percent, text=None):
         return
 
-    def begin_progress(self, title, message, steps):
+    def begin_progress(
+        self, title, message, steps, can_cancel=False, cancel_callback=None
+    ):
         pass
+
+    def get_cancelled(self):
+        return False
 
     def step_progress(self):
         pass

--- a/gramps/gui/test/user_test.py
+++ b/gramps/gui/test/user_test.py
@@ -57,5 +57,51 @@ class TestUser_init_accepts_uistate(unittest.TestCase):
         user.User(uistate=None)
 
 
+class TestUser_get_cancelled(unittest.TestCase):
+    def setUp(self):
+        self.user = user.User()
+
+    def test_default_is_not_cancelled(self):
+        self.assertFalse(self.user.get_cancelled())
+
+    def test_begin_progress_passes_can_cancel_and_callback_to_progressmeter(self):
+        callback = Mock()
+        with (
+            patch("gramps.gui.user.ProgressMeter") as MockPM,
+            patch("gramps.gui.user.Gtk") as MockGtk,
+        ):
+            MockGtk.events_pending.return_value = False
+            self.user.begin_progress(
+                "Title", "Message", 10, can_cancel=True, cancel_callback=callback
+            )
+        MockPM.assert_called_once_with(
+            "Title",
+            parent=self.user.parent,
+            can_cancel=True,
+            cancel_callback=callback,
+        )
+
+    def test_get_cancelled_delegates_to_active_progress_meter(self):
+        with (
+            patch("gramps.gui.user.ProgressMeter") as MockPM,
+            patch("gramps.gui.user.Gtk") as MockGtk,
+        ):
+            MockGtk.events_pending.return_value = False
+            MockPM.return_value.get_cancelled.return_value = True
+            self.user.begin_progress("Title", "Message", 10, can_cancel=True)
+            self.assertTrue(self.user.get_cancelled())
+
+    def test_get_cancelled_false_once_progress_ends(self):
+        with (
+            patch("gramps.gui.user.ProgressMeter") as MockPM,
+            patch("gramps.gui.user.Gtk") as MockGtk,
+        ):
+            MockGtk.events_pending.return_value = False
+            MockPM.return_value.get_cancelled.return_value = True
+            self.user.begin_progress("Title", "Message", 10, can_cancel=True)
+            self.user.end_progress()
+        self.assertFalse(self.user.get_cancelled())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/gramps/gui/user.py
+++ b/gramps/gui/user.py
@@ -95,7 +95,9 @@ class User(user.UserBase):
                 return
         self._fileout.write(msg + "\n")
 
-    def begin_progress(self, title, message, steps):
+    def begin_progress(
+        self, title, message, steps, can_cancel=False, cancel_callback=None
+    ):
         """
         Start showing a progress indicator to the user.
 
@@ -109,11 +111,24 @@ class User(user.UserBase):
         :type steps: int
         :returns: none
         """
-        self._progress = ProgressMeter(title, parent=self.parent)
+        self._progress = ProgressMeter(
+            title,
+            parent=self.parent,
+            can_cancel=can_cancel,
+            cancel_callback=cancel_callback,
+        )
         if steps > 0:
             self._progress.set_pass(message, steps, ProgressMeter.MODE_FRACTION)
         else:
             self._progress.set_pass(message, mode=ProgressMeter.MODE_ACTIVITY)
+        while Gtk.events_pending():
+            Gtk.main_iteration()
+
+    def get_cancelled(self):
+        if self._progress:
+            return self._progress.get_cancelled()
+        else:
+            return False
 
     def step_progress(self):
         """

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -162,6 +162,7 @@ gramps/gen/filters/rules/test/repository_rules_test.py
 # gen.filters.test package
 #
 gramps/gen/filters/test/__init__.py
+gramps/gen/filters/test/filter_cancel_test.py
 gramps/gen/filters/test/filter_optimizer_test.py
 #
 # gen lib API
@@ -299,6 +300,7 @@ gramps/gen/simple/_simpledoc.py
 #
 gramps/gen/test/config_test.py
 gramps/gen/test/constfunc_test.py
+gramps/gen/test/user_test.py
 #
 # gen utils API
 #


### PR DESCRIPTION
Reimplementation of #1963, rebased against current master.

#1963 predates the filter/rules refactor that introduced the
`Optimizer` class and moved several `*FilterMatch` rules (e.g.
`IsAncestorOfFilterMatch`) to build their sub-filter matches via
`filt.apply(db, user=user)` instead of manually looping over
`db.iter_people()`. That refactor made #1963's diff conflict too
deeply/structurally to rebase cleanly, so this PR reimplements the
same feature directly against the current architecture rather than
carrying the old commits forward.

## What changed from the original PR

- Rules whose per-match work is O(1) (children/parents/siblings of a
  filter match) needed no changes at all: they automatically get
  cancellation once `_genericfilter.py` supports it, since the
  expensive matching work now happens inside `filt.apply()`.
- Rules with recursive per-match work (ancestor/descendant/descendant-
  family/common-ancestor "of filter match" variants) get a new
  progress+cancel wrapper around their result-processing loop, sized
  to the actual match count rather than the whole database.
- The outer "Preparing ..." progress meter wrapping the per-rule
  prepare loop from the original PR was deliberately **not**
  reinstated, since master's `acbf8de042` ("Remove the outer progress
  meter from the filter prepare phase", fixing #13725) removed it to
  avoid orphaned/stuck modal dialogs when a rule shows its own nested
  progress meter during `prepare()`.
- Fixed a related bug in `ParamFilter.apply()` that silently dropped
  the `user` argument when delegating to `GenericFilter.apply()`.

## Summary

- `User.begin_progress()` now accepts `can_cancel` / `cancel_callback`.
- Every `User` implementation (CLI, GUI, no-op base) gains
  `get_cancelled()`.
- `GenericFilter.apply()` / `apply_logical_op_to_all()` check
  `get_cancelled()` between steps and stop early, returning whatever
  matches were already found.
- Filter rules that scan large parts of the tree thread `User` through
  their recursive helpers so cancellation is noticed promptly.
- `apply()` always uses a real `User` instance now, so the `if user:`
  guards throughout the filter rules are removed.

## Tests

Added dedicated coverage for the cancellation behavior itself:

- `gen/filters/test/filter_cancel_test.py` (new): exercises
  `GenericFilter.apply()` end-to-end against the example database —
  cancelling before any work starts returns an empty list, cancelling
  partway through returns exactly the matches found so far (a subset
  of the uncancelled result), and cancelling during a recursive
  filter-match rule's `prepare()` (`IsAncestorOfFilterMatch`) doesn't
  raise. The cancelling test double is built on the real
  `gramps.cli.user.User` (not a bare stub), so it exercises actual
  progress-reporting code along the way.
- `gen/test/user_test.py` (new), plus additions to
  `cli/test/user_test.py` and `gui/test/user_test.py`: cover the
  `get_cancelled()` / `begin_progress(can_cancel=..., cancel_callback=...)`
  plumbing for every `User` implementation.

## Test plan

- [x] `black --check` on all changed files
- [x] `mypy` on all changed files
- [x] New cancellation tests pass (`filter_cancel_test`,
      `gen.test.user_test`, plus the added cases in
      `cli.test.user_test` and `gui.test.user_test`)
- [x] Relevant existing test modules (`filter_optimizer_test`,
      `cli.test.user_test`, `person_rules_test`, `family_rules_test`,
      `event_rules_test`) pass in isolation; the same pre-existing
      test-isolation failures reproduce identically on unmodified
      master when these modules are run together, confirming no
      regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)