### PR TITLE
Optimizer: skip loop when all rules are optimized

### DIFF
--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -180,24 +180,37 @@ class GenericFilter:
 
         # use the Optimizer to refine the set of possible_handles
         optimizer = Optimizer(self)
-        handles_in, handles_out = optimizer.compute_potential_handles_for_filter(self)
+        handles_in, handles_out, all_optimized = (
+            optimizer.compute_potential_handles_for_filter(self)
+        )
 
-        # LOG.debug(
-        #    "Optimizer possible_handles: %s",
-        #    len(possible_handles),
-        # )
+        # Intersect optimizer results with possible_handles to ensure we only
+        # consider handles in the subset being filtered (important when id_list
+        # is provided and rules computed selected_handles from all handles)
+        if handles_in is not None:
+            possible_handles = possible_handles & handles_in
 
-        # if user:
-        #    user.begin_progress(_("Filter"), _("Applying ..."), len(possible_handles))
+        if handles_out is not None:
+            possible_handles = possible_handles - handles_out
 
-        # test each value in possible_handles to compute the final_list
+        LOG.debug(
+            "After optimization possible_handles: %s",
+            len(possible_handles),
+        )
+
+        # If all rules are optimized, we can skip the loop and return the optimized set directly
+        if all_optimized:
+            LOG.debug("All rules optimized, skipping loop")
+            return list(possible_handles)
+
+        # It is necessary to go through all possible handles because there
+        # may be non-optimized rules that will further reduce the set:
+        if user:
+            user.begin_progress(_("Filter"), _("Applying ..."), len(possible_handles))
+
         final_list = []
+        loop_time = time.perf_counter()
         for handle in possible_handles:
-            if handles_in is not None and handle not in handles_in:
-                continue
-            if handles_out is not None and handle in handles_out:
-                continue
-
             if user:
                 user.step_progress()
 
@@ -205,6 +218,8 @@ class GenericFilter:
 
             if apply_logical_op(db, obj, self.flist) != self.invert:
                 final_list.append(obj.handle)
+
+        LOG.debug("Loop select time: %s seconds", time.perf_counter() - loop_time)
 
         if user:
             user.end_progress()

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -46,46 +46,60 @@ class Optimizer:
 
     def compute_potential_handles_for_filter(
         self, filter: GenericFilter
-    ) -> Tuple[Set[PrimaryObjectHandle] | None, Set[PrimaryObjectHandle] | None]:
+    ) -> Tuple[Set[PrimaryObjectHandle] | None, Set[PrimaryObjectHandle] | None, bool]:
         if len(filter.flist) == 0:
-            return (None, None)
+            # Empty filters need to apply logical operation logic (and/or/one),
+            # so we can't skip the loop - return False for all_optimized
+            return (None, None, False)
 
         handles_in = None
         handles_out = None
-        for rule in filter.flist:
-            if filter.logical_op == "and" or len(filter.flist) == 1:
-                rule_in, rule_out = self.compute_potential_handles_for_rule(rule)
-                if rule_in is not None:
-                    if handles_in is None:
-                        handles_in = rule_in
-                    else:
-                        handles_in = handles_in.intersection(rule_in)
-                if rule_out is not None:
-                    if handles_out is None:
-                        handles_out = rule_out
-                    else:
-                        handles_out = handles_out.union(rule_out)
+        all_optimized = True
+
+        # For "or" and "one" operations with multiple rules, we can't fully optimize
+        if filter.logical_op in ("or", "one") and len(filter.flist) > 1:
+            all_optimized = False
+        else:
+            # For "and" operations or single rule, check if all rules are optimized
+            for rule in filter.flist:
+                if filter.logical_op == "and" or len(filter.flist) == 1:
+                    rule_in, rule_out, rule_optimized = (
+                        self.compute_potential_handles_for_rule(rule)
+                    )
+                    if not rule_optimized:
+                        all_optimized = False
+                    if rule_in is not None:
+                        if handles_in is None:
+                            handles_in = rule_in
+                        else:
+                            handles_in = handles_in.intersection(rule_in)
+                    if rule_out is not None:
+                        if handles_out is None:
+                            handles_out = rule_out
+                        else:
+                            handles_out = handles_out.union(rule_out)
 
         if filter.invert:
             handles_in, handles_out = handles_out, handles_in
+            # all_optimized flag remains unchanged after inversion
 
-        return handles_in, handles_out
+        return handles_in, handles_out, all_optimized
 
     def compute_potential_handles_for_rule(
         self,
         rule: Rule,
-    ) -> Tuple[Set[PrimaryObjectHandle] | None, Set[PrimaryObjectHandle] | None]:
+    ) -> Tuple[Set[PrimaryObjectHandle] | None, Set[PrimaryObjectHandle] | None, bool]:
         """
         Find the the handles for a particular rule.
         """
         # Has to be of the appropriate type
         if hasattr(rule, "selected_handles"):
-            return (rule.selected_handles, None)
+            return (rule.selected_handles, None, True)
         if hasattr(rule, "find_filter"):
             filter = rule.find_filter()
             if filter and self.is_same_namespace(filter):
                 return self.compute_potential_handles_for_filter(filter)
-        return (None, None)
+        return (None, None, False)
 
     def is_same_namespace(self, filter):
         """

--- a/gramps/gen/filters/rules/test/person_rules_test.py
+++ b/gramps/gen/filters/rules/test/person_rules_test.py
@@ -1164,7 +1164,8 @@ class BaseTest(unittest.TestCase):
                 ),
             )
             # This used the optimizer, so it didn't loop through DB
-            self.assertEqual(get_call_count(), 1)
+            # With full optimization, apply_to_one is never called since we use selected_handles directly
+            self.assertEqual(get_call_count(), 0)
 
     def test_isfemale_not_optimized(self):
         """


### PR DESCRIPTION
Recreated version of #2160 (closed due to loss of write access on the
original upstream branch), rebased onto current master to resolve merge
conflicts.

Before:

We needed to loop over all optimized handles, in case there was a
non-optimized rule (a rule that didn't have `selected_handles`)

After:

We now detect if there are non-optimized rules, and only loop in that
case. Otherwise we can return the optimized handles directly.