### PR TITLE
Add Date.get_gregorian_ymd() and fix death anniversary calendar bug

### DIFF
--- a/gramps/gen/lib/date.py
+++ b/gramps/gen/lib/date.py
@@ -1986,6 +1986,24 @@ class Date(BaseObject):
         """
         return (self.get_year(), self.get_month(), self.get_day())
 
+    def get_gregorian_ymd(self) -> tuple[int, int, int]:
+        """
+        Return (year, month, day) converted to the Gregorian calendar.
+
+        Use this instead of :meth:`get_ymd` whenever the year, month, or
+        day will be compared against, or used to build, another Gregorian
+        date (for example "today" or "this year"), so that dates recorded
+        in a non-Gregorian calendar are not mixed up with Gregorian ones.
+
+        >>> persian_new_year = Date()
+        >>> persian_new_year.set(0, Date.MOD_NONE, Date.CAL_PERSIAN, (1, 1, 1400, False))
+        >>> persian_new_year.get_gregorian_ymd()
+        (2021, 3, 21)
+        """
+        if self.calendar == Date.CAL_GREGORIAN:
+            return self.get_ymd()
+        return self.to_calendar("gregorian").get_ymd()
+
     def get_dmy(self, get_slash=False):
         """
         Return (day, month, year, [slash]).

--- a/gramps/gen/lib/test/date_test.py
+++ b/gramps/gen/lib/test/date_test.py
@@ -1795,6 +1795,33 @@ class AnniversaryDateTest(BaseDateTest):
         self.assertEqual(d.anniversary(1910), (2, 29))
 
 
+class GregorianYmdTest(BaseDateTest):
+    """
+    Tests for Date.get_gregorian_ymd().
+    """
+
+    def test_gregorian_date_is_unchanged(self):
+        d = Date(1999, 5, 17)
+        self.assertEqual(d.get_gregorian_ymd(), d.get_ymd())
+
+    def test_persian_date_converted(self):
+        d = Date()
+        d.set(0, Date.MOD_NONE, Date.CAL_PERSIAN, (1, 1, 1400, False))
+        self.assertEqual(d.get_gregorian_ymd(), (2021, 3, 21))
+
+    def test_julian_date_converted(self):
+        d = Date(1752, 9, 2).to_calendar("julian")
+        self.assertEqual(d.get_gregorian_ymd(), (1752, 9, 2))
+
+    def test_hebrew_date_converted(self):
+        d = Date(2024, 10, 3).to_calendar("hebrew")
+        self.assertEqual(d.get_gregorian_ymd(), (2024, 10, 3))
+
+    def test_islamic_date_converted(self):
+        d = Date(2024, 6, 15).to_calendar("islamic")
+        self.assertEqual(d.get_gregorian_ymd(), (2024, 6, 15))
+
+
 class SortKeyTest(BaseDateTest):
     """Tests for Date.get_sort_key() modifier- and quality-aware sort ordering.
 

--- a/gramps/plugins/webreport/calendar.py
+++ b/gramps/plugins/webreport/calendar.py
@@ -1063,9 +1063,8 @@ class CalendarPage(BasePage):
                 else:
                     death_date = None
                 if self.death_anniv and death_date:
-                    year = death_date.get_year() or this_year
-                    month = death_date.get_month()
-                    day = death_date.get_day()
+                    greg_year, month, day = death_date.get_gregorian_ymd()
+                    year = greg_year or this_year
 
                     short_name = self.get_name(person)
                     prob_alive_date = Date(this_year, month, day)

--- a/gramps/plugins/webreport/webcal.py
+++ b/gramps/plugins/webreport/webcal.py
@@ -1517,9 +1517,8 @@ return false;
                 # primary_name = person.primary_name
                 # name = Name(primary_name)
                 if self.death_anniv and death_date:
-                    year = death_date.get_year() or this_year
-                    month = death_date.get_month()
-                    day = death_date.get_day()
+                    greg_year, month, day = death_date.get_gregorian_ymd()
+                    year = greg_year or this_year
 
                     short_name = self.get_name(person)
                     prob_alive_date = Date(this_year, month, day)


### PR DESCRIPTION
Original issue found by @javadr on https://github.com/gramps-project/addons-source/pull/974

## Summary

- `Date.get_month()`/`get_day()` return raw values in whatever calendar the date was recorded in. Code that extracts month/day from an event date and mixes it with Gregorian year arithmetic silently misplaces non-Gregorian dates (e.g. a Persian or Hebrew death date landing on the wrong Gregorian day).
- In `webreport/calendar.py` and `webreport/webcal.py`, the birthday-anniversary code already guarded against this by converting to Gregorian before extracting month/day, but the neighboring death-anniversary code did not — same bug class as a recently-fixed 16-year-old bug in the BirthdaysGramplet addon (proximity sort using raw, non-Gregorian month/day).
- Adds `Date.get_gregorian_ymd()`, returning `(year, month, day)` already converted to Gregorian, so future code has one obvious call instead of a two-step convert-then-extract pattern that's easy to forget.
- Fixes the death anniversary calculation in both files to use the new method.

## Test plan

- [x] Added `GregorianYmdTest` in `gramps/gen/lib/test/date_test.py` covering an already-Gregorian date (identity) and conversions from Persian, Julian, Hebrew, and Islamic calendars.
- [x] Added a doctest on `get_gregorian_ymd()` reproducing the Persian-new-year scenario from the original bug.
- [x] `python3 -m unittest gramps.gen.lib.test.date_test` — 45 passed.
- [x] `black --check` and `mypy` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)