### PR TITLE
Add UI language preference with restart-and-restore session state

### DIFF
--- a/gramps/cli/argparser.py
+++ b/gramps/cli/argparser.py
@@ -73,6 +73,7 @@ Help options
 
 Application options
   -O, --open=FAMILY_TREE                 Open Family Tree
+  --language=LANG_CODE                   Start Gramps in LANG_CODE for this run only
   --restore-state=STATE_FILE             Restore session state from a restart
   -U, --username=USERNAME                Database username
   -P, --password=PASSWORD                Database password
@@ -141,7 +142,11 @@ gramps -O 'Family Tree 1' -e output.gramps -f gramps
 10. To generate a web site into an other locale (in german):
 LANGUAGE=de_DE; LANG=de_DE.UTF-8 gramps -O 'Family Tree 1' -a report -p name=navwebpage,target=/../de
 
-11. Finally, to start normal interactive session type:
+11. To start Gramps in German for this run only, without changing the
+LANGUAGE preference used the next time Gramps is started:
+gramps --language=de
+
+12. Finally, to start normal interactive session type:
 gramps
 
 Note: These examples are for bash shell.
@@ -161,6 +166,7 @@ class ArgParser:
     The valid options are:
 
     -O, --open=FAMILY_TREE          Open Family Tree
+    --language=LANG_CODE            Start Gramps in LANG_CODE for this run only
     --restore-state=STATE_FILE      Restore session state from a restart
     -U, --username=USERNAME         Database username
     -P, --password=PASSWORD         Database password
@@ -222,6 +228,7 @@ class ArgParser:
 
         self.open_gui = None
         self.open = None
+        self.language = None
         self.restore_state_path = None
         self.username = None
         self.password = None
@@ -291,6 +298,11 @@ class ArgParser:
         for opt_ix, (option, value) in enumerate(options):
             if option in ["-O", "--open"]:
                 self.open = value
+            elif option in ["--language"]:
+                # Already applied to the LANGUAGE environment variable by
+                # grampsapp, before GRAMPS_LOCALE was constructed -- stored
+                # here only so callers can see what was requested.
+                self.language = value
             elif option in ["--restore-state"]:
                 self.restore_state_path = value
                 try:

--- a/gramps/cli/argparser.py
+++ b/gramps/cli/argparser.py
@@ -37,6 +37,7 @@ Module responsible for handling the command line arguments for Gramps.
 import sys
 import os
 import getopt
+import json
 import logging
 import shutil
 from glob import glob
@@ -72,6 +73,7 @@ Help options
 
 Application options
   -O, --open=FAMILY_TREE                 Open Family Tree
+  --restore-state=STATE_FILE             Restore session state from a restart
   -U, --username=USERNAME                Database username
   -P, --password=PASSWORD                Database password
   -C, --create=FAMILY_TREE               Create on open if new Family Tree
@@ -159,6 +161,7 @@ class ArgParser:
     The valid options are:
 
     -O, --open=FAMILY_TREE          Open Family Tree
+    --restore-state=STATE_FILE      Restore session state from a restart
     -U, --username=USERNAME         Database username
     -P, --password=PASSWORD         Database password
     -C, --create=FAMILY_TREE        Create on open if new Family Tree
@@ -219,6 +222,7 @@ class ArgParser:
 
         self.open_gui = None
         self.open = None
+        self.restore_state_path = None
         self.username = None
         self.password = None
         self.exports = []
@@ -287,6 +291,15 @@ class ArgParser:
         for opt_ix, (option, value) in enumerate(options):
             if option in ["-O", "--open"]:
                 self.open = value
+            elif option in ["--restore-state"]:
+                self.restore_state_path = value
+                try:
+                    with open(value, encoding="utf-8") as restore_file:
+                        restore_state = json.load(restore_file)
+                except (OSError, ValueError):
+                    restore_state = {}
+                if restore_state.get("tree"):
+                    self.open = restore_state["tree"]
             elif option in ["-C", "--create"]:
                 self.create = value
             elif option in ["-U", "--username"]:

--- a/gramps/cli/test/argparser_test.py
+++ b/gramps/cli/test/argparser_test.py
@@ -21,6 +21,9 @@
 """Unittest for argparser.py"""
 
 import unittest
+import os
+import json
+import tempfile
 from unittest.mock import Mock
 from ..argparser import ArgParser
 
@@ -95,6 +98,36 @@ class TestArgParser(unittest.TestCase):
     def test_option_with_multiple_arguments(self):
         argument_parser = self.create_parser("-l", "family_tree_name")
         self.assertEqual(argument_parser.database_names, ["family_tree_name"])
+
+    def write_state_file(self, contents):
+        state_file = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, encoding="utf-8"
+        )
+        self.addCleanup(os.remove, state_file.name)
+        json.dump(contents, state_file)
+        state_file.close()
+        return state_file.name
+
+    def test_restore_state_longopt_sets_open_from_tree(self):
+        path = self.write_state_file({"tree": "My Family Tree"})
+        ap = self.create_parser("--restore-state", path)
+        self.assertEqual(ap.open, "My Family Tree")
+        self.assertEqual(ap.restore_state_path, path)
+
+    def test_restore_state_without_tree_key_leaves_open_none(self):
+        path = self.write_state_file({"language": "fr_FR.UTF-8"})
+        ap = self.create_parser("--restore-state", path)
+        self.assertIsNone(ap.open)
+        self.assertEqual(ap.restore_state_path, path)
+
+    def test_restore_state_missing_file_does_not_crash(self):
+        ap = self.create_parser("--restore-state", "/no/such/file.json")
+        self.assertIsNone(ap.open)
+        self.assertEqual(ap.restore_state_path, "/no/such/file.json")
+
+    def test_restore_state_path_defaults_to_none(self):
+        ap = self.create_parser()
+        self.assertIsNone(ap.restore_state_path)
 
 
 if __name__ == "__main__":

--- a/gramps/cli/test/argparser_test.py
+++ b/gramps/cli/test/argparser_test.py
@@ -129,6 +129,14 @@ class TestArgParser(unittest.TestCase):
         ap = self.create_parser()
         self.assertIsNone(ap.restore_state_path)
 
+    def test_language_longopt_sets_language(self):
+        ap = self.create_parser("--language", "fr")
+        self.assertEqual(ap.language, "fr")
+
+    def test_language_defaults_to_none(self):
+        ap = self.create_parser()
+        self.assertIsNone(ap.language)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/gramps/gen/config.py
+++ b/gramps/gen/config.py
@@ -297,6 +297,7 @@ register(
 
 register("preferences.quick-backup-include-mode", False)
 register("preferences.date-format", 0)
+register("preferences.language", "")
 register("preferences.calendar-format-report", 0)
 register("preferences.calendar-format-input", 0)
 register("preferences.february-29", 0)  # 0: 02/28; 1: 03/01; 2: only the 02/29

--- a/gramps/gen/const.py
+++ b/gramps/gen/const.py
@@ -329,6 +329,7 @@ LONGOPTS = [
     "g-fatal-warnings",
     "help",
     "import=",
+    "language=",
     "load-modules=",
     "list" "name=",
     "oaf-activate-iid=",

--- a/gramps/gen/const.py
+++ b/gramps/gen/const.py
@@ -339,6 +339,7 @@ LONGOPTS = [
     "password=",
     "create=",
     "options=",
+    "restore-state=",
     "safe",
     "screen=",
     "show",

--- a/gramps/gen/utils/grampslocale.py
+++ b/gramps/gen/utils/grampslocale.py
@@ -542,23 +542,29 @@ class GrampsLocale:
         translator.lang = "en"
         return translator
 
+    def _get_english_language_name(self, lang_code: str) -> str | None:
+        """
+        Given a language code of the form "lang_region", return the
+        untranslated English name of that language, or ``None``.
+        """
+        try:
+            return _LOCALE_NAMES[lang_code][2]
+        except KeyError:
+            try:
+                return _LOCALE_NAMES[lang_code[:2]][2]
+            except KeyError:
+                LOG.debug("Gramps has no translation for %s", lang_code)
+                return None
+        except IndexError:
+            LOG.debug("Bad Index for tuple %s\n", _LOCALE_NAMES[lang_code][0])
+            return None
+
     def _get_language_string(self, lang_code):
         """
         Given a language code of the form "lang_region", return a text string
         representing that language.
         """
-        try:
-            lang = _LOCALE_NAMES[lang_code][2]
-        except KeyError:
-            try:
-                lang = _LOCALE_NAMES[lang_code[:2]][2]
-            except KeyError:
-                LOG.debug("Gramps has no translation for %s", lang_code)
-                lang = None
-        except IndexError:
-            LOG.debug("Bad Index for tuple %s\n", _LOCALE_NAMES[lang_code][0])
-            lang = None
-
+        lang = self._get_english_language_name(lang_code)
         if lang:
             return self.translation.gettext(lang)
         return lang
@@ -757,6 +763,30 @@ class GrampsLocale:
             for code in self.get_available_translations()
             if self._get_language_string(code)
         }
+
+    def get_language_labels(self) -> dict[str, str]:
+        """
+        Return a dict of code : label for use by language pickers that want
+        to show each language's own name for itself, independent of the
+        currently active UI language, e.g. ``{"fr": "fr - Français (French)"}``.
+
+        Unlike :func:`get_language_dict`, which renders every language's
+        English name translated into the *current* UI language, this looks
+        up each language's endonym in its own translation catalog.
+        """
+        labels = {}
+        for code in self.get_available_translations():
+            english_name = self._get_english_language_name(code)
+            if not english_name:
+                continue
+            try:
+                translator = self._get_translation(languages=[code])
+            except ValueError:
+                endonym = english_name
+            else:
+                endonym = translator.gettext(english_name)
+            labels[code] = f"{code} - {endonym} ({english_name})"
+        return labels
 
     def trans_objclass(self, objclass_str):
         """

--- a/gramps/gen/utils/test/grampslocale_test.py
+++ b/gramps/gen/utils/test/grampslocale_test.py
@@ -349,5 +349,34 @@ class StrcollTest(unittest.TestCase):
         self.assertEqual(self.glocale.strcoll("Abel", "Abel"), 0)
 
 
+class RestoreLanguageTest(unittest.TestCase):
+    """
+    GrampsLocale._init_from_environment() (grampslocale.py:245-253) reads
+    the $LANGUAGE environment variable and validates each candidate with
+    check_available_translations() before using it. This is the exact
+    primitive the restart-and-restore-state feature relies on: on restart,
+    the new process is launched with $LANGUAGE set from the saved
+    "preferences.language" value before gen.const (and therefore
+    GrampsLocale) is even imported. The already-constructed process-wide
+    GrampsLocale singleton can't be re-initialized from a unit test, so
+    this exercises the validation primitive directly instead.
+    """
+
+    def setUp(self):
+        from gramps.gen.const import GRAMPS_LOCALE as glocale
+
+        self.glocale = glocale
+
+    def test_available_language_is_recognized(self):
+        # "fr" translations are confirmed present in this test environment
+        # by AddonTranslatorTest above.
+        self.assertTrue(self.glocale.check_available_translations("fr"))
+
+    def test_unavailable_language_is_rejected(self):
+        self.assertFalse(
+            self.glocale.check_available_translations("xx_not_a_real_locale")
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/gramps/grampsapp.py
+++ b/gramps/grampsapp.py
@@ -46,6 +46,32 @@ if "-S" in sys.argv or "--safe" in sys.argv:
     os.environ["SAFEMODE"] = tempdir.name
 
 # -------------------------------------------------------------------------
+# restore the UI language from a restart-state file, if one was passed.
+# This must happen before the .gen.const import below, because that import
+# constructs the GRAMPS_LOCALE singleton from the environment.
+if "--restore-state" in sys.argv:
+    _state_ix = sys.argv.index("--restore-state")
+    if _state_ix + 1 < len(sys.argv):
+        import json
+
+        try:
+            with open(sys.argv[_state_ix + 1], encoding="utf-8") as _state_file:
+                _restore_language = json.load(_state_file).get("language")
+        except (OSError, ValueError):
+            _restore_language = None
+        if _restore_language:
+            # LANGUAGE is gettext's own message-catalog selector and takes
+            # bare/short codes ("fr", "zh_CN") -- exactly what's stored in
+            # preferences.language. LANG is a different namespace: it must
+            # be a full OS locale name (e.g. "fr_FR.UTF-8") for setlocale()
+            # to succeed, and setting it to a bare code here would make
+            # locale.setlocale(LC_ALL, "") fail and fall back to "C",
+            # degrading LC_TIME/LC_COLLATE along with it. Leave LANG (and
+            # LC_*) alone so date/number/collation keep following the
+            # user's actual system locale.
+            os.environ["LANGUAGE"] = _restore_language
+
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #

--- a/gramps/grampsapp.py
+++ b/gramps/grampsapp.py
@@ -117,6 +117,27 @@ if "--restore-state" in sys.argv:
             os.environ["LANGUAGE"] = _restore_language
 
 # -------------------------------------------------------------------------
+# an explicit --language=CODE (or --language CODE) command line argument
+# always wins over both of the above, including any LANGUAGE already set in
+# the shell environment. It is a one-off override for this run only -- it
+# is deliberately not written to preferences.language, so it never changes
+# what a plain "gramps" invocation picks up next time. Parsed by hand,
+# rather than deferred to cli.argparser.ArgParser, because it must be
+# resolved before the .gen.const import below constructs GRAMPS_LOCALE from
+# the environment; ArgParser itself imports .gen.const and so cannot run
+# yet.
+for _ix, _arg in enumerate(sys.argv[1:], start=1):
+    if _arg.startswith("--language="):
+        _cli_language = _arg.split("=", 1)[1]
+    elif _arg == "--language" and _ix + 1 < len(sys.argv):
+        _cli_language = sys.argv[_ix + 1]
+    else:
+        continue
+    if _cli_language:
+        os.environ["LANGUAGE"] = _cli_language
+    break
+
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #

--- a/gramps/grampsapp.py
+++ b/gramps/grampsapp.py
@@ -46,6 +46,51 @@ if "-S" in sys.argv or "--safe" in sys.argv:
     os.environ["SAFEMODE"] = tempdir.name
 
 # -------------------------------------------------------------------------
+# restore a persisted preferences.language on ordinary startup, i.e. any
+# startup that isn't itself a --restore-state relaunch (that case is
+# handled below) or safe mode (which intentionally ignores customized
+# settings). preferences.language is an ordinary ConfigManager setting
+# (gen/config.py), but ConfigManager can't be used this early -- it
+# itself imports .gen.const, which is what's about to construct the
+# GRAMPS_LOCALE singleton this code needs to run before. Read the ini
+# file directly instead, using only the lightweight, .gen.const-independent
+# path helpers from .gen.constfunc, and tolerate any failure by simply not
+# overriding anything, same as if this block didn't run at all.
+if (
+    "--restore-state" not in sys.argv
+    and "SAFEMODE" not in os.environ
+    and "LANGUAGE" not in os.environ
+):
+    from .gen.constfunc import get_env_var, get_user_config_dir
+    from .version import VERSION_TUPLE
+
+    if "GRAMPSHOME" in os.environ:
+        _user_config = os.path.join(get_env_var("GRAMPSHOME"), "gramps")
+    else:
+        _user_config = os.path.join(get_user_config_dir(), "gramps")
+    _inifile = os.path.join(
+        _user_config,
+        "gramps%s%s" % (VERSION_TUPLE[0], VERSION_TUPLE[1]),
+        "gramps.ini",
+    )
+    if os.path.exists(_inifile):
+        import ast
+        import configparser
+
+        _cp = configparser.ConfigParser(interpolation=None)
+        try:
+            _cp.read(_inifile)
+            _persisted_language = ast.literal_eval(_cp.get("preferences", "language"))
+        except (
+            configparser.Error,
+            ValueError,
+            SyntaxError,
+        ):
+            _persisted_language = None
+        if _persisted_language:
+            os.environ["LANGUAGE"] = _persisted_language
+
+# -------------------------------------------------------------------------
 # restore the UI language from a restart-state file, if one was passed.
 # This must happen before the .gen.const import below, because that import
 # constructs the GRAMPS_LOCALE singleton from the environment.

--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -749,9 +749,15 @@ class GrampsPreferences(ConfigureDialog):
         if dlg.run():
             from .restartstate import capture_state, write_state_file, restart_gramps
 
+            # os.execv replaces this process before ConfigureDialog.close()
+            # runs, so the config.save() it would normally trigger (via
+            # ManagedWindow._save_size/_save_position) never happens. Without
+            # this, changed settings like preferences.language stay in
+            # memory only and are lost when the process image is replaced.
+            config.save()
             state = capture_state(self.dbstate, self.uistate, self.uistate.viewmanager)
             path = write_state_file(state)
-            restart_gramps(path)
+            restart_gramps(path, self.dbstate)
 
     def _resolve_unsaved_editors(self) -> None:
         """
@@ -2213,13 +2219,12 @@ class GrampsPreferences(ConfigureDialog):
         row = 1
         # Language:
         obox = Gtk.ComboBoxText()
-        languages = glocale.get_language_dict()
-        language_codes = [""] + sorted(languages, key=glocale.sort_key)
+        language_labels = glocale.get_language_labels()
+        codes = [""] + sorted(language_labels)
         obox.append_text(_("Use system default"))
-        for language in language_codes[1:]:
-            obox.append_text(language)
+        for code in codes[1:]:
+            obox.append_text(language_labels[code])
         current_language = config.get("preferences.language")
-        codes = [""] + [languages[language] for language in language_codes[1:]]
         try:
             obox.set_active(codes.index(current_language))
         except ValueError:

--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -69,7 +69,7 @@ from gramps.gen.lib import Date, FamilyRelType
 from gramps.gen.lib import Name, Surname, NameOriginType
 from .managedwindow import ManagedWindow
 from .widgets import MarkupLabel, BasicLabel
-from .dialog import ErrorDialog, OkDialog
+from .dialog import ErrorDialog, QuestionDialog2
 from .editors.editplaceformat import EditPlaceFormat
 from .display import display_help
 from gramps.gen.plug.utils import available_updates
@@ -677,6 +677,7 @@ class GrampsPreferences(ConfigureDialog):
     )
 
     def __init__(self, uistate, dbstate, initial_panel: str | None = None) -> None:
+        self._restart_settings: set[str] = set()
         page_funcs = (
             self.add_data_panel,
             self.add_general_panel,
@@ -717,6 +718,52 @@ class GrampsPreferences(ConfigureDialog):
         except ValueError:
             return
         self.panel.set_current_page(page_num)
+
+    def mark_restart_required(self, key: str, *_args) -> None:
+        """
+        Record that the given config key was changed and needs a restart to
+        take effect. Compatible with add_checkbox's extra_callback signature.
+        """
+        self._restart_settings.add(key)
+
+    def done(self, obj, value) -> None:
+        if value == Gtk.ResponseType.HELP:
+            return
+        if self._restart_settings:
+            self.offer_restart()
+        ConfigureDialog.done(self, obj, value)
+
+    def offer_restart(self) -> None:
+        """
+        Offer to restart Gramps so that changed restart-required settings
+        take effect, restoring the current tree/view/selection/editors.
+        """
+        self._resolve_unsaved_editors()
+        dlg = QuestionDialog2(
+            _("Restart Gramps?"),
+            _("Some changes require Gramps to restart to take effect. " "Restart now?"),
+            _("Restart Now"),
+            _("Restart Later"),
+            parent=self.window,
+        )
+        if dlg.run():
+            from .restartstate import capture_state, write_state_file, restart_gramps
+
+            state = capture_state(self.dbstate, self.uistate, self.uistate.viewmanager)
+            path = write_state_file(state)
+            restart_gramps(path)
+
+    def _resolve_unsaved_editors(self) -> None:
+        """
+        Force a save-or-discard decision on every open primary-object editor
+        with unsaved changes, so a restart never silently loses or silently
+        carries forward in-progress edits.
+        """
+        from .editors.editprimary import EditPrimary
+
+        for item in list(self.uistate.gwm.id2item.values()):
+            if isinstance(item, EditPrimary) and item.data_has_changed():
+                item.close()
 
     def create_grid(self):
         """
@@ -1732,12 +1779,7 @@ class GrampsPreferences(ConfigureDialog):
             obox.set_active(active)
         else:
             obox.set_active(0)
-        obox.connect(
-            "changed",
-            lambda obj: config.set(
-                "preferences.age-display-precision", obj.get_active() + 1
-            ),
-        )
+        obox.connect("changed", self.age_precision_changed)
         lwidget = BasicLabel(_("%s: ") % _("Age display precision *"))
         grid.attach(lwidget, 1, row, 1, 1)
         grid.attach(obox, 2, row, 2, 1)
@@ -1762,6 +1804,9 @@ class GrampsPreferences(ConfigureDialog):
             "preferences.age-after-death",
             start=2,
             stop=3,
+            extra_callback=lambda obj: self.mark_restart_required(
+                "preferences.age-after-death"
+            ),
         )
 
         row += 1
@@ -2005,20 +2050,28 @@ class GrampsPreferences(ConfigureDialog):
         """
         self.tag_format_entry.set_sensitive(obj.get_active())
 
+    def language_changed(self, obj, codes: list[str]) -> None:
+        """
+        Save "Language" option, requires a restart to take effect.
+        """
+        config.set("preferences.language", codes[obj.get_active()])
+        self.mark_restart_required("preferences.language")
+
     def date_format_changed(self, obj):
         """
-        Save "Date format" option.
-        And show notify message to restart Gramps.
+        Save "Date format" option, requires a restart to take effect.
         """
         config.set("preferences.date-format", obj.get_active())
-        OkDialog(
-            _("Change is not immediate"),
-            _(
-                "Changing the date format will not take "
-                "effect until the next time Gramps is started."
-            ),
-            parent=self.window,
-        )
+        self.mark_restart_required("preferences.date-format")
+
+    def age_precision_changed(self, obj):
+        """
+        Save "Age display precision" option, requires a restart to take
+        effect.
+        """
+        # Combo_box active index is from 0 to 2, we need values from 1 to 3
+        config.set("preferences.age-display-precision", obj.get_active() + 1)
+        self.mark_restart_required("preferences.age-display-precision")
 
     def date_calendar_changed(self, obj):
         """
@@ -2158,6 +2211,33 @@ class GrampsPreferences(ConfigureDialog):
         label.set_margin_top(10)
 
         row = 1
+        # Language:
+        obox = Gtk.ComboBoxText()
+        languages = glocale.get_language_dict()
+        language_codes = [""] + sorted(languages, key=glocale.sort_key)
+        obox.append_text(_("Use system default"))
+        for language in language_codes[1:]:
+            obox.append_text(language)
+        current_language = config.get("preferences.language")
+        codes = [""] + [languages[language] for language in language_codes[1:]]
+        try:
+            obox.set_active(codes.index(current_language))
+        except ValueError:
+            obox.set_active(0)
+        obox.connect("changed", self.language_changed, codes)
+        lwidget = BasicLabel(_("%s: ") % _("Language *"))
+        lwidget.set_use_underline(True)
+        lwidget.set_mnemonic_widget(obox)
+        obox.set_tooltip_text(
+            _(
+                "The language used for the Gramps user interface.\n"
+                "Requires Gramps restart to apply."
+            )
+        )
+        grid.attach(lwidget, 1, row, 1, 1)
+        grid.attach(obox, 2, row, 2, 1)
+
+        row += 1
         self.add_checkbox(
             grid,
             _("Display Tip of the Day"),
@@ -2231,6 +2311,9 @@ class GrampsPreferences(ConfigureDialog):
                 "Show or hide text beside Navigator buttons "
                 "(People, Families, Events...).\n"
                 "Requires Gramps restart to apply."
+            ),
+            extra_callback=lambda obj: self.mark_restart_required(
+                "interface.sidebar-text"
             ),
         )
 

--- a/gramps/gui/grampsgui.py
+++ b/gramps/gui/grampsgui.py
@@ -621,6 +621,11 @@ class Gramps:
             # open without fam tree loaded
             self._vm.post_init_interface()
 
+        if getattr(argparser, "restore_state_path", None):
+            from .restartstate import apply_post_init_state
+
+            apply_post_init_state(argparser.restore_state_path, dbstate, self._vm)
+
         if config.get("behavior.use-tips"):
             TipOfDay(self._vm.uistate)
 

--- a/gramps/gui/restartstate.py
+++ b/gramps/gui/restartstate.py
@@ -1,0 +1,169 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       The Gramps Project
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Capture and restore a Gramps session across a self-relaunch (``os.execv``).
+
+Some preferences (UI language, date format, ...) only take effect on the
+next process start. Rather than leave the user to close and reopen Gramps
+manually and land on the welcome screen, these functions snapshot the
+currently open tree, active view, selection and open editors to a small
+JSON file, relaunch the process, and restore that state once the new
+process has finished loading the tree.
+"""
+
+# -------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import logging
+from typing import Any, TYPE_CHECKING
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from gramps.gen.errors import HandleError
+
+if TYPE_CHECKING:
+    from gramps.gen.dbstate import DbState
+    from .displaystate import DisplayState
+    from .viewmanager import ViewManager
+
+LOG = logging.getLogger(".gui.restartstate")
+
+STATE_VERSION = 1
+
+
+def capture_state(
+    dbstate: "DbState", uistate: "DisplayState", viewmanager: "ViewManager"
+) -> dict[str, Any]:
+    """
+    Snapshot the current session (open tree, active view, selection, and
+    open primary-object editors) into a plain dict suitable for JSON export.
+    """
+    from .editors.editprimary import EditPrimary
+    from gramps.gen.config import config
+
+    state: dict[str, Any] = {
+        "version": STATE_VERSION,
+        "language": config.get("preferences.language"),
+        "tree": None,
+        "active_view": None,
+        "selected": {},
+        "open_editors": [],
+    }
+
+    if dbstate.is_open():
+        state["tree"] = dbstate.db.get_save_path()
+
+    state["active_view"] = viewmanager.get_active_view_id()
+
+    for (nav_type, nav_group), history in uistate.history_lookup.items():
+        if nav_group != 0:
+            continue
+        handle = history.present()
+        if handle:
+            state["selected"][nav_type] = handle
+
+    for item in uistate.gwm.id2item.values():
+        if not isinstance(item, EditPrimary):
+            continue
+        obj = item.obj
+        handle = obj.get_handle() if obj else None
+        if handle:
+            state["open_editors"].append(
+                {"object_type": obj.__class__.__name__, "handle": handle}
+            )
+
+    return state
+
+
+def write_state_file(state: dict[str, Any]) -> str:
+    """
+    Write the given state dict to a temp JSON file and return its path.
+    """
+    handle, path = tempfile.mkstemp(prefix="gramps_restart_", suffix=".json")
+    with os.fdopen(handle, "w", encoding="utf-8") as state_file:
+        json.dump(state, state_file)
+    return path
+
+
+def restart_gramps(path: str) -> None:
+    """
+    Relaunch the current Gramps process, passing it the restore-state file.
+    """
+    os.execv(sys.executable, [sys.executable] + sys.argv + ["--restore-state", path])
+
+
+def apply_post_init_state(
+    path: str, dbstate: "DbState", viewmanager: "ViewManager"
+) -> None:
+    """
+    Restore active view, selection, and open editors from a restart-state
+    file, once the tree named in that file has finished loading.
+
+    Any handle that no longer resolves (the tree may have changed between
+    the snapshot and this restart) is silently skipped rather than raised.
+    """
+    from .editors import EditObject
+
+    try:
+        with open(path, encoding="utf-8") as state_file:
+            state = json.load(state_file)
+    except (OSError, ValueError):
+        return
+
+    uistate = viewmanager.uistate
+
+    active_view = state.get("active_view")
+    if active_view:
+        for cat_num, cat_views in enumerate(viewmanager.views):
+            for view_num, (pdata, _page_def) in enumerate(cat_views):
+                if pdata.id == active_view:
+                    viewmanager.goto_page(cat_num, view_num)
+                    break
+
+    for nav_type, handle in state.get("selected", {}).items():
+        has_handle = dbstate.db.method("has_%s_handle", nav_type)
+        try:
+            if has_handle and has_handle(handle):
+                uistate.set_active(handle, nav_type)
+        except HandleError:
+            LOG.info("Skipping stale selection %s/%s on restart", nav_type, handle)
+
+    for editor in state.get("open_editors", []):
+        object_type = editor.get("object_type")
+        handle = editor.get("handle")
+        has_handle = dbstate.db.method("has_%s_handle", object_type)
+        try:
+            if has_handle and has_handle(handle):
+                EditObject(
+                    dbstate, uistate, [], object_type, prop="handle", value=handle
+                )
+        except HandleError:
+            LOG.info("Skipping stale open editor %s/%s on restart", object_type, handle)

--- a/gramps/gui/restartstate.py
+++ b/gramps/gui/restartstate.py
@@ -113,10 +113,18 @@ def write_state_file(state: dict[str, Any]) -> str:
     return path
 
 
-def restart_gramps(path: str) -> None:
+def restart_gramps(path: str, dbstate: "DbState | None" = None) -> None:
     """
     Relaunch the current Gramps process, passing it the restore-state file.
+
+    Closes the open database first, if any, so its lock file is released
+    and the relaunched process can reopen the same tree. Without this, the
+    new process finds the tree locked by itself (``os.execv`` keeps the same
+    pid but never runs the close/unlock code) and aborts while still inside
+    GTK's application-activate callback.
     """
+    if dbstate is not None and dbstate.is_open():
+        dbstate.db.close()
     os.execv(sys.executable, [sys.executable] + sys.argv + ["--restore-state", path])
 
 

--- a/gramps/gui/spell.py
+++ b/gramps/gui/spell.py
@@ -94,12 +94,21 @@ class Spell:
         if not HAVE_GSPELL:
             return
 
-        locale_code = glocale.locale_code()
+        # Gspell has no notion of $LANGUAGE; it only ever resolves a
+        # dictionary from a single locale-like code. Prefer glocale.language
+        # (the $LANGUAGE-driven UI language) so the spell-check dictionary
+        # follows the user's chosen Gramps language, falling back to
+        # glocale.locale_code() (the $LANG-driven system locale) if no
+        # dictionary matches.
         gspell_language = None
-        if locale_code is not None:
+        for locale_code in list(glocale.language or []) + [glocale.locale_code()]:
+            if not locale_code:
+                continue
             gspell_language = Gspell.language_lookup(locale_code[:5])
             if gspell_language is None:
                 gspell_language = Gspell.language_lookup(locale_code[:2])
+            if gspell_language is not None:
+                break
         checker = Gspell.Checker.new(gspell_language)
         buffer = Gspell.TextBuffer.get_from_gtk_text_buffer(textview.get_buffer())
         buffer.set_spell_checker(checker)

--- a/gramps/gui/test/restartstate_test.py
+++ b/gramps/gui/test/restartstate_test.py
@@ -1,0 +1,107 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       The Gramps Project
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Unittest for restartstate.py"""
+
+import json
+import os
+import unittest
+from unittest.mock import Mock
+
+from ..restartstate import capture_state, write_state_file
+from ..editors.editprimary import EditPrimary
+
+
+def make_history(handle):
+    history = Mock()
+    history.present.return_value = handle
+    return history
+
+
+def make_editor(object_type, handle):
+    obj = Mock()
+    obj.get_handle.return_value = handle
+    obj.__class__ = type(object_type, (), {})
+    editor = Mock(spec=EditPrimary)
+    editor.obj = obj
+    return editor
+
+
+class CaptureStateTest(unittest.TestCase):
+    def setUp(self):
+        self.dbstate = Mock()
+        self.uistate = Mock()
+        self.uistate.history_lookup = {}
+        self.uistate.gwm.id2item = {}
+        self.viewmanager = Mock()
+        self.viewmanager.get_active_view_id.return_value = "PersonView"
+
+    def test_tree_is_none_when_no_db_open(self):
+        self.dbstate.is_open.return_value = False
+        state = capture_state(self.dbstate, self.uistate, self.viewmanager)
+        self.assertIsNone(state["tree"])
+
+    def test_tree_is_save_path_when_db_open(self):
+        self.dbstate.is_open.return_value = True
+        self.dbstate.db.get_save_path.return_value = "/home/user/.gramps/tree1"
+        state = capture_state(self.dbstate, self.uistate, self.viewmanager)
+        self.assertEqual(state["tree"], "/home/user/.gramps/tree1")
+
+    def test_active_view_captured(self):
+        self.dbstate.is_open.return_value = False
+        state = capture_state(self.dbstate, self.uistate, self.viewmanager)
+        self.assertEqual(state["active_view"], "PersonView")
+
+    def test_selected_captures_only_nav_group_zero_with_a_handle(self):
+        self.dbstate.is_open.return_value = False
+        self.uistate.history_lookup = {
+            ("Person", 0): make_history("person-handle"),
+            ("Person", 1): make_history("other-group-handle"),
+            ("Family", 0): make_history(None),
+        }
+        state = capture_state(self.dbstate, self.uistate, self.viewmanager)
+        self.assertEqual(state["selected"], {"Person": "person-handle"})
+
+    def test_open_editors_captures_only_editprimary_instances_with_a_handle(self):
+        self.dbstate.is_open.return_value = False
+        unsaved_editor = make_editor("Person", None)
+        saved_editor = make_editor("Family", "family-handle")
+        self.uistate.gwm.id2item = {
+            "id(unsaved)": unsaved_editor,
+            "family-handle": saved_editor,
+            "other-window": Mock(),
+        }
+        state = capture_state(self.dbstate, self.uistate, self.viewmanager)
+        self.assertEqual(
+            state["open_editors"],
+            [{"object_type": "Family", "handle": "family-handle"}],
+        )
+
+
+class WriteStateFileTest(unittest.TestCase):
+    def test_round_trips_through_json(self):
+        state = {"version": 1, "language": "fr_FR.UTF-8", "tree": "My Tree"}
+        path = write_state_file(state)
+        self.addCleanup(os.remove, path)
+        with open(path, encoding="utf-8") as state_file:
+            self.assertEqual(json.load(state_file), state)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -1105,6 +1105,16 @@ class ViewManager(CLIManager):
             # Should solve bug 12636
             return self.pages[0]
 
+    def get_active_view_id(self):
+        """
+        Return the id of the currently active view, or None.
+        """
+        page_num = self.notebook.get_current_page()
+        for (cat_num, view_num), num in self.page_lookup.items():
+            if num == page_num:
+                return self.views[cat_num][view_num][0].id
+        return None
+
     def get_category(self, cat_name):
         """
         Return the category number from the given category name.


### PR DESCRIPTION
## Summary

Gramps currently determines its UI language purely from `LANG`/`LANGUAGE`
environment variables set before launch — there's no in-app way to change it.
This adds a **Language** preference to the Preferences dialog, alongside the
4 existing settings already marked "Requires Restart" (date format, age
display precision, age-after-death display, sidebar text), which previously
only showed a passive warning telling the user to restart manually.

Changing any of these 5 settings now offers to restart Gramps automatically:

- Any open Person/Family/etc. editors with unsaved changes go through the
  existing per-editor save/discard prompt first.
- On confirmation, Gramps snapshots the current session (open tree, active
  view, selected record, open editors) to a small JSON file and relaunches
  itself via `os.execv` with a new `--restore-state <path>` flag.
- The relaunched process restores the tree, view, selection, and open
  editors instead of landing on the welcome screen.

## Design notes

- A live, in-process reload (no restart at all) was considered and rejected
  — it would require making `_()`/gettext lazy everywhere translated
  strings get cached at import time, plus a correctly-ordered teardown/
  rebuild of the entire GTK widget tree including third-party gramplets.
  `os.execv` trades that complexity for a guaranteed clean process restart.
- The UI language override only sets the `LANGUAGE` environment variable
  (gettext's own message-catalog selector, which accepts bare codes like
  `fr`), not `LANG` — `LANG` needs a full OS locale name for `setlocale()`
  to succeed, and setting it to a bare code risked falling back to `"C"`
  and degrading date/collation formatting along with the message language.
- Window geometry and gramplet/sidebar layout are intentionally *not*
  duplicated in the restore-state file — they're already persisted
  continuously to config independent of this feature.

## Follow-up (not in this PR)

Collation and date-format probably shouldn't be global, env-derived,
restart-gated settings at all — they likely belong per-tree, following the
existing pattern name-display-format already uses (`db.get_name_group_mapping`,
per-tree database metadata) rather than the global `ConfigManager`. Noted for
a future PR.

## Test plan

- [x] `black --check` on all changed files
- [x] `mypy` — no issues
- [x] `python3 -m unittest gramps.cli.test.argparser_test gramps.gen.utils.test.grampslocale_test gramps.gui.test.restartstate_test` — 52/52 passing
- [ ] Manual end-to-end verification in a GUI environment (open tree → edit
      a record → change a restart-required preference → confirm restart →
      confirm tree/view/selection/editor restored) — not yet done, this
      sandbox's GTK bindings are mismatched and can't launch the full app

Opening as a **draft** pending that manual GUI verification and review of
the state-restoration design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)