### PR TITLE
Assert on messages logged during test execution

### DIFF
--- a/gramps/gen/fs/fs_import/test/importer_test.py
+++ b/gramps/gen/fs/fs_import/test/importer_test.py
@@ -271,7 +271,17 @@ class TestAddChild(unittest.TestCase):
 
         with patch.dict(fs_utilities.FS_INDEX_PEOPLE, {}, clear=False):
             with patch.dict(deserialize.Person.index, {}, clear=False):
-                importer.add_child(cpr)
+                with self.assertLogs(
+                    "gramps.gen.fs.fs_import.importer", level="WARNING"
+                ) as cm:
+                    importer.add_child(cpr)
+                self.assertTrue(
+                    any(
+                        "Skipping child relationship with unresolved FS parent(s): ['P1', 'P2']"
+                        in msg
+                        for msg in cm.output
+                    )
+                )
 
         mock_db.add_family.assert_not_called()
 

--- a/gramps/gen/utils/test/pypi_test.py
+++ b/gramps/gen/utils/test/pypi_test.py
@@ -157,6 +157,7 @@ class TestIsPureWheel(unittest.TestCase):
 #
 # -------------------------------------------------------------------------
 class TestResolvePypiName(unittest.TestCase):
+
     def test_pil_maps_to_pillow(self):
         """PIL (current addon-source import name) maps to Pillow and warns."""
         with self.assertLogs("gramps.gen.utils.pypi", level="WARNING") as cm:
@@ -166,23 +167,44 @@ class TestResolvePypiName(unittest.TestCase):
 
     def test_yaml_maps_to_pyyaml(self):
         """yaml import name maps to PyYAML."""
-        self.assertEqual(resolve_pypi_name("yaml"), "PyYAML")
+        with self.assertLogs("gramps.gen.utils.pypi", level="WARNING") as cm:
+            result = resolve_pypi_name("yaml")
+        self.assertEqual(result, "PyYAML")
+        self.assertTrue(any("yaml" in msg and "PyYAML" in msg for msg in cm.output))
 
     def test_cv2_maps_to_opencv(self):
         """cv2 import name maps to opencv-python."""
-        self.assertEqual(resolve_pypi_name("cv2"), "opencv-python")
+        with self.assertLogs("gramps.gen.utils.pypi", level="WARNING") as cm:
+            result = resolve_pypi_name("cv2")
+        self.assertEqual(result, "opencv-python")
+        self.assertTrue(
+            any("cv2" in msg and "opencv-python" in msg for msg in cm.output)
+        )
 
     def test_bs4_maps_to_beautifulsoup4(self):
         """bs4 import name maps to beautifulsoup4."""
-        self.assertEqual(resolve_pypi_name("bs4"), "beautifulsoup4")
+        with self.assertLogs("gramps.gen.utils.pypi", level="WARNING") as cm:
+            result = resolve_pypi_name("bs4")
+        self.assertEqual(result, "beautifulsoup4")
+        self.assertTrue(
+            any("bs4" in msg and "beautifulsoup4" in msg for msg in cm.output)
+        )
 
     def test_serial_maps_to_pyserial(self):
         """serial import name maps to pyserial (not the unrelated 'serial' package)."""
-        self.assertEqual(resolve_pypi_name("serial"), "pyserial")
+        with self.assertLogs("gramps.gen.utils.pypi", level="WARNING") as cm:
+            result = resolve_pypi_name("serial")
+        self.assertEqual(result, "pyserial")
+        self.assertTrue(any("serial" in msg and "pyserial" in msg for msg in cm.output))
 
     def test_sklearn_maps_to_scikit_learn(self):
         """sklearn stub has no wheels; maps to scikit-learn."""
-        self.assertEqual(resolve_pypi_name("sklearn"), "scikit-learn")
+        with self.assertLogs("gramps.gen.utils.pypi", level="WARNING") as cm:
+            result = resolve_pypi_name("sklearn")
+        self.assertEqual(result, "scikit-learn")
+        self.assertTrue(
+            any("sklearn" in msg and "scikit-learn" in msg for msg in cm.output)
+        )
 
     def test_unknown_name_returned_unchanged_no_warning(self):
         """A name not in the table is returned as-is and emits no warning."""
@@ -319,7 +341,17 @@ class TestCompatibleTags(unittest.TestCase):
                     import gramps.gen.utils.pypi as pypi_mod
 
                     pypi_mod._COMPAT_TAGS = None
-                    py_tags, abi_tags, plat_tags = _compatible_tags()
+                    with self.assertLogs(
+                        "gramps.gen.utils.pypi", level="WARNING"
+                    ) as cm:
+                        py_tags, abi_tags, plat_tags = _compatible_tags()
+                        self.assertTrue(
+                            any(
+                                "Could not determine macOS version from platform.mac_ver(); compiled wheels will not be matched."
+                                in msg
+                                for msg in cm.output
+                            )
+                        )
         # Must not raise; "any" must still be present so pure wheels match.
         self.assertIn("any", plat_tags)
         # No macosx_* tags should be generated when version is unknown.


### PR DESCRIPTION
Some unit tests result in log messages (warnings) being emitted which can be seen in the output (see below). These messages are actually expected and do not represent failures.

However, messages being logged in the output of a test run means someone has to review them and determine whether they are real warnings, failures or errors.

In the modified tests these warnings were expected, so I used the Python capability to assert on log messages to capture and validate them, thus strengthening the test case and cleaning the output at the same time. This pattern was already in use in some places.

To run modified tests:

`python3 -m unittest gramps.gen.utils.test.pypi_test.TestResolvePypiName`
`python3 -m unittest  gramps.gen.utils.test.pypi_test.TestCompatibleTags.test_macos_empty_version_does_not_crash`
`python3 -m unittest gramps.gen.fs.fs_import.test.importer_test.TestAddChild`

Expand the `Run test suite` section in the [CI run from this PR which no longer shows warnings  in the output](https://github.com/gramps-project/gramps/actions/runs/29203342419/job/86678315740?pr=2465). For comparison, see the prior output below:

<details><summary>UT Run showing warnings interspersed</summary>
<p>

```
Run export GDK_BACKEND=-
  export GDK_BACKEND=-
  export GRAMPS_RESOURCES=build/share
  python3 -m unittest discover -p "*_test.py"
  shell: /usr/bin/bash -e {0}
/usr/lib/python3/dist-packages/requests/__init__.py:87: RequestsDependencyWarning: urllib3 (2.7.0) or chardet (4.0.0) doesn't match a supported version!
  warnings.warn("urllib3 ({}) or chardet ({}) doesn't match a supported "

(python3 -m unittest:4625): Gtk-CRITICAL **: 19:54:21.331: gtk_icon_theme_get_for_screen: assertion 'GDK_IS_SCREEN (screen)' failed
..........................................................................................................................................................................................................................................................Can't find filter _no_such_filter_ in the defined custom filters
.Can't find filter _no_such_filter_ in the defined custom filters
.Can't find filter _no_such_filter_ in the defined custom filters
.Can't find filter _no_such_filter_ in the defined custom filters
.Can't find filter _no_such_filter_ in the defined custom filters
.Can't find filter _no_such_filter_ in the defined custom filters
.Can't find filter _no_such_filter_ in the defined custom filters
.Can't find filter _no_such_filter_ in the defined custom filters
............................................................................................................Skipping child relationship with unresolved FS parent(s): ['P1', 'P2']
.....................................................................................................
(...many log lines removed...)
.......................ssssssssssssssssssssssssssssssssssssssssssssssssssssssss........................................................................................................................Could not determine macOS version from platform.mac_ver(); compiled wheels will not be matched.
.............................................................................................................................................requires_mod value 'bs4' is a Python import name, not a PyPI package name.  Please update the addon to use 'beautifulsoup4' instead.  The correct name has been applied automatically this time.
.requires_mod value 'cv2' is a Python import name, not a PyPI package name.  Please update the addon to use 'opencv-python' instead.  The correct name has been applied automatically this time.
...requires_mod value 'serial' is a Python import name, not a PyPI package name.  Please update the addon to use 'pyserial' instead.  The correct name has been applied automatically this time.
.requires_mod value 'sklearn' is a Python import name, not a PyPI package name.  Please update the addon to use 'scikit-learn' instead.  The correct name has been applied automatically this time.
..requires_mod value 'yaml' is a Python import name, not a PyPI package name.  Please update the addon to use 'PyYAML' instead.  The correct name has been applied automatically this time.
........................................................ss..............................................................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 32951 tests in 212.897s

OK (skipped=58)
```
</p>
</details> 