### PR TITLE
Add sub-events: let events belong to one or more super-events

### DIFF
--- a/data/grampsxml.dtd
+++ b/data/grampsxml.dtd
@@ -218,13 +218,16 @@ EVENT
 
 <!ELEMENT event (type?, (daterange|datespan|dateval|datestr)?, place?, cause?,
                  description?, attribute*, noteref*, citationref*, objref*,
-                 tagref*)>
+                 tagref*, partof*)>
 <!ATTLIST event
         id        CDATA #IMPLIED
         handle    ID    #REQUIRED
         priv      (0|1) #IMPLIED
         change    CDATA #REQUIRED
 >
+
+<!ELEMENT partof EMPTY>
+<!ATTLIST partof hlink IDREF #REQUIRED>
 
 <!--    ************************************************************
 SOURCES

--- a/data/grampsxml.rng
+++ b/data/grampsxml.rng
@@ -402,6 +402,9 @@
     <zeroOrMore><element name="tagref">
         <ref name="tagref-content"/>
     </element></zeroOrMore>
+    <zeroOrMore><element name="partof">
+        <attribute name="hlink"><data type="IDREF"/></attribute>
+    </element></zeroOrMore>
   </define>
 
   <define name="citation-content">

--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -419,7 +419,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
 
     __callback_map = {}
 
-    VERSION = (22, 0, 0)
+    VERSION = (23, 0, 0)
 
     def __init__(self, directory=None):
         DbReadBase.__init__(self)
@@ -2779,6 +2779,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
             gramps_upgrade_20,
             gramps_upgrade_21,
             gramps_upgrade_22,
+            gramps_upgrade_23,
         )
 
         if version < 14:
@@ -2799,6 +2800,8 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
             gramps_upgrade_21(self)
         if version < 22:
             gramps_upgrade_22(self)
+        if version < 23:
+            gramps_upgrade_23(self)
 
         self.rebuild_secondary(callback)
         self.reindex_reference_map(callback)

--- a/gramps/gen/db/upgrade.py
+++ b/gramps/gen/db/upgrade.py
@@ -81,6 +81,45 @@ def _upgrade_person_json_22(person_data):
     return True
 
 
+def _upgrade_event_json_23(event_data):
+    """
+    Upgrade raw Event JSON data from version 22 to 23 in place.
+    """
+    if event_data.get("super_event_list") is not None:
+        return False
+
+    event_data["super_event_list"] = []
+
+    return True
+
+
+def gramps_upgrade_23(self):
+    """
+    Upgrade database from version 22 to 23.
+
+    Rewrite Event JSON data so every Event has a super_event_list,
+    defaulting to an empty list when missing.
+    """
+    self.set_serializer("json")
+
+    length = self.get_number_of_events()
+    self.set_total(length)
+
+    self._txn_begin()
+    try:
+        for handle in self.get_event_handles():
+            json_data = self.get_raw_event_data(handle)
+            if _upgrade_event_json_23(json_data):
+                self._commit_raw(json_data, EVENT_KEY)
+            self.update()
+
+        self._set_metadata("version", 23, use_txn=False)
+        self._txn_commit()
+    except Exception:
+        self._txn_abort()
+        raise
+
+
 def gramps_upgrade_22(self):
     """
     Upgrade database from version 21 to 22.

--- a/gramps/gen/lib/event.py
+++ b/gramps/gen/lib/event.py
@@ -24,12 +24,15 @@
 Event object for Gramps.
 """
 
+from __future__ import annotations
+
 # -------------------------------------------------------------------------
 #
 # Python modules
 #
 # -------------------------------------------------------------------------
 import logging
+from typing import TYPE_CHECKING
 
 # -------------------------------------------------------------------------
 #
@@ -46,6 +49,9 @@ from .notebase import NoteBase
 from .placebase import PlaceBase
 from .primaryobj import PrimaryObject
 from .tagbase import TagBase
+
+if TYPE_CHECKING:
+    from ..types import EventHandle
 
 _ = glocale.translation.gettext
 
@@ -97,9 +103,11 @@ class Event(
         if source:
             self.__description = source.description
             self.__type = EventType(source.type)
+            self.super_event_list: list[EventHandle] = list(source.super_event_list)
         else:
             self.__description = ""
             self.__type = EventType()
+            self.super_event_list: list[EventHandle] = []
 
     def serialize(self, no_text_date=False):
         """
@@ -133,6 +141,7 @@ class Event(
             self.change,
             TagBase.serialize(self),
             self.private,
+            self.super_event_list,
         )
 
     def get_object_state(self):
@@ -216,6 +225,11 @@ class Event(
                     "title": _("Tags"),
                 },
                 "private": {"type": "boolean", "title": _("Private")},
+                "super_event_list": {
+                    "type": "array",
+                    "items": {"type": "string", "maxLength": 50},
+                    "title": _("Part of"),
+                },
             },
         }
 
@@ -242,6 +256,7 @@ class Event(
             self.change,
             tag_list,
             self.private,
+            self.super_event_list,
         ) = data
 
         self.__type = EventType()
@@ -269,6 +284,8 @@ class Event(
         """
         if classname == "Place":
             return self.place == handle
+        if classname == "Event":
+            return handle in self.super_event_list
         return False
 
     def _remove_handle_references(self, classname, handle_list):
@@ -282,6 +299,10 @@ class Event(
         """
         if classname == "Place" and self.place in handle_list:
             self.place = ""
+        if classname == "Event":
+            self.super_event_list = [
+                handle for handle in self.super_event_list if handle not in handle_list
+            ]
 
     def _replace_handle_reference(self, classname, old_handle, new_handle):
         """
@@ -296,6 +317,13 @@ class Event(
         """
         if classname == "Place" and self.place == old_handle:
             self.place = new_handle
+        if classname == "Event" and old_handle in self.super_event_list:
+            self.super_event_list = list(
+                dict.fromkeys(
+                    new_handle if handle == old_handle else handle
+                    for handle in self.super_event_list
+                )
+            )
 
     def get_text_data_list(self):
         """
@@ -350,6 +378,8 @@ class Event(
         )
         if self.place:
             ret.append(("Place", self.place))
+        for handle in self.super_event_list:
+            ret.append(("Event", handle))
         return ret
 
     def get_handle_referents(self):
@@ -427,6 +457,18 @@ class Event(
         self._merge_citation_list(acquisition)
         self._merge_media_list(acquisition)
         self._merge_tag_list(acquisition)
+        self._merge_super_event_list(acquisition)
+
+    def _merge_super_event_list(self, acquisition):
+        """
+        Add the super-events of acquisition to this event's super-event list.
+
+        :param acquisition: The event to merge with the present event.
+        :type acquisition: Event
+        """
+        for handle in acquisition.super_event_list:
+            if handle not in self.super_event_list and handle != self.handle:
+                self.super_event_list.append(handle)
 
     def set_type(self, the_type):
         """
@@ -474,3 +516,34 @@ class Event(
         None,
         "Returns or sets description of the event",
     )
+
+    def get_super_event_list(self) -> list[EventHandle]:
+        """
+        Return the list of super-event handles for the Event object.
+
+        :returns: Returns the super-event handle list for the Event
+        :rtype: list[EventHandle]
+        """
+        return self.super_event_list
+
+    def set_super_event_list(self, super_event_list: list[EventHandle]):
+        """
+        Set the super-event handle list for the Event object.
+
+        :param super_event_list: super-event handle list to assign to the Event
+        :type super_event_list: list[EventHandle]
+        """
+        self.super_event_list = super_event_list
+
+    def add_super_event(self, handle: EventHandle):
+        """
+        Add a super-event handle to the Event's super-event list.
+
+        Does nothing if the handle is already present or refers to this
+        event itself.
+
+        :param handle: handle of the super-event to add
+        :type handle: EventHandle
+        """
+        if handle != self.handle and handle not in self.super_event_list:
+            self.super_event_list.append(handle)

--- a/gramps/gen/lib/test/event_test.py
+++ b/gramps/gen/lib/test/event_test.py
@@ -1,0 +1,166 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Tests for Event.super_event_list (sub-events feature).
+
+# python3 -m unittest gramps.gen.lib.test.event_test -v
+"""
+
+import unittest
+
+from gramps.gen.lib.event import Event
+from gramps.gen.lib.json_utils import data_to_object, object_to_data, remove_object
+
+
+# -------------------------------------------------------------------------
+#
+# TestEventSuperEventList
+#
+# -------------------------------------------------------------------------
+class TestEventSuperEventList(unittest.TestCase):
+    """Tests for Event.super_event_list."""
+
+    def test_new_event_has_empty_super_event_list(self):
+        """A freshly created Event has an empty super_event_list."""
+        event = Event()
+        self.assertEqual(event.get_super_event_list(), [])
+
+    def test_copy_constructor_copies_super_event_list(self):
+        """Copying an Event copies its super_event_list, not a shared reference."""
+        source = Event()
+        source.add_super_event("super-h1")
+        copy = Event(source)
+        self.assertEqual(copy.get_super_event_list(), ["super-h1"])
+        copy.add_super_event("super-h2")
+        self.assertEqual(source.get_super_event_list(), ["super-h1"])
+
+    def test_add_super_event(self):
+        """add_super_event appends a new handle."""
+        event = Event()
+        event.add_super_event("super-h1")
+        self.assertEqual(event.get_super_event_list(), ["super-h1"])
+
+    def test_add_super_event_no_duplicate(self):
+        """add_super_event does not add the same handle twice."""
+        event = Event()
+        event.add_super_event("super-h1")
+        event.add_super_event("super-h1")
+        self.assertEqual(event.get_super_event_list(), ["super-h1"])
+
+    def test_add_super_event_rejects_self_reference(self):
+        """add_super_event refuses to add the event's own handle."""
+        event = Event()
+        event.set_handle("self-h1")
+        event.add_super_event("self-h1")
+        self.assertEqual(event.get_super_event_list(), [])
+
+    def test_set_super_event_list(self):
+        """set_super_event_list replaces the whole list."""
+        event = Event()
+        event.set_super_event_list(["h1", "h2"])
+        self.assertEqual(event.get_super_event_list(), ["h1", "h2"])
+
+    def test_has_handle_reference(self):
+        """has_handle_reference("Event", ...) checks super_event_list."""
+        event = Event()
+        event.add_super_event("super-h1")
+        self.assertTrue(event.has_handle_reference("Event", "super-h1"))
+        self.assertFalse(event.has_handle_reference("Event", "super-h2"))
+
+    def test_remove_handle_references(self):
+        """remove_handle_references("Event", ...) drops matching handles."""
+        event = Event()
+        event.set_super_event_list(["h1", "h2", "h3"])
+        event.remove_handle_references("Event", ["h1", "h3"])
+        self.assertEqual(event.get_super_event_list(), ["h2"])
+
+    def test_replace_handle_reference(self):
+        """replace_handle_reference("Event", ...) swaps a super-event handle."""
+        event = Event()
+        event.set_super_event_list(["h1", "h2"])
+        event.replace_handle_reference("Event", "h1", "h3")
+        self.assertEqual(event.get_super_event_list(), ["h3", "h2"])
+
+    def test_replace_handle_reference_dedups(self):
+        """Replacing a handle that collides with an existing one is deduped."""
+        event = Event()
+        event.set_super_event_list(["h1", "h2"])
+        event.replace_handle_reference("Event", "h1", "h2")
+        self.assertEqual(event.get_super_event_list(), ["h2"])
+
+    def test_get_referenced_handles_includes_super_events(self):
+        """get_referenced_handles reports ("Event", handle) for super-events."""
+        event = Event()
+        event.set_super_event_list(["h1", "h2"])
+        refs = event.get_referenced_handles()
+        self.assertIn(("Event", "h1"), refs)
+        self.assertIn(("Event", "h2"), refs)
+
+    def test_merge_unions_super_event_list(self):
+        """merge() unions the acquisition's super_event_list into self."""
+        phoenix = Event()
+        phoenix.set_super_event_list(["h1"])
+        titanic = Event()
+        titanic.set_super_event_list(["h2"])
+        phoenix.merge(titanic)
+        self.assertEqual(phoenix.get_super_event_list(), ["h1", "h2"])
+
+    def test_merge_dedups_super_event_list(self):
+        """merge() does not duplicate a super-event present on both sides."""
+        phoenix = Event()
+        phoenix.set_super_event_list(["h1"])
+        titanic = Event()
+        titanic.set_super_event_list(["h1"])
+        phoenix.merge(titanic)
+        self.assertEqual(phoenix.get_super_event_list(), ["h1"])
+
+    def test_merge_drops_self_reference(self):
+        """merge() will not let the merged event become its own super-event."""
+        phoenix = Event()
+        phoenix.set_handle("new-h1")
+        phoenix.set_super_event_list([])
+        titanic = Event()
+        titanic.set_super_event_list(["new-h1"])
+        phoenix.merge(titanic)
+        self.assertEqual(phoenix.get_super_event_list(), [])
+
+    def test_serialize_round_trip(self):
+        """super_event_list survives a serialize()/unserialize() round trip."""
+        event = Event()
+        event.set_super_event_list(["h1", "h2"])
+        restored = Event()
+        restored.unserialize(event.serialize())
+        self.assertEqual(restored.get_super_event_list(), ["h1", "h2"])
+
+    def test_json_round_trip(self):
+        """super_event_list survives get_object_state/set_object_state (JSON path)."""
+        event = Event()
+        event.set_super_event_list(["h1", "h2"])
+        data = remove_object(object_to_data(event))
+        restored = data_to_object(data)
+        self.assertEqual(restored.get_super_event_list(), ["h1", "h2"])
+
+    def test_get_schema_declares_super_event_list(self):
+        """get_schema() documents the super_event_list field."""
+        schema = Event.get_schema()
+        self.assertIn("super_event_list", schema["properties"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gen/lib/test/merge_test.py
+++ b/gramps/gen/lib/test/merge_test.py
@@ -409,6 +409,30 @@ class EventCheck(
         self.titanic = Event(self.phoenix)
         self.ref_obj = Event(self.phoenix)
 
+    def test_super_event_list_merge(self):
+        self.titanic.add_super_event("123456")
+        self.ref_obj.add_super_event("123456")
+        self.phoenix.merge(self.titanic)
+        self.assertEqual(self.phoenix.serialize(), self.ref_obj.serialize())
+
+    def test_super_event_list_merge_dedup(self):
+        self.phoenix.add_super_event("123456")
+        self.titanic.add_super_event("123456")
+        self.ref_obj.add_super_event("123456")
+        self.phoenix.merge(self.titanic)
+        self.assertEqual(self.phoenix.serialize(), self.ref_obj.serialize())
+
+    def test_replace_super_event_absent(self):
+        self.phoenix.add_super_event("123456")
+        self.ref_obj.add_super_event("654321")
+        self.phoenix.replace_handle_reference("Event", "123456", "654321")
+        self.assertEqual(self.phoenix.serialize(), self.ref_obj.serialize())
+
+    def test_remove_super_event_references(self):
+        self.phoenix.add_super_event("123456")
+        self.phoenix.remove_handle_references("Event", ["123456"])
+        self.assertEqual(self.phoenix.serialize(), self.ref_obj.serialize())
+
 
 class EventRefCheck(unittest.TestCase, PrivacyBaseTest, NoteBaseTest, AttrBaseTest):
     def setUp(self):

--- a/gramps/gen/merge/mergeeventquery.py
+++ b/gramps/gen/merge/mergeeventquery.py
@@ -26,7 +26,7 @@ Provide merge capabilities for events.
 # Gramps modules
 #
 # -------------------------------------------------------------------------
-from ..lib import Person, Family, Note
+from ..lib import Event, Person, Family, Note
 from ..db import DbTxn
 from ..const import GRAMPS_LOCALE as glocale
 
@@ -90,6 +90,18 @@ class MergeEventQuery:
                     assert note.has_handle_reference("Event", old_handle)
                     note.replace_handle_reference("Event", old_handle, new_handle)
                     self.database.commit_note(note, trans)
+                elif class_name == Event.__name__:
+                    event = self.database.get_event_from_handle(handle)
+                    assert event.has_handle_reference("Event", old_handle)
+                    if handle == new_handle:
+                        # phoenix referred to titanic as a super-event; now
+                        # that titanic has become phoenix, drop the
+                        # reference instead of making phoenix its own
+                        # super-event.
+                        event.remove_handle_references("Event", [old_handle])
+                    else:
+                        event.replace_handle_reference("Event", old_handle, new_handle)
+                    self.database.commit_event(event, trans)
                 else:
                     raise MergeError(
                         "Encounter an object of type %s that has "

--- a/gramps/gen/merge/test/mergeeventquery_test.py
+++ b/gramps/gen/merge/test/mergeeventquery_test.py
@@ -1,0 +1,118 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Tests for MergeEventQuery and Event super_event_list backlinks.
+
+# python3 -m unittest gramps.gen.merge.test.mergeeventquery_test -v
+"""
+
+# -------------------------------------------------------------------------
+#
+# Standard python modules
+#
+# -------------------------------------------------------------------------
+import unittest
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from gramps.gen.utils.id import set_det_id
+from gramps.gen.db import DbTxn
+from gramps.gen.db.utils import make_database
+from gramps.gen.dbstate import DbState
+from gramps.cli.clidbman import CLIDbManager
+from gramps.gen.lib import Event, EventType
+from gramps.gen.merge import MergeEventQuery
+
+
+class MergeEventQueryTest(unittest.TestCase):
+    param = "sqlite"
+
+    def setUp(self):
+        set_det_id(True)
+        self.dbstate = DbState()
+        self.dbman = CLIDbManager(self.dbstate)
+        dirpath, _name = self.dbman.create_new_db_cli(
+            "Test: MergeEventQuery", dbid=self.param
+        )
+        self.db = make_database(self.param)
+        self.db.load(dirpath, None)
+        self.dbstate.change_database_noclose(self.db)
+
+    def tearDown(self):
+        self.db.close()
+        self.dbman.remove_database("Test: MergeEventQuery")
+
+    def _add_event(self, description, super_event_list=None):
+        event = Event()
+        event.set_type(EventType.CUSTOM)
+        event.set_description(description)
+        event.set_super_event_list(super_event_list or [])
+        with DbTxn("add event", self.db) as trans:
+            self.db.add_event(event, trans)
+        return event
+
+    def test_merge_super_event_updates_sub_event_backlink(self):
+        """Merging a super-event updates the sub-event's super_event_list."""
+        super_a = self._add_event("Super A")
+        super_b = self._add_event("Super B")
+        sub = self._add_event("Sub", super_event_list=[super_b.handle])
+
+        query = MergeEventQuery(self.dbstate, super_a, super_b)
+        query.execute()
+
+        updated_sub = self.db.get_event_from_handle(sub.handle)
+        self.assertEqual(updated_sub.get_super_event_list(), [super_a.handle])
+        with self.assertRaises(Exception):
+            self.db.get_event_from_handle(super_b.handle)
+
+    def test_merge_does_not_create_self_reference(self):
+        """Merging a super-event into its own sub-event drops the stale link
+        instead of making the result its own super-event."""
+        super_event = self._add_event("Super")
+        sub = self._add_event("Sub", super_event_list=[super_event.handle])
+
+        # sub (phoenix) absorbs super_event (titanic): sub was a sub-event
+        # of super_event, so after the merge sub must not reference itself.
+        query = MergeEventQuery(self.dbstate, sub, super_event)
+        query.execute()
+
+        updated_sub = self.db.get_event_from_handle(sub.handle)
+        self.assertEqual(updated_sub.get_super_event_list(), [])
+        self.assertNotIn(sub.handle, updated_sub.get_super_event_list())
+
+    def test_merge_unrelated_events_leaves_super_event_lists_untouched(self):
+        """Merging events unrelated to any sub-event hierarchy is a no-op
+        for other events' super_event_list."""
+        top = self._add_event("Top")
+        sub = self._add_event("Sub", super_event_list=[top.handle])
+        other_a = self._add_event("Other A")
+        other_b = self._add_event("Other B")
+
+        query = MergeEventQuery(self.dbstate, other_a, other_b)
+        query.execute()
+
+        updated_sub = self.db.get_event_from_handle(sub.handle)
+        self.assertEqual(updated_sub.get_super_event_list(), [top.handle])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gen/utils/db.py
+++ b/gramps/gen/utils/db.py
@@ -21,12 +21,15 @@
 Utilities for getting information from the database.
 """
 
+from __future__ import annotations
+
 # -------------------------------------------------------------------------
 #
 # Standard python modules
 #
 # -------------------------------------------------------------------------
 import logging
+from typing import TYPE_CHECKING
 
 # -------------------------------------------------------------------------
 #
@@ -36,7 +39,12 @@ import logging
 from ..const import GRAMPS_LOCALE as glocale
 from ..display.name import displayer as name_displayer
 from ..display.place import displayer as place_displayer
+from ..errors import HandleError
 from ..lib import EventType, EventRoleType, NameOriginType, Surname
+
+if TYPE_CHECKING:
+    from ..db.base import DbReadBase
+    from ..types import EventHandle
 
 _ = glocale.translation.sgettext
 
@@ -487,6 +495,54 @@ def for_each_ancestor(db, start, func, data):
                     todo.append(mother_handle)
         done_ids.add(person_handle)
     return 0
+
+
+# -------------------------------------------------------------------------
+#
+# Detect event super-event cycles.
+#
+# -------------------------------------------------------------------------
+def event_creates_cycle(
+    db: DbReadBase,
+    event_handle: EventHandle,
+    candidate_super_handle: EventHandle,
+) -> bool:
+    """
+    Return True if adding candidate_super_handle as a super-event of the
+    event at event_handle would create a cycle.
+
+    This walks the ancestry of candidate_super_handle looking for
+    event_handle. If found, event_handle is already an ancestor of
+    candidate_super_handle, so making candidate_super_handle a super-event
+    of event_handle would close a loop.
+
+    :param db: database to query
+    :type db: DbReadBase
+    :param event_handle: handle of the event that would gain a super-event
+    :type event_handle: EventHandle
+    :param candidate_super_handle: handle of the proposed super-event
+    :type candidate_super_handle: EventHandle
+    :returns: True if the addition would create a cycle
+    :rtype: bool
+    """
+    if event_handle == candidate_super_handle:
+        return True
+
+    todo = [candidate_super_handle]
+    seen = set()
+    while todo:
+        handle = todo.pop()
+        if handle == event_handle:
+            return True
+        if handle in seen:
+            continue
+        seen.add(handle)
+        try:
+            event = db.get_event_from_handle(handle)
+        except HandleError:
+            continue
+        todo.extend(event.get_super_event_list())
+    return False
 
 
 # -------------------------------------------------------------------------

--- a/gramps/gen/utils/test/db_test.py
+++ b/gramps/gen/utils/test/db_test.py
@@ -1,0 +1,135 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Tests for event_creates_cycle in gen/utils/db.py.
+
+# python3 -m unittest gramps.gen.utils.test.db_test -v
+"""
+
+# -------------------------------------------------------------------------
+#
+# Standard python modules
+#
+# -------------------------------------------------------------------------
+import unittest
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from gramps.gen.errors import HandleError
+from gramps.gen.lib import Event
+from gramps.gen.utils.db import event_creates_cycle
+
+
+# -------------------------------------------------------------------------
+#
+# FakeCycleDb
+#
+# -------------------------------------------------------------------------
+class FakeCycleDb:
+    """
+    Minimal database stub exposing only get_event_from_handle, keyed on
+    a plain dict of handle -> Event.
+    """
+
+    def __init__(self, events):
+        self.events = events
+
+    def get_event_from_handle(self, handle):
+        if handle not in self.events:
+            raise HandleError(f"Handle {handle} not found")
+        return self.events[handle]
+
+
+def _make_event(handle, super_event_list=None):
+    event = Event()
+    event.set_handle(handle)
+    event.set_super_event_list(super_event_list or [])
+    return event
+
+
+# -------------------------------------------------------------------------
+#
+# TestEventCreatesCycle
+#
+# -------------------------------------------------------------------------
+class TestEventCreatesCycle(unittest.TestCase):
+    """Tests for event_creates_cycle."""
+
+    def test_no_cycle_for_unrelated_events(self):
+        db = FakeCycleDb(
+            {
+                "a": _make_event("a"),
+                "b": _make_event("b"),
+            }
+        )
+        self.assertFalse(event_creates_cycle(db, "a", "b"))
+
+    def test_direct_self_reference_is_a_cycle(self):
+        db = FakeCycleDb({"a": _make_event("a")})
+        self.assertTrue(event_creates_cycle(db, "a", "a"))
+
+    def test_direct_cycle_detected(self):
+        # b is already a super-event of a; making b a sub-event of a
+        # (i.e. a a super-event of b) would close a 2-cycle.
+        db = FakeCycleDb(
+            {
+                "a": _make_event("a", ["b"]),
+                "b": _make_event("b"),
+            }
+        )
+        self.assertTrue(event_creates_cycle(db, "b", "a"))
+
+    def test_indirect_cycle_detected(self):
+        # a -> b -> c (c is a's ancestor via b). Making c a sub-event of a
+        # would close the loop a -> b -> c -> a.
+        db = FakeCycleDb(
+            {
+                "a": _make_event("a", ["b"]),
+                "b": _make_event("b", ["c"]),
+                "c": _make_event("c"),
+            }
+        )
+        self.assertTrue(event_creates_cycle(db, "c", "a"))
+
+    def test_dag_shared_ancestor_is_not_a_cycle(self):
+        # Both b and c are sub-events of a (a DAG, not a cycle):
+        # a
+        # |-- b
+        # |-- c
+        # Adding a as a super-event of neither b nor c creates a cycle;
+        # proposing b as a super-event of c (unrelated branch) is fine too.
+        db = FakeCycleDb(
+            {
+                "a": _make_event("a"),
+                "b": _make_event("b", ["a"]),
+                "c": _make_event("c", ["a"]),
+            }
+        )
+        self.assertFalse(event_creates_cycle(db, "c", "b"))
+
+    def test_missing_handle_is_ignored(self):
+        db = FakeCycleDb({"a": _make_event("a", ["missing"])})
+        self.assertFalse(event_creates_cycle(db, "z", "a"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gui/editors/displaytabs/__init__.py
+++ b/gramps/gui/editors/displaytabs/__init__.py
@@ -63,4 +63,5 @@ from .repoembedlist import RepoEmbedList
 from .surnametab import SurnameTab
 from .sourcebackreflist import SourceBackRefList
 from .srcattrembedlist import SrcAttrEmbedList
+from .supereventembedlist import SuperEventEmbedList
 from .webembedlist import WebEmbedList

--- a/gramps/gui/editors/displaytabs/supereventembedlist.py
+++ b/gramps/gui/editors/displaytabs/supereventembedlist.py
@@ -1,0 +1,184 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+# -------------------------------------------------------------------------
+#
+# Python classes
+#
+# -------------------------------------------------------------------------
+from gi.repository import GLib
+
+# -------------------------------------------------------------------------
+#
+# Gramps classes
+#
+# -------------------------------------------------------------------------
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+
+_ = glocale.translation.gettext
+from gramps.gen.lib import Event
+from gramps.gen.errors import WindowActiveError
+from .embeddedlist import EmbeddedList, TEXT_COL
+from .supereventmodel import SuperEventModel
+from ...selectors import SelectorFactory
+from ...dbguielement import DbGUIElement
+
+
+# -------------------------------------------------------------------------
+#
+# SuperEventEmbedList
+#
+# -------------------------------------------------------------------------
+class SuperEventEmbedList(DbGUIElement, EmbeddedList):
+    """
+    Displays the "Part of" list: the super-events of the event being
+    edited, i.e. the events this one is a sub-event of.
+    """
+
+    _HANDLE_COL = 3
+    _DND_TYPE = None
+
+    _column_names = [
+        (_("ID"), 0, 75, TEXT_COL, -1, None),
+        (_("Type"), 1, 100, TEXT_COL, -1, None),
+        (_("Description"), 2, 250, TEXT_COL, -1, None),
+    ]
+
+    def __init__(self, dbstate, uistate, track, data, config_key, handle, callback):
+        self.data = data
+        self.handle = handle
+        self.callback = callback
+        DbGUIElement.__init__(self, dbstate.db)
+        EmbeddedList.__init__(
+            self,
+            dbstate,
+            uistate,
+            track,
+            _("Part of"),
+            SuperEventModel,
+            config_key,
+            share_button=True,
+            move_buttons=True,
+        )
+
+    def _connect_db_signals(self):
+        """
+        called on init of DbGUIElement, connect to db as required.
+        """
+        # note: event-rebuild closes the editors, so no need to connect to it
+        self.callman.register_callbacks(
+            {
+                "event-update": self.event_change,  # change to event we track
+                "event-delete": self.event_delete,  # delete of event we track
+            }
+        )
+        self.callman.connect_all(keys=["event"])
+
+    def event_change(self, *obj):
+        """
+        Callback method called when a tracked super-event changes (type,
+        description, ...).
+        """
+        self.rebuild()
+
+    def event_delete(self, hndls):
+        """
+        Callback method called when a tracked super-event is deleted.
+        Remove it from the list so no dangling reference is shown.
+        """
+        for handle in hndls:
+            if handle in self.data:
+                self.data.remove(handle)
+        self.rebuild()
+
+    def get_data(self):
+        self.callman.register_handles({"event": list(self.data)})
+        return self.data
+
+    def column_order(self):
+        return ((1, 0), (1, 1), (1, 2))
+
+    def get_icon_name(self):
+        return "gramps-event"
+
+    def get_skip_list(self, handle):
+        """
+        Return the handles that must not be offered as a super-event for
+        handle: itself, its own (recursive) sub-events -- selecting one of
+        those would close a cycle -- and events already in the list.
+        """
+        todo = [handle]
+        skip = [handle]
+        while todo:
+            current = todo.pop()
+            for _cls, child in self.dbstate.db.find_backlink_handles(
+                current, ["Event"]
+            ):
+                if child not in skip:
+                    todo.append(child)
+                    skip.append(child)
+        for existing in self.data:
+            if existing not in skip:
+                skip.append(existing)
+        return skip
+
+    def add_button_clicked(self, obj):
+        event = Event()
+        try:
+            from .. import EditEvent
+
+            EditEvent(self.dbstate, self.uistate, self.track, event, self.add_callback)
+        except WindowActiveError:
+            pass
+
+    def add_callback(self, event):
+        self._add_super_event(event.get_handle())
+
+    def share_button_clicked(self, obj):
+        SelectEvent = SelectorFactory("Event")
+
+        sel = SelectEvent(
+            self.dbstate, self.uistate, self.track, skip=self.get_skip_list(self.handle)
+        )
+        event = sel.run()
+        if event:
+            self._add_super_event(event.get_handle())
+
+    def _add_super_event(self, handle):
+        data = self.get_data()
+        if handle in data:
+            return
+        data.append(handle)
+        self.changed = True
+        self.rebuild()
+        GLib.idle_add(self.tree.scroll_to_cell, len(data) - 1)
+
+    def edit_button_clicked(self, obj):
+        handle = self.get_selected()
+        if handle:
+            event = self.dbstate.db.get_event_from_handle(handle)
+            try:
+                from .. import EditEvent
+
+                EditEvent(self.dbstate, self.uistate, self.track, event)
+            except WindowActiveError:
+                pass
+
+    def post_rebuild(self, prebuildpath):
+        self.callback()

--- a/gramps/gui/editors/displaytabs/supereventmodel.py
+++ b/gramps/gui/editors/displaytabs/supereventmodel.py
@@ -1,0 +1,53 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+# -------------------------------------------------------------------------
+#
+# GTK libraries
+#
+# -------------------------------------------------------------------------
+from gi.repository import Gtk
+
+
+# -------------------------------------------------------------------------
+#
+# SuperEventModel
+#
+# -------------------------------------------------------------------------
+class SuperEventModel(Gtk.ListStore):
+    """
+    Model backing the "Part of" list on the event editor.
+
+    Each row shows the Gramps ID, type, and description of a super-event
+    referenced by handle in the event's super_event_list.
+    """
+
+    def __init__(self, handle_list, db):
+        Gtk.ListStore.__init__(self, str, str, str, str)
+        self.db = db
+        for handle in handle_list:
+            event = self.db.get_event_from_handle(handle)
+            self.append(
+                row=[
+                    event.get_gramps_id(),
+                    str(event.get_type()),
+                    event.get_description(),
+                    handle,
+                ]
+            )

--- a/gramps/gui/editors/editevent.py
+++ b/gramps/gui/editors/editevent.py
@@ -54,6 +54,7 @@ from .displaytabs import (
     GalleryTab,
     EventBackRefList,
     EventAttrEmbedList,
+    SuperEventEmbedList,
 )
 from ..widgets import (
     MonitoredEntry,
@@ -250,6 +251,17 @@ class EditEvent(EditPrimary):
         )
         self._add_tab(notebook, self.attr_list)
 
+        self.super_event_list = SuperEventEmbedList(
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_super_event_list(),
+            "event_editor_super_events",
+            self.obj.handle,
+            lambda: None,
+        )
+        self._add_tab(notebook, self.super_event_list)
+
         handle_list = self.dbstate.db.find_backlink_handles(self.obj.handle)
         self.backref_list = EventBackRefList(
             self.dbstate,
@@ -269,6 +281,7 @@ class EditEvent(EditPrimary):
         self.track_ref_for_deletion("note_list")
         self.track_ref_for_deletion("gallery_list")
         self.track_ref_for_deletion("attr_list")
+        self.track_ref_for_deletion("super_event_list")
         self.track_ref_for_deletion("backref_list")
 
     def build_menu_names(self, event):

--- a/gramps/gui/views/treemodels/__init__.py
+++ b/gramps/gui/views/treemodels/__init__.py
@@ -23,7 +23,7 @@ Package init for the treemodels package.
 
 from .peoplemodel import PeopleBaseModel, PersonListModel, PersonTreeModel
 from .familymodel import FamilyModel
-from .eventmodel import EventModel
+from .eventmodel import EventModel, EventTreeModel
 from .sourcemodel import SourceModel
 from .placemodel import PlaceBaseModel, PlaceListModel, PlaceTreeModel
 from .mediamodel import MediaModel

--- a/gramps/gui/views/treemodels/eventmodel.py
+++ b/gramps/gui/views/treemodels/eventmodel.py
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2000-2006  Donald N. Allingham
 # Copyright (C) 2024       Doug Blank
+# Copyright (C) 2026       Doug Blank
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -41,33 +42,33 @@ from gi.repository import Gtk
 #
 # -------------------------------------------------------------------------
 from gramps.gen.datehandler import format_time, get_date, get_date_valid
+from gramps.gen.db.generic import Cursor
 from gramps.gen.lib import Event, EventType
 from gramps.gen.lib.json_utils import data_to_object
 from gramps.gen.utils.db import get_participant_from_event
 from gramps.gen.display.place import displayer as place_displayer
 from gramps.gen.config import config
 from .flatbasemodel import FlatBaseModel
+from .treebasemodel import TreeBaseModel
 from gramps.gen.const import GRAMPS_LOCALE as glocale
+
+_ = glocale.translation.gettext
 
 INVALID_DATE_FORMAT = config.get("preferences.invalid-date-format")
 
 
 # -------------------------------------------------------------------------
 #
-# EventModel
+# EventBaseModel
 #
 # -------------------------------------------------------------------------
-class EventModel(FlatBaseModel):
-    def __init__(
-        self,
-        db,
-        uistate,
-        scol=0,
-        order=Gtk.SortType.ASCENDING,
-        search=None,
-        skip=set(),
-        sort_map=None,
-    ):
+class EventBaseModel:
+    """
+    Column definitions shared by the flat (:class:`EventModel`) and
+    hierarchical (:class:`EventTreeModel`) event models.
+    """
+
+    def __init__(self, db):
         self.gen_cursor = db.get_event_cursor
         self.map = db.get_raw_event_data
 
@@ -95,9 +96,6 @@ class EventModel(FlatBaseModel):
             self.column_participant,
             self.column_tag_color,
         ]
-        FlatBaseModel.__init__(
-            self, db, uistate, scol, order, search=search, skip=skip, sort_map=sort_map
-        )
 
     def destroy(self):
         """
@@ -108,7 +106,6 @@ class EventModel(FlatBaseModel):
         self.map = None
         self.fmap = None
         self.smap = None
-        FlatBaseModel.destroy(self)
 
     def color_column(self):
         """
@@ -223,3 +220,151 @@ class EventModel(FlatBaseModel):
         tag_list = list(map(self.get_tag_name, data.tag_list))
         # TODO for Arabic, should the next line's comma be translated?
         return ", ".join(sorted(tag_list, key=glocale.sort_key))
+
+
+# -------------------------------------------------------------------------
+#
+# EventModel
+#
+# -------------------------------------------------------------------------
+class EventModel(EventBaseModel, FlatBaseModel):
+    """
+    Flat event model.
+    """
+
+    def __init__(
+        self,
+        db,
+        uistate,
+        scol=0,
+        order=Gtk.SortType.ASCENDING,
+        search=None,
+        skip=set(),
+        sort_map=None,
+    ):
+        EventBaseModel.__init__(self, db)
+        FlatBaseModel.__init__(
+            self, db, uistate, scol, order, search=search, skip=skip, sort_map=sort_map
+        )
+
+    def destroy(self):
+        """
+        Unset all elements that can prevent garbage collection
+        """
+        EventBaseModel.destroy(self)
+        FlatBaseModel.destroy(self)
+
+
+# -------------------------------------------------------------------------
+#
+# EventTreeModel
+#
+# -------------------------------------------------------------------------
+class EventTreeModel(EventBaseModel, TreeBaseModel):
+    """
+    Hierarchical event model, showing sub-events under their super-event.
+
+    An event with more than one super-event (``super_event_list``) is
+    placed under the first one; the "Part of" tab in the event editor
+    remains the authoritative view of every super-event relationship.
+    This mirrors how :class:`~.placemodel.PlaceTreeModel` places a Place
+    under only the first of its ``placeref_list`` entries.
+    """
+
+    def __init__(
+        self,
+        db,
+        uistate,
+        scol=0,
+        order=Gtk.SortType.ASCENDING,
+        search=None,
+        skip=set(),
+        sort_map=None,
+    ):
+        EventBaseModel.__init__(self, db)
+        TreeBaseModel.__init__(
+            self,
+            db,
+            uistate,
+            scol=scol,
+            order=order,
+            search=search,
+            skip=skip,
+            sort_map=sort_map,
+            nrgroups=1,
+            group_can_have_handle=True,
+        )
+
+    def destroy(self):
+        """
+        Unset all elements that can prevent garbage collection
+        """
+        EventBaseModel.destroy(self)
+        TreeBaseModel.destroy(self)
+
+    def _set_base_data(self):
+        """See TreeBaseModel; most has been set in EventBaseModel.__init__."""
+        self.number_items = self.db.get_number_of_events
+        self.gen_cursor = self._get_event_tree_cursor
+
+    def _get_event_tree_cursor(self):
+        return Cursor(self._iter_event_tree_data)
+
+    def _iter_event_tree_data(self):
+        """
+        Yield (handle, data) for every event, parents before children, so
+        that TreeBaseModel.add_row can place each event under its primary
+        super-event. Events unreachable from a root (e.g. a data-entry
+        cycle that slipped past the editor's guard) are yielded last,
+        rather than silently dropped.
+        """
+        all_data = dict(self.db.get_event_cursor())
+        children = {}
+        roots = []
+        for handle, data in all_data.items():
+            super_list = data.super_event_list
+            parent = super_list[0] if super_list else None
+            if parent not in all_data:
+                parent = None
+            if parent is None:
+                roots.append(handle)
+            else:
+                children.setdefault(parent, []).append(handle)
+
+        visited = set()
+        queue = list(roots)
+        while queue:
+            handle = queue.pop(0)
+            if handle in visited:
+                continue
+            visited.add(handle)
+            yield (handle, all_data[handle])
+            queue.extend(children.get(handle, []))
+
+        for handle, data in all_data.items():
+            if handle not in visited:
+                yield (handle, data)
+
+    def get_tree_levels(self):
+        """
+        Return the headings of the levels in the hierarchy.
+        """
+        return [_("Event")]
+
+    def add_row(self, handle, data):
+        """
+        Add a node to the node map for a single event.
+
+        handle      The handle of the gramps object.
+        data        The object data.
+        """
+        sort_key = self.sort_func(data)
+        super_list = data.super_event_list
+        parent = super_list[0] if super_list else None
+
+        # Add the node as a root node if the parent is not in the tree.
+        # This will happen when the view is filtered.
+        if not self._get_node(parent):
+            parent = None
+
+        self.add_node(parent, handle, sort_key, handle, add_parent=False)

--- a/gramps/plugins/db/dbapi/test/upgrade_test.py
+++ b/gramps/plugins/db/dbapi/test/upgrade_test.py
@@ -70,13 +70,20 @@ def _ensure_test_resources():
 os.environ["GRAMPS_RESOURCES"] = _ensure_test_resources()
 os.environ["HOME"] = os.environ.get("HOME") or tempfile.mkdtemp(prefix="gramps-home-")
 
-dialog_module = types.ModuleType("gramps.gui.dialog")
-setattr(dialog_module, "InfoDialog", object)
-sys.modules.setdefault("gramps.gui.dialog", dialog_module)
+_dialog_stub_installed = "gramps.gui.dialog" not in sys.modules
+if _dialog_stub_installed:
+    dialog_module = types.ModuleType("gramps.gui.dialog")
+    setattr(dialog_module, "InfoDialog", object)
+    sys.modules["gramps.gui.dialog"] = dialog_module
 
+from gramps.gen.db.dbconst import EVENT_KEY, PERSON_KEY
+from gramps.gen.db.upgrade import gramps_upgrade_22, gramps_upgrade_23
 
-from gramps.gen.db.dbconst import PERSON_KEY
-from gramps.gen.db.upgrade import gramps_upgrade_22
+if _dialog_stub_installed:
+    # Don't leave the stub in sys.modules: later test modules in the same
+    # process (e.g. discover runs) that need the real gramps.gui.dialog
+    # would otherwise silently get this fake one instead.
+    del sys.modules["gramps.gui.dialog"]
 
 DEFAULT_FAMILYSEARCH_SYNC_JSON = {
     "_class": "FamilySearchSync",
@@ -96,8 +103,9 @@ class FakeUpgradeDb:
     Minimal database stub for testing schema upgrade functions.
     """
 
-    def __init__(self, people):
-        self.people = copy.deepcopy(people)
+    def __init__(self, people=None, events=None):
+        self.people = copy.deepcopy(people) if people else {}
+        self.events = copy.deepcopy(events) if events else {}
         self.metadata = {}
         self.total = None
         self.serializer_name = None
@@ -113,6 +121,9 @@ class FakeUpgradeDb:
     def get_number_of_people(self):
         return len(self.people)
 
+    def get_number_of_events(self):
+        return len(self.events)
+
     def set_total(self, total):
         self.total = total
 
@@ -122,15 +133,24 @@ class FakeUpgradeDb:
     def get_person_handles(self):
         return list(self.people.keys())
 
+    def get_event_handles(self):
+        return list(self.events.keys())
+
     def get_raw_person_data(self, handle):
         return self.people[handle]
+
+    def get_raw_event_data(self, handle):
+        return self.events[handle]
 
     def get_person_from_handle(self, handle):
         raise AssertionError("gramps_upgrade_22 should use raw person JSON only")
 
     def _commit_raw(self, data, obj_key):
         self.commits.append((copy.deepcopy(data), obj_key))
-        self.people[data["handle"]] = copy.deepcopy(data)
+        if obj_key == EVENT_KEY:
+            self.events[data["handle"]] = copy.deepcopy(data)
+        else:
+            self.people[data["handle"]] = copy.deepcopy(data)
 
     def update(self):
         self.updates += 1
@@ -194,6 +214,37 @@ class DbUpgradeTest(unittest.TestCase):
             DEFAULT_FAMILYSEARCH_SYNC_JSON,
         )
         self.assertEqual(db.people["person-2"]["familysearch_sync"], existing_sync)
+
+    def test_upgrade_23_updates_raw_event_json_without_event_model(self):
+        db = FakeUpgradeDb(
+            events={
+                "event-1": {
+                    "_class": "Event",
+                    "handle": "event-1",
+                    "gramps_id": "E0001",
+                },
+                "event-2": {
+                    "_class": "Event",
+                    "handle": "event-2",
+                    "gramps_id": "E0002",
+                    "super_event_list": ["event-1"],
+                },
+            }
+        )
+
+        gramps_upgrade_23(db)
+
+        self.assertEqual(db.serializer_name, "json")
+        self.assertEqual(db.total, 2)
+        self.assertTrue(db.txn_started)
+        self.assertTrue(db.txn_committed)
+        self.assertFalse(db.txn_aborted)
+        self.assertEqual(db.updates, 2)
+        self.assertEqual(db.metadata["version"], 23)
+        self.assertEqual(len(db.commits), 1)
+        self.assertEqual(db.commits[0][1], EVENT_KEY)
+        self.assertEqual(db.events["event-1"]["super_event_list"], [])
+        self.assertEqual(db.events["event-2"]["super_event_list"], ["event-1"])
 
 
 if __name__ == "__main__":

--- a/gramps/plugins/export/exportxml.py
+++ b/gramps/plugins/export/exportxml.py
@@ -850,6 +850,9 @@ class GrampsXmlWriter(UpdateCallback):
         for tag_handle in event.get_tag_list():
             self.write_ref("tagref", tag_handle, index + 1)
 
+        for super_handle in event.get_super_event_list():
+            self.write_ref("partof", super_handle, index + 1)
+
         self.g.write("%s</event>\n" % sp)
 
     def dump_ordinance(self, ord, index=1):

--- a/gramps/plugins/export/test/exportxml_partof_test.py
+++ b/gramps/plugins/export/test/exportxml_partof_test.py
@@ -1,0 +1,101 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Round-trip test for Event.super_event_list through Gramps XML.
+
+# python3 -m unittest gramps.plugins.export.test.exportxml_partof_test -v
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+
+from gramps.cli.user import User
+from gramps.gen.db import DbTxn
+from gramps.gen.db.utils import make_database
+from gramps.gen.lib import Event, EventType
+from gramps.plugins.export.exportxml import export_data
+from gramps.plugins.importer.importxml import importData
+
+
+class ExportImportPartOfTest(unittest.TestCase):
+    """Tests that super_event_list survives an XML export/import round trip."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
+
+    def _make_source_db(self):
+        db = make_database("sqlite")
+        source_dir = os.path.join(self.tmpdir, "source_db")
+        os.mkdir(source_dir)
+        db.load(source_dir)
+
+        top = Event()
+        top.set_type(EventType.CUSTOM)
+        top.set_description("Emigration 1882")
+        mid = Event()
+        mid.set_type(EventType.CUSTOM)
+        mid.set_description("Montebello Journey")
+        sub = Event()
+        sub.set_type(EventType.CUSTOM)
+        sub.set_description("Departure from Bremen")
+
+        with DbTxn("add events", db) as trans:
+            db.add_event(top, trans)
+            db.add_event(mid, trans)
+            db.add_event(sub, trans)
+            mid.add_super_event(top.handle)
+            sub.add_super_event(mid.handle)
+            db.commit_event(mid, trans)
+            db.commit_event(sub, trans)
+
+        return db, top.gramps_id, mid.gramps_id, sub.gramps_id
+
+    def test_super_event_list_round_trip(self):
+        db, top_gid, mid_gid, sub_gid = self._make_source_db()
+
+        xml_path = os.path.join(self.tmpdir, "export.gramps")
+        export_data(db, xml_path, User())
+        db.close()
+
+        target = make_database("sqlite")
+        target_dir = os.path.join(self.tmpdir, "target_db")
+        os.mkdir(target_dir)
+        target.load(target_dir)
+        importData(target, xml_path, User())
+
+        top2 = target.get_event_from_gramps_id(top_gid)
+        mid2 = target.get_event_from_gramps_id(mid_gid)
+        sub2 = target.get_event_from_gramps_id(sub_gid)
+
+        self.assertEqual(mid2.get_super_event_list(), [top2.handle])
+        self.assertEqual(sub2.get_super_event_list(), [mid2.handle])
+        self.assertEqual(top2.get_super_event_list(), [])
+
+        target.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/plugins/importer/importxml.py
+++ b/gramps/plugins/importer/importxml.py
@@ -732,6 +732,7 @@ class GrampsParser(UpdateCallback):
             "noteref": (self.start_noteref, None),
             "p": (None, self.stop_ptag),
             "parentin": (self.start_parentin, None),
+            "partof": (self.start_partof, None),
             "people": (self.start_people, self.stop_people),
             "person": (self.start_person, self.stop_person),
             "img": (self.start_photo, self.stop_photo),
@@ -1480,6 +1481,13 @@ class GrampsParser(UpdateCallback):
         handle = self.inaugurate(attrs["hlink"], "place", Place)
         self.placeref.ref = handle
         self.placeobj.add_placeref(self.placeref)
+
+    def start_partof(self, attrs):
+        """
+        Add a super-event reference to the event currently being processed.
+        """
+        handle = self.inaugurate(attrs["hlink"], "event", Event)
+        self.event.add_super_event(handle)
 
     def start_attribute(self, attrs):
         self.attribute = Attribute()

--- a/gramps/plugins/lib/libgrampsxml.py
+++ b/gramps/plugins/lib/libgrampsxml.py
@@ -32,5 +32,5 @@
 # Public Constants
 #
 # ------------------------------------------------------------------------
-GRAMPS_XML_VERSION_TUPLE = (1, 7, 2)  # version for Gramps 6.0
+GRAMPS_XML_VERSION_TUPLE = (1, 7, 3)  # version for Gramps 6.1: event partof added
 GRAMPS_XML_VERSION = ".".join(str(i) for i in GRAMPS_XML_VERSION_TUPLE)

--- a/gramps/plugins/view/eventtreeview.py
+++ b/gramps/plugins/view/eventtreeview.py
@@ -1,0 +1,153 @@
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Event Tree View
+"""
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+
+_ = glocale.translation.gettext
+
+from gramps.gen.errors import WindowActiveError
+from gramps.gen.lib import Event
+from gramps.gui.editors import EditEvent
+from gramps.gui.views.treemodels import EventTreeModel
+from .eventview import EventView
+
+
+# -------------------------------------------------------------------------
+#
+# EventTreeView
+#
+# -------------------------------------------------------------------------
+class EventTreeView(EventView):
+    """
+    A hierarchical view of events, showing sub-events under their
+    super-event.
+    """
+
+    def __init__(self, pdata, dbstate, uistate, nav_group=0):
+        EventView.__init__(
+            self, pdata, dbstate, uistate, nav_group, model_class=EventTreeModel
+        )
+
+    def get_viewtype_stock(self):
+        """
+        Override the default icon. Set for hierarchical view.
+        """
+        return "gramps-tree-group"
+
+    def define_actions(self):
+        """
+        Define actions for the popup menu specific to the tree view.
+        """
+        EventView.define_actions(self)
+
+        self._add_action("OpenBranch", self.open_branch)
+        self._add_action("CloseBranch", self.close_branch)
+        self._add_action("OpenAllNodes", self.open_all_nodes)
+        self._add_action("CloseAllNodes", self.close_all_nodes)
+
+    additional_ui = EventView.additional_ui[:]
+    additional_ui.append(
+        """
+        <section id="PopUpTree">
+          <item>
+            <attribute name="action">win.OpenBranch</attribute>
+            <attribute name="label" translatable="yes">"""
+        """Expand this Entire Group</attribute>
+          </item>
+          <item>
+            <attribute name="action">win.CloseBranch</attribute>
+            <attribute name="label" translatable="yes">"""
+        """Collapse this Entire Group</attribute>
+          </item>
+          <item>
+            <attribute name="action">win.OpenAllNodes</attribute>
+            <attribute name="label" translatable="yes">"""
+        """Expand all Nodes</attribute>
+          </item>
+          <item>
+            <attribute name="action">win.CloseAllNodes</attribute>
+            <attribute name="label" translatable="yes">"""
+        """Collapse all Nodes</attribute>
+          </item>
+        </section>
+        """
+    )
+
+    def add(self, *obj):
+        """
+        Add a new event. If a single event is selected, use it as the new
+        event's super-event (the "Part of" tab lets the user add further
+        super-events or remove this one).
+        """
+        event = Event()
+        selected = self.selected_handles()
+        if len(selected) == 1:
+            event.add_super_event(selected[0])
+
+        try:
+            EditEvent(self.dbstate, self.uistate, [], event)
+        except WindowActiveError:
+            pass
+
+    def row_update(self, handle_list):
+        """
+        Called when an event is updated.
+        """
+        EventView.row_update(self, handle_list)
+
+        for handle in handle_list:
+            # Rebuild the model if the primary super-event has changed.
+            if self._significant_change(handle):
+                self.build_tree()
+                break
+
+    def _significant_change(self, handle):
+        """
+        Return True if the primary super-event is different from the
+        parent displayed in the tree, or if there are children.
+        The first occurs if a change moves a sub-event to a different
+        super-event, the second if a change to a super-event occurs (a
+        description change might shift position in the tree).
+        """
+        new_handle = None
+        event = self.dbstate.db.get_event_from_handle(handle)
+        super_event_list = event.get_super_event_list()
+        if len(super_event_list) > 0:
+            new_handle = super_event_list[0]
+
+        old_handle = None
+        children = False
+        iter_ = self.model.get_iter_from_handle(handle)
+        if iter_:
+            parent_iter = self.model.iter_parent(iter_)
+            if parent_iter:
+                old_handle = self.model.get_handle_from_iter(parent_iter)
+            children = self.model.get_node_from_iter(iter_).children
+        return new_handle != old_handle or children
+
+    def get_config_name(self):
+        return __name__

--- a/gramps/plugins/view/eventview.py
+++ b/gramps/plugins/view/eventview.py
@@ -116,7 +116,7 @@ class EventView(ListView):
     FILTER_TYPE = "Event"
     QR_CATEGORY = CATEGORY_QR_EVENT
 
-    def __init__(self, pdata, dbstate, uistate, nav_group=0):
+    def __init__(self, pdata, dbstate, uistate, nav_group=0, model_class=EventModel):
         """
         Create the Event View
         """
@@ -140,7 +140,7 @@ class EventView(ListView):
             pdata,
             dbstate,
             uistate,
-            EventModel,
+            model_class,
             signal_map,
             EventBookmarks,
             nav_group,

--- a/gramps/plugins/view/view.gpr.py
+++ b/gramps/plugins/view/view.gpr.py
@@ -50,6 +50,23 @@ register(
 
 register(
     VIEW,
+    id="eventtreeview",
+    name=_("Event Tree"),
+    description=_("A view displaying events in a tree format."),
+    version="1.0",
+    gramps_target_version=MODULE_VERSION,
+    status=STABLE,
+    fname="eventtreeview.py",
+    authors=["The Gramps project"],
+    authors_email=["https://gramps-project.org"],
+    category=("Events", _("Events")),
+    viewclass="EventTreeView",
+    stock_icon="gramps-tree-group",
+    order=START,
+)
+
+register(
+    VIEW,
     id="familyview",
     name=_("Families"),
     description=_("The view showing all families"),

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -448,6 +448,7 @@ gramps/gui/editors/displaytabs/placenameembedlist.py
 gramps/gui/editors/displaytabs/placerefembedlist.py
 gramps/gui/editors/displaytabs/repoembedlist.py
 gramps/gui/editors/displaytabs/srcattrembedlist.py
+gramps/gui/editors/displaytabs/supereventembedlist.py
 gramps/gui/editors/displaytabs/surnametab.py
 gramps/gui/editors/displaytabs/webembedlist.py
 gramps/gui/editors/editaddress.py
@@ -812,6 +813,7 @@ gramps/plugins/tool/verify.py
 gramps/plugins/view/citationlistview.py
 gramps/plugins/view/citationtreeview.py
 gramps/plugins/view/dashboardview.py
+gramps/plugins/view/eventtreeview.py
 gramps/plugins/view/eventview.py
 gramps/plugins/view/familyview.py
 gramps/plugins/view/fanchart2wayview.py

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -195,6 +195,7 @@ gramps/gen/lib/urlbase.py
 # gen lib test API
 #
 gramps/gen/lib/test/date_test.py
+gramps/gen/lib/test/event_test.py
 gramps/gen/lib/test/grampstype_test.py
 gramps/gen/lib/test/handleref_test.py
 gramps/gen/lib/test/merge_test.py
@@ -205,6 +206,10 @@ gramps/gen/lib/test/styledtext_test.py
 # gen.merge package
 #
 gramps/gen/merge/__init__.py
+#
+# gen.merge.test package
+#
+gramps/gen/merge/test/mergeeventquery_test.py
 #
 # gen mime API
 #
@@ -327,6 +332,7 @@ gramps/gen/utils/docgen/tabbeddoc.py
 #
 gramps/gen/utils/test/alive_test.py
 gramps/gen/utils/test/callback_test.py
+gramps/gen/utils/test/db_test.py
 gramps/gen/utils/test/file_test.py
 gramps/gen/utils/test/grampslocale_test.py
 gramps/gen/utils/test/keyword_test.py
@@ -385,6 +391,7 @@ gramps/gui/editors/displaytabs/placerefmodel.py
 gramps/gui/editors/displaytabs/reporefmodel.py
 gramps/gui/editors/displaytabs/sourcebackreflist.py
 gramps/gui/editors/displaytabs/srcattrmodel.py
+gramps/gui/editors/displaytabs/supereventmodel.py
 gramps/gui/editors/displaytabs/surnamemodel.py
 gramps/gui/editors/displaytabs/webmodel.py
 #
@@ -568,6 +575,7 @@ gramps/plugins/export/__init__.py
 # plugins/export/test directory
 #
 gramps/plugins/export/test/exportvcard_test.py
+gramps/plugins/export/test/exportxml_partof_test.py
 #
 # plugins/gramplet directory
 #


### PR DESCRIPTION
## Summary

Implements the community-requested sub-events feature (events can belong to one or more "super-events", browsable as a hierarchy) discussed in:
- https://gramps-project.org/bugs/view.php?id=10672
- https://gramps.discourse.group/t/whats-in-development-for-gramps-6-2/9641/9
- https://gramps.discourse.group/t/whats-in-development-for-gramps-6-2/9641/14

Design mirrors the existing Place hierarchy (`placeref_list`): a plain `super_event_list: list[EventHandle]` on `Event`, no new secondary-object class, no new database tables.

- **Data model** — `Event.super_event_list`, with serialize/schema, handle-reference methods, `merge()` union with a self-reference guard, and accessors.
- **Migration** — schema version bumped to `(23, 0, 0)` with `gramps_upgrade_23()`. Sub-event lookups reuse the existing indexed backlink table via `find_backlink_handles()` — no full-table scan.
- **Merge handling** — fixes a `MergeError` that would otherwise fire as soon as an event gains an `Event`-class backlink (merging a super-event that other events point to).
- **Editor UI** — a new "Part of" tab on the event editor (add/remove/reorder super-events), with a cycle guard using the same `find_backlink_handles` pattern the place editor already uses.
- **Tree view** — a new "Event Tree" view alongside the existing flat Events view, following the same List/Tree split Places already has. Built without a new DB schema (in-memory BFS ordering).
- **XML** — `<partof hlink="..."/>` added to `exportxml.py`/`importxml.py`, `grampsxml.dtd`, `grampsxml.rng`, with the XML version bumped so the relationship survives export/import instead of being silently dropped.

Deferred (not in this PR, by design): an optional merge-dialog warning when merging events with sub-event relationships, and gramplet/report support for showing sub-event structure (existing reports are unaffected — every event still appears in flat listings).

## Test plan

- [x] New unit/integration tests added for every phase (data model, migration, merge, cycle detection, XML round-trip) — 10,734 tests pass together via `python3 -m unittest`.
- [x] `mypy` clean on the full project.
- [x] `black --check` clean on all changed files.
- [x] Verified `EventTreeModel`'s tree-building logic against a real SQLite-backed database (multi-level nesting, multiple children, unrelated roots, and a cycle-safety case) since a full interactive GTK session wasn't renderable in the sandbox this was built in.
- [ ] Manual GUI smoke test in a real desktop session (editor "Part of" tab, Event Tree view) — not yet done by a human; recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)