### PR TITLE
Add check for stale files in POTFILES.in

### DIFF
--- a/.github/workflows/gramps-ci.yml
+++ b/.github/workflows/gramps-ci.yml
@@ -83,16 +83,16 @@ jobs:
         intltool-update -m
         missing_found=0
         notexist_found=0
-        [[ -s missing  ]] && missing_found=1
-        [[ -s notexist ]] && notexist_found=1
-        if [[ $missing_found -eq 1 && $notexist_found -eq 1 ]]; then
+        [ -s missing  ] && missing_found=1
+        [ -s notexist ] && notexist_found=1
+        if [ $missing_found -eq 1 ] && [ $notexist_found -eq 1 ]; then
           echo "ERROR - A new file is not listed in either POTFILES.in or POTFILES.skip."
           echo "ERROR: stale entries in POTFILES.in that no longer exist."
           exit 1
-        elif [[ $notexist_found -eq 1 ]]; then
+        elif [ $notexist_found -eq 1 ]; then
           echo "ERROR: POTFILES.in lists files that no longer exist."
           exit 1
-        elif [[ $missing_found -eq 1 ]]; then
+        elif [ $missing_found -eq 1 ]; then
           echo "ERROR - A new file is not listed in either POTFILES.in or POTFILES.skip."
           exit 1
 

--- a/.github/workflows/gramps-ci.yml
+++ b/.github/workflows/gramps-ci.yml
@@ -95,6 +95,7 @@ jobs:
         elif [ $missing_found -eq 1 ]; then
           echo "ERROR - A new file is not listed in either POTFILES.in or POTFILES.skip."
           exit 1
+        fi
 
   pypi-installer:
     name: PyPI installer tests (${{ matrix.os }})

--- a/.github/workflows/gramps-ci.yml
+++ b/.github/workflows/gramps-ci.yml
@@ -81,10 +81,20 @@ jobs:
       run: |
         cd po
         intltool-update -m
-        if [ -f "missing" ]; then
-          echo "ERROR - A new file is not listed in either POTFILES.in or POTFILES.skip";
-          exit 1;
-        fi
+        missing_found=0
+        notexist_found=0
+        [[ -s missing  ]] && missing_found=1
+        [[ -s notexist ]] && notexist_found=1
+        if [[ $missing_found -eq 1 && $notexist_found -eq 1 ]]; then
+          echo "ERROR - A new file is not listed in either POTFILES.in or POTFILES.skip."
+          echo "ERROR: stale entries in POTFILES.in that no longer exist."
+          exit 1
+        elif [[ $notexist_found -eq 1 ]]; then
+          echo "ERROR: POTFILES.in lists files that no longer exist."
+          exit 1
+        elif [[ $missing_found -eq 1 ]]; then
+          echo "ERROR - A new file is not listed in either POTFILES.in or POTFILES.skip."
+          exit 1
 
   pypi-installer:
     name: PyPI installer tests (${{ matrix.os }})


### PR DESCRIPTION
When` intltool-update -m` finds file entries in POTFILES.in which no longer exist, it logs those to `notexist`. If that file is found, CI will now treat that as an error in addition to the new file test.

It's interesting that the man page for intltool-update does not mention this scenario, but I found that to be the behavior and Claude confirmed it.

Please squash-and-merge.