### PR TITLE
Guard tar/zip extraction against path-traversal (CVE-2007-4559)

### DIFF
--- a/gramps/gen/plug/utils.py
+++ b/gramps/gen/plug/utils.py
@@ -43,6 +43,7 @@ from ..config import config
 from ..const import GRAMPS_LOCALE as glocale
 from ..const import USER_PLUGINS
 from ..constfunc import mac
+from ..utils.safearchive import is_safe_archive_member, is_safe_tar_member
 from . import BasePluginManager
 from ._pluginreg import make_environment
 
@@ -119,8 +120,14 @@ class Zipfile:
     def extractall(self, path, members=None):
         """
         Extract all of the files in the zip into path.
+
+        Raises ``ValueError`` if an entry's path would resolve outside of
+        ``path`` (Zip Slip / CVE-2007-4559).
         """
         names = self.zip_obj.namelist()
+        for name in names:
+            if not is_safe_archive_member(name, path):
+                raise ValueError("Unsafe path in archive member: %s" % name)
         for name in self.get_paths(names):
             fullname = os.path.join(path, name)
             if not os.path.exists(fullname):
@@ -446,10 +453,16 @@ def load_addon_file(path, callback=None):
     if len(good_gpr) > 0:
         # Now, install the ok ones
         try:
+            if isinstance(file_obj, tarfile.TarFile):
+                for member in file_obj.getmembers():
+                    if not is_safe_tar_member(member, USER_PLUGINS):
+                        raise tarfile.TarError(
+                            "Unsafe path in archive member: %s" % member.name
+                        )
             file_obj.extractall(USER_PLUGINS)
-        except OSError:
+        except (OSError, ValueError, tarfile.TarError):
             if callback:
-                callback(f"OSError installing '{path}', skipped!")
+                callback(f"Error installing '{path}', skipped!")
             file_obj.close()
             return False
         if callback:

--- a/gramps/gen/utils/safearchive.py
+++ b/gramps/gen/utils/safearchive.py
@@ -1,0 +1,73 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Helpers guarding archive extraction against path-traversal ("Zip Slip",
+CVE-2007-4559): a crafted zip or tar file can use an absolute path, a
+``../`` member name, or a symlink/hardlink to make a naive extractor
+create or overwrite files outside the intended target directory.
+"""
+
+# -------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import os
+import tarfile
+
+
+# -------------------------------------------------------------------------
+#
+# Functions
+#
+# -------------------------------------------------------------------------
+def is_within_directory(directory: str, target: str) -> bool:
+    """
+    Return True if ``target`` resolves to a path inside ``directory``.
+    """
+    abs_directory = os.path.abspath(directory)
+    abs_target = os.path.abspath(target)
+    return os.path.commonpath([abs_directory, abs_target]) == abs_directory
+
+
+def is_safe_archive_member(name: str, target_dir: str) -> bool:
+    """
+    Check that extracting an archive member named ``name`` into
+    ``target_dir`` cannot write outside of it.
+    """
+    if os.path.isabs(name) or name.startswith(("/", "\\")):
+        return False
+    target_path = os.path.join(target_dir, name)
+    return is_within_directory(target_dir, target_path)
+
+
+def is_safe_tar_member(tarinfo: tarfile.TarInfo, target_dir: str) -> bool:
+    """
+    Check that extracting ``tarinfo`` into ``target_dir`` cannot write or
+    link outside of it.
+    """
+    if not is_safe_archive_member(tarinfo.name, target_dir):
+        return False
+    if tarinfo.issym() or tarinfo.islnk():
+        target_path = os.path.join(target_dir, tarinfo.name)
+        link_target = os.path.join(os.path.dirname(target_path), tarinfo.linkname)
+        if not is_within_directory(target_dir, link_target):
+            return False
+    return True

--- a/gramps/gen/utils/test/safearchive_test.py
+++ b/gramps/gen/utils/test/safearchive_test.py
@@ -1,0 +1,120 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Unittest for the archive path-traversal guards ("Zip Slip", CVE-2007-4559).
+"""
+
+import os
+import tarfile
+import unittest
+
+from gramps.gen.utils.safearchive import (
+    is_safe_archive_member,
+    is_safe_tar_member,
+    is_within_directory,
+)
+
+
+def _make_tarinfo(name: str, linkname: str = "", linktype: str | None = None):
+    tarinfo = tarfile.TarInfo(name=name)
+    if linktype == "sym":
+        tarinfo.type = tarfile.SYMTYPE
+        tarinfo.linkname = linkname
+    elif linktype == "link":
+        tarinfo.type = tarfile.LNKTYPE
+        tarinfo.linkname = linkname
+    return tarinfo
+
+
+class IsWithinDirectoryCheck(unittest.TestCase):
+    def setUp(self):
+        self.target_dir = os.path.join(os.sep, "home", "user", "tree.media")
+
+    def test_subpath_is_within(self):
+        self.assertTrue(
+            is_within_directory(
+                self.target_dir, os.path.join(self.target_dir, "photo.jpg")
+            )
+        )
+
+    def test_sibling_path_is_not_within(self):
+        self.assertFalse(
+            is_within_directory(
+                self.target_dir,
+                os.path.join(os.path.dirname(self.target_dir), "other.media"),
+            )
+        )
+
+
+class IsSafeArchiveMemberCheck(unittest.TestCase):
+    def setUp(self):
+        self.target_dir = os.path.join(os.sep, "home", "user", "tree.media")
+
+    def test_regular_relative_member_is_safe(self):
+        self.assertTrue(is_safe_archive_member("photo.jpg", self.target_dir))
+
+    def test_relative_subdir_member_is_safe(self):
+        name = os.path.join("sub", "photo.jpg")
+        self.assertTrue(is_safe_archive_member(name, self.target_dir))
+
+    def test_absolute_path_is_unsafe(self):
+        name = os.path.join(os.sep, "etc", "passwd")
+        self.assertFalse(is_safe_archive_member(name, self.target_dir))
+
+    def test_parent_traversal_is_unsafe(self):
+        name = os.path.join("..", "..", "..", "etc", "passwd")
+        self.assertFalse(is_safe_archive_member(name, self.target_dir))
+
+
+class IsSafeTarMemberCheck(unittest.TestCase):
+    def setUp(self):
+        self.target_dir = os.path.join(os.sep, "home", "user", "tree.media")
+
+    def test_regular_relative_member_is_safe(self):
+        tarinfo = _make_tarinfo("photo.jpg")
+        self.assertTrue(is_safe_tar_member(tarinfo, self.target_dir))
+
+    def test_parent_traversal_is_unsafe(self):
+        tarinfo = _make_tarinfo(os.path.join("..", "..", "..", "etc", "passwd"))
+        self.assertFalse(is_safe_tar_member(tarinfo, self.target_dir))
+
+    def test_symlink_escaping_target_is_unsafe(self):
+        tarinfo = _make_tarinfo(
+            "innocuous",
+            linkname=os.path.join("..", "..", "etc", "passwd"),
+            linktype="sym",
+        )
+        self.assertFalse(is_safe_tar_member(tarinfo, self.target_dir))
+
+    def test_symlink_within_target_is_safe(self):
+        tarinfo = _make_tarinfo("link", linkname="photo.jpg", linktype="sym")
+        self.assertTrue(is_safe_tar_member(tarinfo, self.target_dir))
+
+    def test_hardlink_escaping_target_is_unsafe(self):
+        tarinfo = _make_tarinfo(
+            "innocuous",
+            linkname=os.path.join(os.sep, "etc", "passwd"),
+            linktype="link",
+        )
+        self.assertFalse(is_safe_tar_member(tarinfo, self.target_dir))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/plugins/importer/importgpkg.py
+++ b/gramps/plugins/importer/importgpkg.py
@@ -50,45 +50,10 @@ log = logging.getLogger(".ReadPkg")
 # -------------------------------------------------------------------------
 from gramps.gen.const import XMLFILE
 from gramps.gen.utils.file import media_path
+from gramps.gen.utils.safearchive import is_safe_tar_member
 
 ## we need absolute import as this is dynamically loaded:
 from gramps.plugins.importer.importxml import importData
-
-
-# -------------------------------------------------------------------------
-#
-# Safe tar extraction (CVE-2007-4559)
-#
-# -------------------------------------------------------------------------
-def _is_within_directory(directory: str, target: str) -> bool:
-    """
-    Return True if ``target`` resolves to a path inside ``directory``.
-    """
-    abs_directory = os.path.abspath(directory)
-    abs_target = os.path.abspath(target)
-    return os.path.commonpath([abs_directory, abs_target]) == abs_directory
-
-
-def _is_safe_member(tarinfo: tarfile.TarInfo, target_dir: str) -> bool:
-    """
-    Check that extracting ``tarinfo`` into ``target_dir`` cannot write or
-    link outside of it.
-
-    A malicious .gpkg file could otherwise use an absolute path, a
-    path-traversal name (e.g. ``../../etc/passwd``), or a symlink/hardlink
-    to make ``TarFile.extract()`` create or overwrite files outside the
-    intended media directory (CVE-2007-4559).
-    """
-    if os.path.isabs(tarinfo.name) or tarinfo.name.startswith(("/", "\\")):
-        return False
-    target_path = os.path.join(target_dir, tarinfo.name)
-    if not _is_within_directory(target_dir, target_path):
-        return False
-    if tarinfo.issym() or tarinfo.islnk():
-        link_target = os.path.join(os.path.dirname(target_path), tarinfo.linkname)
-        if not _is_within_directory(target_dir, link_target):
-            return False
-    return True
 
 
 # -------------------------------------------------------------------------
@@ -128,7 +93,7 @@ def impData(database, name, user):
     try:
         archive = tarfile.open(name)
         for tarinfo in archive:
-            if not _is_safe_member(tarinfo, tmpdir_path):
+            if not is_safe_tar_member(tarinfo, tmpdir_path):
                 raise tarfile.TarError(
                     "Unsafe path in archive member: %s" % tarinfo.name
                 )

--- a/gramps/plugins/importer/importgpkg.py
+++ b/gramps/plugins/importer/importgpkg.py
@@ -57,6 +57,42 @@ from gramps.plugins.importer.importxml import importData
 
 # -------------------------------------------------------------------------
 #
+# Safe tar extraction (CVE-2007-4559)
+#
+# -------------------------------------------------------------------------
+def _is_within_directory(directory: str, target: str) -> bool:
+    """
+    Return True if ``target`` resolves to a path inside ``directory``.
+    """
+    abs_directory = os.path.abspath(directory)
+    abs_target = os.path.abspath(target)
+    return os.path.commonpath([abs_directory, abs_target]) == abs_directory
+
+
+def _is_safe_member(tarinfo: tarfile.TarInfo, target_dir: str) -> bool:
+    """
+    Check that extracting ``tarinfo`` into ``target_dir`` cannot write or
+    link outside of it.
+
+    A malicious .gpkg file could otherwise use an absolute path, a
+    path-traversal name (e.g. ``../../etc/passwd``), or a symlink/hardlink
+    to make ``TarFile.extract()`` create or overwrite files outside the
+    intended media directory (CVE-2007-4559).
+    """
+    if os.path.isabs(tarinfo.name) or tarinfo.name.startswith(("/", "\\")):
+        return False
+    target_path = os.path.join(target_dir, tarinfo.name)
+    if not _is_within_directory(target_dir, target_path):
+        return False
+    if tarinfo.issym() or tarinfo.islnk():
+        link_target = os.path.join(os.path.dirname(target_path), tarinfo.linkname)
+        if not _is_within_directory(target_dir, link_target):
+            return False
+    return True
+
+
+# -------------------------------------------------------------------------
+#
 #
 #
 # -------------------------------------------------------------------------
@@ -92,6 +128,10 @@ def impData(database, name, user):
     try:
         archive = tarfile.open(name)
         for tarinfo in archive:
+            if not _is_safe_member(tarinfo, tmpdir_path):
+                raise tarfile.TarError(
+                    "Unsafe path in archive member: %s" % tarinfo.name
+                )
             archive.extract(tarinfo, tmpdir_path)
         archive.close()
     except:

--- a/gramps/plugins/importer/test/importgpkg_test.py
+++ b/gramps/plugins/importer/test/importgpkg_test.py
@@ -1,0 +1,107 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Unittest for the tarfile path-traversal guard in the Gramps package
+importer (CVE-2007-4559).
+"""
+
+import io
+import os
+import tarfile
+import unittest
+
+from gramps.plugins.importer.importgpkg import _is_safe_member
+
+
+def _make_tarinfo(name: str, linkname: str = "", linktype: str | None = None):
+    tarinfo = tarfile.TarInfo(name=name)
+    if linktype == "sym":
+        tarinfo.type = tarfile.SYMTYPE
+        tarinfo.linkname = linkname
+    elif linktype == "link":
+        tarinfo.type = tarfile.LNKTYPE
+        tarinfo.linkname = linkname
+    return tarinfo
+
+
+class SafeMemberCheck(unittest.TestCase):
+    def setUp(self):
+        self.target_dir = os.path.join(os.sep, "home", "user", "tree.media")
+
+    def test_regular_relative_member_is_safe(self):
+        tarinfo = _make_tarinfo("photo.jpg")
+        self.assertTrue(_is_safe_member(tarinfo, self.target_dir))
+
+    def test_relative_subdir_member_is_safe(self):
+        tarinfo = _make_tarinfo(os.path.join("sub", "photo.jpg"))
+        self.assertTrue(_is_safe_member(tarinfo, self.target_dir))
+
+    def test_absolute_path_is_unsafe(self):
+        tarinfo = _make_tarinfo(os.path.join(os.sep, "etc", "passwd"))
+        self.assertFalse(_is_safe_member(tarinfo, self.target_dir))
+
+    def test_parent_traversal_is_unsafe(self):
+        tarinfo = _make_tarinfo(os.path.join("..", "..", "..", "etc", "passwd"))
+        self.assertFalse(_is_safe_member(tarinfo, self.target_dir))
+
+    def test_symlink_escaping_target_is_unsafe(self):
+        tarinfo = _make_tarinfo(
+            "innocuous",
+            linkname=os.path.join("..", "..", "etc", "passwd"),
+            linktype="sym",
+        )
+        self.assertFalse(_is_safe_member(tarinfo, self.target_dir))
+
+    def test_symlink_within_target_is_safe(self):
+        tarinfo = _make_tarinfo("link", linkname="photo.jpg", linktype="sym")
+        self.assertTrue(_is_safe_member(tarinfo, self.target_dir))
+
+    def test_hardlink_escaping_target_is_unsafe(self):
+        tarinfo = _make_tarinfo(
+            "innocuous",
+            linkname=os.path.join(os.sep, "etc", "passwd"),
+            linktype="link",
+        )
+        self.assertFalse(_is_safe_member(tarinfo, self.target_dir))
+
+
+class MaliciousArchiveExtractionCheck(unittest.TestCase):
+    """
+    Build an in-memory tar archive that mimics a malicious .gpkg file and
+    verify every unsafe member it contains is rejected before extraction.
+    """
+
+    def test_all_members_of_malicious_archive_are_rejected(self):
+        buffer = io.BytesIO()
+        with tarfile.open(fileobj=buffer, mode="w") as archive:
+            evil = tarfile.TarInfo(name=os.path.join("..", "..", "evil.txt"))
+            data = b"payload"
+            evil.size = len(data)
+            archive.addfile(evil, io.BytesIO(data))
+        buffer.seek(0)
+
+        target_dir = os.path.join(os.sep, "home", "user", "tree.media")
+        with tarfile.open(fileobj=buffer) as archive:
+            for tarinfo in archive:
+                self.assertFalse(_is_safe_member(tarinfo, target_dir))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/plugins/importer/test/importgpkg_test.py
+++ b/gramps/plugins/importer/test/importgpkg_test.py
@@ -19,7 +19,8 @@
 
 """
 Unittest for the tarfile path-traversal guard in the Gramps package
-importer (CVE-2007-4559).
+importer (CVE-2007-4559). See also gramps.gen.utils.test.safearchive_test
+for coverage of the underlying is_safe_tar_member() helper.
 """
 
 import io
@@ -27,65 +28,14 @@ import os
 import tarfile
 import unittest
 
-from gramps.plugins.importer.importgpkg import _is_safe_member
-
-
-def _make_tarinfo(name: str, linkname: str = "", linktype: str | None = None):
-    tarinfo = tarfile.TarInfo(name=name)
-    if linktype == "sym":
-        tarinfo.type = tarfile.SYMTYPE
-        tarinfo.linkname = linkname
-    elif linktype == "link":
-        tarinfo.type = tarfile.LNKTYPE
-        tarinfo.linkname = linkname
-    return tarinfo
-
-
-class SafeMemberCheck(unittest.TestCase):
-    def setUp(self):
-        self.target_dir = os.path.join(os.sep, "home", "user", "tree.media")
-
-    def test_regular_relative_member_is_safe(self):
-        tarinfo = _make_tarinfo("photo.jpg")
-        self.assertTrue(_is_safe_member(tarinfo, self.target_dir))
-
-    def test_relative_subdir_member_is_safe(self):
-        tarinfo = _make_tarinfo(os.path.join("sub", "photo.jpg"))
-        self.assertTrue(_is_safe_member(tarinfo, self.target_dir))
-
-    def test_absolute_path_is_unsafe(self):
-        tarinfo = _make_tarinfo(os.path.join(os.sep, "etc", "passwd"))
-        self.assertFalse(_is_safe_member(tarinfo, self.target_dir))
-
-    def test_parent_traversal_is_unsafe(self):
-        tarinfo = _make_tarinfo(os.path.join("..", "..", "..", "etc", "passwd"))
-        self.assertFalse(_is_safe_member(tarinfo, self.target_dir))
-
-    def test_symlink_escaping_target_is_unsafe(self):
-        tarinfo = _make_tarinfo(
-            "innocuous",
-            linkname=os.path.join("..", "..", "etc", "passwd"),
-            linktype="sym",
-        )
-        self.assertFalse(_is_safe_member(tarinfo, self.target_dir))
-
-    def test_symlink_within_target_is_safe(self):
-        tarinfo = _make_tarinfo("link", linkname="photo.jpg", linktype="sym")
-        self.assertTrue(_is_safe_member(tarinfo, self.target_dir))
-
-    def test_hardlink_escaping_target_is_unsafe(self):
-        tarinfo = _make_tarinfo(
-            "innocuous",
-            linkname=os.path.join(os.sep, "etc", "passwd"),
-            linktype="link",
-        )
-        self.assertFalse(_is_safe_member(tarinfo, self.target_dir))
+from gramps.gen.utils.safearchive import is_safe_tar_member
 
 
 class MaliciousArchiveExtractionCheck(unittest.TestCase):
     """
     Build an in-memory tar archive that mimics a malicious .gpkg file and
-    verify every unsafe member it contains is rejected before extraction.
+    verify every unsafe member it contains is rejected before extraction,
+    the same way gramps.plugins.importer.importgpkg.impData() does.
     """
 
     def test_all_members_of_malicious_archive_are_rejected(self):
@@ -100,7 +50,7 @@ class MaliciousArchiveExtractionCheck(unittest.TestCase):
         target_dir = os.path.join(os.sep, "home", "user", "tree.media")
         with tarfile.open(fileobj=buffer) as archive:
             for tarinfo in archive:
-                self.assertFalse(_is_safe_member(tarinfo, target_dir))
+                self.assertFalse(is_safe_tar_member(tarinfo, target_dir))
 
 
 if __name__ == "__main__":

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -314,6 +314,7 @@ gramps/gen/utils/location.py
 gramps/gen/utils/lru.py
 gramps/gen/utils/maclocale.py
 gramps/gen/utils/resourcepath.py
+gramps/gen/utils/safearchive.py
 gramps/gen/utils/thumbnails.py
 gramps/gen/utils/unittest.py
 #
@@ -335,6 +336,7 @@ gramps/gen/utils/test/place_test.py
 gramps/gen/utils/test/pypi_e2e_test.py
 gramps/gen/utils/test/pypi_test.py
 gramps/gen/utils/test/requirements_test.py
+gramps/gen/utils/test/safearchive_test.py
 #
 # gui - GUI code
 #
@@ -599,6 +601,7 @@ gramps/plugins/importer/__init__.py
 #
 gramps/plugins/importer/test/importgedcom_ambiguous_date_test.py
 gramps/plugins/importer/test/importgeneweb_test.py
+gramps/plugins/importer/test/importgpkg_test.py
 gramps/plugins/importer/test/importvcard_test.py
 #
 # plugins/lib directory


### PR DESCRIPTION
## Summary
- The `.gpkg` importer (`gramps/plugins/importer/importgpkg.py`) extracted archive members with `tarfile.TarFile.extract()` without validating their paths, vulnerable to [CVE-2007-4559](https://nvd.nist.gov/vuln/detail/CVE-2007-4559) / "Zip Slip" (see also [python/cpython#73974](https://github.com/python/cpython/issues/73974)).
- The addon/plugin installer (`load_addon_file()` in `gramps/gen/plug/utils.py`) has the same class of bug in **two** places: the custom `Zipfile.extractall()` wrapper (used for `.zip` addon packages) and a bare `tarfile.TarFile.extractall()` call (used for `.tar.gz`/`.tgz` addon packages). This is arguably higher risk than the `.gpkg` case since addon packages are fetched from a URL (the Gramps addon server or a configured mirror) rather than a file the user deliberately imports.
- In each case a crafted archive could use an absolute path, a `../` path-traversal member name, or a symlink/hardlink to create or overwrite files outside the intended target directory (media directory for `.gpkg`, plugin directory for addons).
- Added a shared `gramps/gen/utils/safearchive.py` module (`is_safe_archive_member()`, `is_safe_tar_member()`) and applied it at all three extraction sites before any member is written to disk. This is a self-contained workaround that does not rely on Python 3.12+'s `filter=` extraction parameter (PEP 706), so it works across all Python versions Gramps supports (3.10+).

Fixes #12911.

## Test plan
- [x] `gramps/gen/utils/test/safearchive_test.py` — unit tests for the shared helpers (absolute paths, `../` traversal, symlink/hardlink escapes).
- [x] `gramps/plugins/importer/test/importgpkg_test.py` — integration-style test against a crafted malicious tar archive.
- [x] Manual checks: crafted malicious zip/tar member is rejected via `Zipfile.extractall()` (raises `ValueError`) and via the addon-installer's tar-member pre-check; a benign zip with a real directory entry still extracts correctly (no regression).
- [x] `python3 -m unittest gramps.gen.utils.test.safearchive_test gramps.plugins.importer.test.importgpkg_test -v` — all pass.
- [x] `black --check` on all changed files.
- [x] `mypy` (full project) — no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)