### PR TITLE
Warn when the UI language's system locale isn't installed

### DIFF
--- a/gramps/gen/utils/grampslocale.py
+++ b/gramps/gen/utils/grampslocale.py
@@ -380,16 +380,23 @@ class GrampsLocale:
             if len(check_lang) < 2 or check_lang[1] not in ("utf-8", "UTF-8"):
                 lang = ".".join((check_lang[0], "UTF-8"))
 
-        os.environ["LANG"] = lang
         if (
             check_lang[0] not in ("C", "en")
             and sys.platform not in ("darwin", "win32")
             and not _locale_is_installed(lang)
         ):
-            # Translations aren't available yet this early in construction
-            # (self.translation is set later, in __init__); remember the
-            # missing locale and warn about it once they are.
+            # Don't hand Gtk a LANG it can't satisfy -- that's exactly what
+            # triggers its own opaque "Locale not supported by C library"
+            # warning when it makes its own setlocale(LC_ALL, "") call.
+            # Leave LANG as whatever the environment already provided (it
+            # hasn't been touched above) so date/number/collation
+            # formatting keeps following that instead. Translations aren't
+            # available yet this early in construction (self.translation
+            # is set later, in __init__); remember the missing locale and
+            # warn about it, in the user's chosen language, once they are.
             self._missing_locale = lang
+        else:
+            os.environ["LANG"] = lang
         # We need to convert 'en' and 'en_US' to 'C' to avoid confusing
         # GtkBuilder when it's retrieving strings from our Glade files
         # since we have neither an en.po nor an en_US.po.

--- a/gramps/gen/utils/grampslocale.py
+++ b/gramps/gen/utils/grampslocale.py
@@ -49,12 +49,19 @@ if sys.platform == "win32":
     from .win32locale import win32_locale_init_from_env, win32_locale_bindtextdomain
 
 from .win32locale import _LOCALE_NAMES
+from ...version import VERSION_TUPLE
 
 LOG = logging.getLogger("." + __name__)
 LOG.propagate = True
 HAVE_ICU = False
 _ICU_ERR = None
 _HDLR = None
+# Mirrors gen.const.URL_WIKISTRING, which can't be imported here: gen.const
+# is what constructs the primary GrampsLocale instance in the first place.
+_LOCALE_WIKI_URL = (
+    "https://gramps-project.org/wiki/index.php?title=Gramps_%s.%s_Wiki_Manual"
+    "_-_Setting_up_language_environment" % (VERSION_TUPLE[0], VERSION_TUPLE[1])
+)
 # GrampsLocale initialization comes before command-line argument
 # passing, so one must set the log level directly. The default is
 # logging.WARN. Uncomment the following to change it to logging.DEBUG:
@@ -79,6 +86,30 @@ _RTL_LOCALES = ("ar", "he")
 
 # locales with less than 70% currently translated
 INCOMPLETE_TRANSLATIONS = ("ar", "ba", "bg", "ko", "sq", "zh_HK", "zh_TW")
+
+
+def _locale_is_installed(lang: str) -> bool:
+    """
+    Probe whether ``lang`` (a full locale such as "fi_FI.UTF-8") is
+    actually installed on this system, without leaving any lasting effect
+    on the process locale.
+
+    Gtk will make its own setlocale(LC_ALL, "") call against the LANG
+    we're about to write into the environment, and silently falls back to
+    the 'C' locale if the C library rejects it, degrading date, number,
+    and sort-order formatting with only a generic "Locale not supported by
+    C library" message and no indication of why. Callers use this to log
+    something actionable instead, once translations are available (they
+    aren't yet, this early in GrampsLocale's own construction).
+    """
+    previous = locale.setlocale(locale.LC_ALL)
+    try:
+        locale.setlocale(locale.LC_ALL, lang)
+    except locale.Error:
+        return False
+    else:
+        locale.setlocale(locale.LC_ALL, previous)
+        return True
 
 
 def _check_gformat():
@@ -281,6 +312,8 @@ class GrampsLocale:
         )
         LOG.addHandler(_HDLR)
 
+        self._missing_locale: str | None = None
+
         # Now that we have a logger set up we can issue the icu error if needed.
         if not HAVE_ICU:
             LOG.warning(_ICU_ERR)
@@ -348,6 +381,15 @@ class GrampsLocale:
                 lang = ".".join((check_lang[0], "UTF-8"))
 
         os.environ["LANG"] = lang
+        if (
+            check_lang[0] not in ("C", "en")
+            and sys.platform not in ("darwin", "win32")
+            and not _locale_is_installed(lang)
+        ):
+            # Translations aren't available yet this early in construction
+            # (self.translation is set later, in __init__); remember the
+            # missing locale and warn about it once they are.
+            self._missing_locale = lang
         # We need to convert 'en' and 'en_US' to 'C' to avoid confusing
         # GtkBuilder when it's retrieving strings from our Glade files
         # since we have neither an en.po nor an en_US.po.
@@ -497,6 +539,22 @@ class GrampsLocale:
             )
             self.translation = GrampsNullTranslations()
             self.translation.lang = "en"
+
+        if getattr(self, "_missing_locale", None):
+            _ = self.translation.gettext
+            LOG.warning(
+                _(
+                    "Gramps could not find the system locale %(locale)s "
+                    "needed for the language %(language)s. Dates, numbers, "
+                    "and sorting may not display correctly until it is "
+                    "installed. See %(wiki_url)s for instructions."
+                )
+                % {
+                    "locale": self._missing_locale,
+                    "language": self.language[0],
+                    "wiki_url": _LOCALE_WIKI_URL,
+                }
+            )
 
         if _HDLR:
             LOG.removeHandler(_HDLR)

--- a/gramps/gen/utils/test/grampslocale_test.py
+++ b/gramps/gen/utils/test/grampslocale_test.py
@@ -349,5 +349,48 @@ class StrcollTest(unittest.TestCase):
         self.assertEqual(self.glocale.strcoll("Abel", "Abel"), 0)
 
 
+class LocaleIsInstalledTest(unittest.TestCase):
+    """
+    Tests for _locale_is_installed(), which probes whether a full locale
+    (e.g. "fi_FI.UTF-8") is actually installed on this system.
+
+    GrampsLocale.__init_first_instance() uses this to detect, ahead of
+    time, the same condition that otherwise surfaces only as Gtk's own
+    opaque "Locale not supported by C library" warning once Gtk makes its
+    own setlocale(LC_ALL, "") call. When the probe fails, GrampsLocale.
+    __init__ later logs a translatable warning -- once self.translation
+    exists, which it doesn't yet this early in construction -- naming the
+    missing locale, the Gramps language that needed it, and a wiki link.
+    """
+
+    def test_uninstalled_locale_is_reported_missing(self):
+        from ..grampslocale import _locale_is_installed
+
+        self.assertFalse(_locale_is_installed("xx_XX.UTF-8"))
+
+    def test_installed_locale_is_reported_present(self):
+        from ..grampslocale import _locale_is_installed
+
+        self.assertTrue(_locale_is_installed("C"))
+
+    def test_process_locale_restored_after_successful_probe(self):
+        import locale
+
+        from ..grampslocale import _locale_is_installed
+
+        before = locale.setlocale(locale.LC_ALL)
+        _locale_is_installed("C")
+        self.assertEqual(locale.setlocale(locale.LC_ALL), before)
+
+    def test_process_locale_unchanged_after_failed_probe(self):
+        import locale
+
+        from ..grampslocale import _locale_is_installed
+
+        before = locale.setlocale(locale.LC_ALL)
+        _locale_is_installed("xx_XX.UTF-8")
+        self.assertEqual(locale.setlocale(locale.LC_ALL), before)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

Currently, gramps displays the following when a language pack is not installed:

```
(Gramps.py:2401429): Gtk-WARNING **: 05:37:58.349: Locale not supported by C library.
	Using the fallback 'C' locale.
```

We add the following translatable text:

```
.gramps.gen.utils.grampslocale.WARNING: Gramps could not find the system locale 
fi_FI.UTF-8 needed for the language fi. Dates, numbers, and sorting may not display
correctly until it is installed. See 
https://gramps-project.org/wiki/index.php?title=Gramps_6.1_Wiki_Manual_-_Setting_up_language_environment 
for instructions.
```

Note: That URL doesn't exist, but I couldn't find a page that would be helpful. We should remove the URL or fill that page in.

## Summary
- Gramps resolves the chosen UI language to a full system locale (e.g. `fi_FI.UTF-8`) and writes it into `LANG` for Gtk to pick up.
- If that locale isn't actually installed, Gtk's own `setlocale(LC_ALL, "")` call silently falls back to the `'C'` locale, printing only a generic, unhelpful warning: `Locale not supported by C library. Using the fallback 'C' locale.`
- `GrampsLocale` now probes for this ahead of time (`_locale_is_installed()`), and once translations are available (they aren't yet this early in construction), logs a translatable warning naming the missing locale, the language that needed it, and a wiki link with instructions on how to install it.

## Test plan
- [x] `black --check` on changed files
- [x] `mypy` on changed files
- [x] `python3 -m unittest gramps.gen.utils.test.grampslocale_test` — all passing, including new `LocaleIsInstalledTest` cases
- [x] Manually reproduced: selecting a language whose locale isn't installed now logs `Gramps could not find the system locale fi_FI.UTF-8 needed for the language fi. Dates, numbers, and sorting may not display correctly until it is installed. See <wiki-url> for instructions.` instead of Gtk's opaque message; an installed language stays silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)