### PR TITLE
FamilySearch: fix 5 bugs, and 3 performance issues

### DIFF
--- a/gramps/gen/fs/compare/__init__.py
+++ b/gramps/gen/fs/compare/__init__.py
@@ -29,7 +29,7 @@ from .comparators import (
     compare_spouses,
     compare_other_facts,
 )
-from .aggregate import compare_fs_to_gramps
+from .aggregate import compare_fs_to_gramps, backfill_last_modified
 
 __all__ = [
     "person_dates_str",
@@ -42,4 +42,5 @@ __all__ = [
     "compare_spouses",
     "compare_other_facts",
     "compare_fs_to_gramps",
+    "backfill_last_modified",
 ]

--- a/gramps/gen/fs/compare/aggregate.py
+++ b/gramps/gen/fs/compare/aggregate.py
@@ -71,11 +71,20 @@ def _ui_row(row: Any) -> Any:
 
 
 def compare_fs_to_gramps(
-    fs_person: Any, gr_person: Person, db: Any, model: Any = None, dupdoc: bool = False
+    fs_person: Any,
+    gr_person: Person,
+    db: Any,
+    model: Any = None,
+    dupdoc: bool = False,
+    txn: Any = None,
 ):
     """
     stores comparison timestamps/flags on the Person
     via db_familysearch.FSStatusDB (JSON attribute blob).
+
+    :param txn: optional shared DbTxn to commit the status update into,
+        instead of opening a new one. Pass this when calling in a loop
+        over many people, to avoid one commit (and GUI signal) per person.
     """
     db_state = db_familysearch.FSStatusDB(db, gr_person.handle)
     db_state.get()
@@ -318,7 +327,7 @@ def compare_fs_to_gramps(
 
     # Persist the updated db_state
     try:
-        db_state.commit()
+        db_state.commit(txn)
     except Exception:
         pass
 

--- a/gramps/gen/fs/compare/aggregate.py
+++ b/gramps/gen/fs/compare/aggregate.py
@@ -20,10 +20,11 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor, as_completed
 import email.utils
 import logging
 import time
-from typing import Any, Optional, Tuple
+from typing import Any, Callable, Optional, Tuple
 
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.lib import EventType, Person
@@ -68,6 +69,123 @@ def _ui_row(row: Any) -> Any:
     r = list(row)
     r[0] = _ui_color(r[0])
     return r
+
+
+def _resolve_last_modified(
+    fs_session: Any, fs_id: str
+) -> tuple[list[str], int | None, str | None]:
+    """
+    Follow FSID redirects and resolve Last-Modified/Etag for one person.
+
+    Pure network I/O -- safe to run from a worker thread. Returns the chain
+    of redirected-to FSIDs (empty if none), the resolved Last-Modified as a
+    Unix timestamp (or None if unavailable), and the Etag (or None).
+    """
+    redirects: list[str] = []
+    path = "/platform/tree/persons/" + fs_id
+    r = fs_session.head_url(path)
+
+    while (
+        r is not None
+        and getattr(r, "status_code", 0) == 301
+        and hasattr(r, "headers")
+        and "X-Entity-Forwarded-Id" in r.headers
+    ):
+        fs_id = r.headers["X-Entity-Forwarded-Id"]
+        redirects.append(fs_id)
+        path = "/platform/tree/persons/" + fs_id
+        r = fs_session.head_url(path)
+
+    last_modified: int | None = None
+    etag: str | None = None
+    if r is not None and hasattr(r, "headers"):
+        if "Last-Modified" in r.headers:
+            try:
+                last_modified = int(
+                    time.mktime(email.utils.parsedate(r.headers["Last-Modified"]))
+                )
+            except Exception:
+                last_modified = None
+        if "Etag" in r.headers:
+            etag = r.headers["Etag"]
+
+    return redirects, last_modified, etag
+
+
+def backfill_last_modified(
+    db: Any,
+    pairs: list[tuple[Any, Person]],
+    progress_callback: Callable[[], None] | None = None,
+    max_workers: int = 8,
+) -> int:
+    """
+    Concurrently resolve Last-Modified/Etag for FamilySearch persons that
+    don't already have it cached, following FSID redirects along the way.
+
+    compare_fs_to_gramps() issues this same HEAD request per person, one at
+    a time, whenever a person's Last-Modified wasn't already captured
+    during download -- for a large bulk import that serial fallback can add
+    up to many minutes. Call this once, before comparing a batch of
+    persons, to resolve them all concurrently first; compare_fs_to_gramps()
+    then finds Last-Modified already set and skips its own network call.
+
+    :param pairs: (fs_person, gr_person) pairs to resolve. Pairs whose
+        fs_person already has a Last-Modified are skipped.
+    :param progress_callback: optional callable invoked after each
+        concurrent resolution completes.
+    :returns: the number of persons successfully resolved.
+    """
+    fs_session = getattr(tree, "_fs_session", None)
+    if fs_session is None:
+        return 0
+
+    to_resolve = [
+        (fs_person, gr_person)
+        for fs_person, gr_person in pairs
+        if getattr(fs_person, "id", None)
+        and not getattr(fs_person, "_last_modified", 0)
+    ]
+    if not to_resolve:
+        return 0
+
+    resolved = 0
+    max_workers = min(max_workers, len(to_resolve))
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {
+            executor.submit(_resolve_last_modified, fs_session, fs_person.id): (
+                fs_person,
+                gr_person,
+            )
+            for fs_person, gr_person in to_resolve
+        }
+        for future in as_completed(futures):
+            fs_person, gr_person = futures[future]
+            try:
+                redirects, last_modified, etag = future.result()
+            except Exception:
+                logger.warning(
+                    "Failed to backfill Last-Modified for FamilySearch id %s",
+                    fs_person.id,
+                    exc_info=True,
+                )
+                if progress_callback is not None:
+                    progress_callback()
+                continue
+
+            for fsid in redirects:
+                fs_utilities.link_gramps_fs_id(db, gr_person, fsid)
+            if redirects:
+                fs_person.id = redirects[-1]
+            if last_modified is not None:
+                fs_person._last_modified = last_modified
+                resolved += 1
+            if etag is not None:
+                fs_person._etag = etag
+
+            if progress_callback is not None:
+                progress_callback()
+
+    return resolved
 
 
 def compare_fs_to_gramps(

--- a/gramps/gen/fs/compare/test/aggregate_test.py
+++ b/gramps/gen/fs/compare/test/aggregate_test.py
@@ -1,0 +1,196 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Tests for backfill_last_modified in gramps/gen/fs/compare/aggregate.py.
+
+# python3 -m unittest gramps.gen.fs.compare.test.aggregate_test -v
+"""
+
+import os
+import shutil
+import tempfile
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+ROOT_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "..", "..")
+)
+
+
+def _ensure_test_resources():
+    resource_path = os.environ.get("GRAMPS_RESOURCES")
+    if resource_path and os.path.exists(
+        os.path.join(resource_path, "gramps", "authors.xml")
+    ):
+        return resource_path
+
+    build_share = os.path.join(ROOT_DIR, "build", "share")
+    if os.path.exists(os.path.join(build_share, "gramps", "authors.xml")):
+        return build_share
+
+    resource_path = tempfile.mkdtemp(prefix="gramps-resources-")
+    os.makedirs(os.path.join(resource_path, "gramps", "images"), exist_ok=True)
+    os.makedirs(os.path.join(resource_path, "doc", "gramps"), exist_ok=True)
+    os.makedirs(os.path.join(resource_path, "locale"), exist_ok=True)
+
+    shutil.copyfile(
+        os.path.join(ROOT_DIR, "data", "authors.xml"),
+        os.path.join(resource_path, "gramps", "authors.xml"),
+    )
+    shutil.copyfile(
+        os.path.join(ROOT_DIR, "images", "gramps.png"),
+        os.path.join(resource_path, "gramps", "images", "gramps.png"),
+    )
+    shutil.copyfile(
+        os.path.join(ROOT_DIR, "COPYING"),
+        os.path.join(resource_path, "doc", "gramps", "COPYING"),
+    )
+    return resource_path
+
+
+os.environ["GRAMPS_RESOURCES"] = _ensure_test_resources()
+os.environ["HOME"] = os.environ.get("HOME") or tempfile.mkdtemp(prefix="gramps-home-")
+
+import gramps.gen.fs.tree as tree_mod
+from gramps.gen.fs.compare import aggregate
+
+
+def _fs_person(fsid, last_modified=0):
+    person = types.SimpleNamespace()
+    person.id = fsid
+    if last_modified:
+        person._last_modified = last_modified
+    return person
+
+
+def _response(status_code=200, headers=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.headers = headers or {}
+    return resp
+
+
+# -------------------------------------------------------------------------
+#
+# TestBackfillLastModified
+#
+# -------------------------------------------------------------------------
+class TestBackfillLastModified(unittest.TestCase):
+    """Tests for aggregate.backfill_last_modified."""
+
+    def setUp(self):
+        tree_mod._fs_session = None
+
+    def tearDown(self):
+        tree_mod._fs_session = None
+
+    def test_no_session_returns_zero_without_error(self):
+        """When _fs_session is None, returns 0 and touches nothing."""
+        pairs = [(_fs_person("FS-001"), MagicMock())]
+        result = aggregate.backfill_last_modified(MagicMock(), pairs)
+        self.assertEqual(result, 0)
+
+    def test_already_has_last_modified_is_skipped(self):
+        """Pairs whose fs_person already has _last_modified are never fetched."""
+        session = MagicMock()
+        tree_mod._fs_session = session
+        pairs = [(_fs_person("FS-010", last_modified=123), MagicMock())]
+
+        result = aggregate.backfill_last_modified(MagicMock(), pairs)
+
+        session.head_url.assert_not_called()
+        self.assertEqual(result, 0)
+
+    def test_resolves_last_modified_and_etag_concurrently(self):
+        """Two persons needing backfill are both resolved and updated."""
+        session = MagicMock()
+        session.head_url.return_value = _response(
+            headers={"Last-Modified": "Mon, 01 Jan 2024 00:00:00 GMT", "Etag": "abc"}
+        )
+        tree_mod._fs_session = session
+
+        fs_a = _fs_person("FS-020")
+        fs_b = _fs_person("FS-021")
+        pairs = [(fs_a, MagicMock()), (fs_b, MagicMock())]
+
+        result = aggregate.backfill_last_modified(MagicMock(), pairs)
+
+        self.assertEqual(result, 2)
+        self.assertTrue(getattr(fs_a, "_last_modified", 0))
+        self.assertTrue(getattr(fs_b, "_last_modified", 0))
+        self.assertEqual(fs_a._etag, "abc")
+        self.assertEqual(fs_b._etag, "abc")
+
+    def test_progress_callback_called_once_per_pair(self):
+        """progress_callback fires once per resolved pair, not per HTTP call."""
+        session = MagicMock()
+        session.head_url.return_value = _response(headers={})
+        tree_mod._fs_session = session
+
+        pairs = [
+            (_fs_person("FS-030"), MagicMock()),
+            (_fs_person("FS-031"), MagicMock()),
+        ]
+        callback = MagicMock()
+
+        aggregate.backfill_last_modified(MagicMock(), pairs, progress_callback=callback)
+
+        self.assertEqual(callback.call_count, 2)
+
+    def test_redirect_chain_relinks_fsid_and_updates_person(self):
+        """A 301 redirect follows to the new FSID and calls link_gramps_fs_id."""
+        session = MagicMock()
+        redirect_resp = _response(
+            status_code=301, headers={"X-Entity-Forwarded-Id": "FS-NEW"}
+        )
+        final_resp = _response(
+            headers={"Last-Modified": "Mon, 01 Jan 2024 00:00:00 GMT"}
+        )
+        session.head_url.side_effect = [redirect_resp, final_resp]
+        tree_mod._fs_session = session
+
+        fs_person = _fs_person("FS-040")
+        gr_person = MagicMock()
+        pairs = [(fs_person, gr_person)]
+
+        with patch.object(aggregate.fs_utilities, "link_gramps_fs_id") as mock_link:
+            db = MagicMock()
+            aggregate.backfill_last_modified(db, pairs)
+
+        mock_link.assert_called_once_with(db, gr_person, "FS-NEW")
+        self.assertEqual(fs_person.id, "FS-NEW")
+        self.assertTrue(getattr(fs_person, "_last_modified", 0))
+
+    def test_resolve_exception_is_logged_and_does_not_raise(self):
+        """A failure resolving one person is logged and does not abort the batch."""
+        session = MagicMock()
+        session.head_url.side_effect = RuntimeError("network failure")
+        tree_mod._fs_session = session
+
+        pairs = [(_fs_person("FS-050"), MagicMock())]
+
+        with patch.object(aggregate, "logger"):
+            result = aggregate.backfill_last_modified(MagicMock(), pairs)
+
+        self.assertEqual(result, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gen/fs/session.py
+++ b/gramps/gen/fs/session.py
@@ -509,6 +509,9 @@ class Session(requests.Session):
         self.listen_timeout: int = int(
             os.environ.get("GRAMPS_FS_LISTENER_TIMEOUT", "300") or "300"
         )
+        self.api_timeout_s: int = int(
+            os.environ.get("GRAMPS_FS_API_TIMEOUT", "30") or "30"
+        )
         self.auth_provider: str = _normalize_auth_provider(
             os.environ.get("GRAMPS_FS_AUTH_PROVIDER", "").strip()
             or str(
@@ -940,6 +943,7 @@ class Session(requests.Session):
         return method(url, **retry_kwargs)
 
     def _route_api_request(self, method_name: str, url: str, **kwargs):
+        kwargs.setdefault("timeout", self.api_timeout_s)
         text_url = str(url)
         if self._using_foundation_middleware() and text_url.startswith(
             ("http://", "https://")

--- a/gramps/gen/fs/session.py
+++ b/gramps/gen/fs/session.py
@@ -480,6 +480,10 @@ class Session(requests.Session):
         self.access_token: str | None = None
         self.refresh_token: str | None = None
         self.id_token: str | None = None
+        # Serializes token refreshes so concurrent 401s (e.g. from the
+        # importer's worker threads) don't each kick off their own
+        # refresh request against the same login.
+        self._token_refresh_lock = threading.Lock()
         self.foundation_base_url: str = _normalize_base_url(
             os.environ.get("GRAMPS_FS_FOUNDATION_BASE_URL", "").strip()
             or str(_cfg_get("familysearch.middleware.base-url", "") or "").strip()
@@ -922,9 +926,15 @@ class Session(requests.Session):
             return False
 
     def refresh_access_token(self) -> bool:
-        if self._using_foundation_middleware():
-            return self._refresh_foundation_access_token()
-        return self._refresh_direct_access_token()
+        token_before = self.access_token
+        with self._token_refresh_lock:
+            if self.access_token != token_before:
+                # Another thread already refreshed the token while we
+                # were waiting for the lock; no need to do it again.
+                return True
+            if self._using_foundation_middleware():
+                return self._refresh_foundation_access_token()
+            return self._refresh_direct_access_token()
 
     def _request_with_api_retry(self, method_name: str, url: str, **kwargs):
         method = getattr(super(), method_name)

--- a/gramps/gen/fs/test/tree_test.py
+++ b/gramps/gen/fs/test/tree_test.py
@@ -229,6 +229,40 @@ class TestAddPersons(unittest.TestCase):
         # FS-031 failed — it may or may not be in _persons, but no exception should propagate
         # (the important guarantee is that the call didn't raise)
 
+    def test_add_persons_progress_callback_called_once_per_fetch(self):
+        """progress_callback is invoked once per completed fetch, success or failure."""
+        mock_person_a = MagicMock(spec=deserialize.Person)
+        mock_response = MagicMock()
+        mock_response.headers = {}
+
+        deserialize.Person.index["FS-040"] = mock_person_a
+
+        def fake_fetch_raw(fsid):
+            if fsid == "FS-041":
+                raise RuntimeError("network failure")
+            return (fsid, mock_response, {"persons": [{"id": fsid}]})
+
+        callback = MagicMock()
+
+        with patch("gramps.gen.fs.tree.LOG"):
+            with patch.object(self.tree, "_fetch_raw", side_effect=fake_fetch_raw):
+                with patch("gramps.gen.fs.tree.deserialize.deserialize_json"):
+                    self.tree.add_persons(
+                        ["FS-040", "FS-041"], progress_callback=callback
+                    )
+
+        self.assertEqual(callback.call_count, 2)
+
+    def test_add_persons_no_fetch_needed_never_calls_progress_callback(self):
+        """progress_callback is not called when every fid is already cached."""
+        mock_person = MagicMock(spec=deserialize.Person)
+        self.tree._persons["FS-050"] = mock_person
+
+        callback = MagicMock()
+        self.tree.add_persons(["FS-050"], progress_callback=callback)
+
+        callback.assert_not_called()
+
 
 # -------------------------------------------------------------------------
 #

--- a/gramps/gen/fs/tree.py
+++ b/gramps/gen/fs/tree.py
@@ -21,7 +21,7 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Iterable, Set
+from typing import Callable, Iterable, Set
 import calendar
 import email.utils
 import logging
@@ -100,10 +100,19 @@ class Tree(deserialize.Gedcomx):
 
         self._persons[fsid] = fs_person
 
-    def add_persons(self, fids: Iterable[str]) -> None:
+    def add_persons(
+        self,
+        fids: Iterable[str],
+        progress_callback: Callable[[], None] | None = None,
+    ) -> None:
         """
         Add multiple FamilySearch persons, fetching HTTP responses concurrently
         and deserializing sequentially to avoid shared-state races.
+
+        :param progress_callback: optional callable invoked after each
+            concurrent fetch completes, so a caller (e.g. the GUI layer) can
+            report progress and keep the interface responsive during what
+            may be a long-running batch of network requests.
         """
         requested_fids = list(fids)
         to_fetch = [fid for fid in requested_fids if fid not in self._persons]
@@ -126,6 +135,8 @@ class Tree(deserialize.Gedcomx):
                             futures[future],
                             exc_info=True,
                         )
+                    if progress_callback is not None:
+                        progress_callback()
 
             for fid in to_fetch:
                 if fid not in raw_results:
@@ -151,7 +162,11 @@ class Tree(deserialize.Gedcomx):
             if fid not in self._persons and fid in deserialize.Person.index:
                 self._persons[fid] = deserialize.Person.index[fid]
 
-    def add_parents(self, fids: Set[str]) -> Set[str]:
+    def add_parents(
+        self,
+        fids: Set[str],
+        progress_callback: Callable[[], None] | None = None,
+    ) -> Set[str]:
         rels: Set[str] = set()
         for fid in fids & set(self._persons.keys()):
             p = self._persons[fid]
@@ -167,10 +182,14 @@ class Tree(deserialize.Gedcomx):
                     rels.add(cp.parent2.resourceId)
 
         rels.difference_update(fids)
-        self.add_persons(rels)
+        self.add_persons(rels, progress_callback=progress_callback)
         return set(filter(None, rels))
 
-    def add_spouses(self, fids: Set[str]) -> Set[str]:
+    def add_spouses(
+        self,
+        fids: Set[str],
+        progress_callback: Callable[[], None] | None = None,
+    ) -> Set[str]:
         rels: Set[str] = set()
         for fid in fids & set(self._persons.keys()):
             p = self._persons[fid]
@@ -188,10 +207,14 @@ class Tree(deserialize.Gedcomx):
                     rels.add(family.parent2.resourceId)
 
         rels.difference_update(fids)
-        self.add_persons(rels)
+        self.add_persons(rels, progress_callback=progress_callback)
         return set(filter(None, rels))
 
-    def add_children(self, fids: Set[str]) -> Set[str]:
+    def add_children(
+        self,
+        fids: Set[str],
+        progress_callback: Callable[[], None] | None = None,
+    ) -> Set[str]:
         rels: Set[str] = set()
         for fid in fids & set(self._persons.keys()):
             p = self._persons[fid]
@@ -215,7 +238,7 @@ class Tree(deserialize.Gedcomx):
                         rels.add(child.resourceId)
 
         rels.difference_update(fids)
-        self.add_persons(rels)
+        self.add_persons(rels, progress_callback=progress_callback)
         return set(filter(None, rels))
 
 

--- a/gramps/gen/fs/utils/__init__.py
+++ b/gramps/gen/fs/utils/__init__.py
@@ -4,7 +4,7 @@ from .attributes import get_fsftid, get_internet_address
 from .dates import fs_date_to_gramps_date, gramps_date_to_formal
 from .events import get_fs_fact, get_gramps_event
 from .index import FS_INDEX_PEOPLE, FS_INDEX_PLACES
-from .linking import link_gramps_fs_id
+from .linking import link_gramps_fs_id, link_gramps_fs_id_by_handle
 
 __all__ = [
     "FS_INDEX_PEOPLE",
@@ -16,4 +16,5 @@ __all__ = [
     "get_gramps_event",
     "get_internet_address",
     "link_gramps_fs_id",
+    "link_gramps_fs_id_by_handle",
 ]

--- a/gramps/gen/fs/utils/linking.py
+++ b/gramps/gen/fs/utils/linking.py
@@ -80,3 +80,32 @@ def link_gramps_fs_id(db: Any, gr_object: Any, fsid: str) -> None:
 
     if internal_txn:
         db.transaction_commit(txn)
+
+
+def link_gramps_fs_id_by_handle(
+    db: Any, handle: Optional[str], fallback_object: Any, fsid: str
+) -> Any:
+    """
+    Attach/update the _FSFTID attribute on the database's own copy of a
+    person and commit it, so a FamilySearch link is saved immediately,
+    independent of any other unsaved edits sitting in a live person
+    editor for the same person.
+
+    Falls back to committing `fallback_object` directly when `handle`
+    does not resolve in the database, e.g. a brand-new, not-yet-saved
+    person for which there is no separate database copy to commit.
+
+    :returns: the object that was actually committed.
+    """
+    target = None
+    if isinstance(handle, str) and handle:
+        try:
+            target = db.get_person_from_handle(handle)
+        except Exception:
+            target = None
+
+    if target is None:
+        target = fallback_object
+
+    link_gramps_fs_id(db, target, fsid)
+    return target

--- a/gramps/gui/fs/actions.py
+++ b/gramps/gui/fs/actions.py
@@ -62,6 +62,7 @@ from gramps.gen.fs.fs_import import deserializer as deserialize
 from gramps.gen.fs.fs_import.notes import add_note
 import gramps.gen.fs.person.mixins.cache as cache_mod
 from gramps.gui.dialog import ErrorDialog, OkDialog, QuestionDialog2
+from gramps.gui.display import display_url
 
 from . import sync_directions
 from . import ui as fs_ui
@@ -226,6 +227,35 @@ def compare_person(dbstate, uistate, track, person, session, parent, editor=None
         )
     except TypeError:
         CompareWindow(dbstate, uistate, track, person, fsid, session, parent)
+
+
+def _fs_url_lang() -> str:
+    """Return a 2-letter language code for FamilySearch URLs, defaulting to 'en'."""
+    try:
+        lang = (glocale.language[0] or "en")[:2].lower()
+    except Exception:
+        return "en"
+    return lang if lang.isalpha() else "en"
+
+
+def open_person_in_familysearch(
+    dbstate, uistate, track, person, session, parent, editor=None
+):
+    """Open the current person's FamilySearch person page in a web browser."""
+    _bind_global_session(session)
+
+    fsid = _get_fs_id(person)
+    if not fsid:
+        _info(
+            parent,
+            _("FamilySearch"),
+            _("No FamilySearch ID linked.\nClick 'Link FamilySearch ID' first."),
+        )
+        return
+
+    display_url(
+        f"https://www.familysearch.org/{_fs_url_lang()}/tree/person/details/{fsid}"
+    )
 
 
 # --------------------------

--- a/gramps/gui/fs/actions.py
+++ b/gramps/gui/fs/actions.py
@@ -37,6 +37,7 @@ from gramps.gen.db import DbTxn
 from gramps.gen.display.name import displayer as name_displayer
 from gramps.gen.fs import tags as fs_tags
 from gramps.gen.fs import tree as fs_tree
+from gramps.gen.fs import utils as fs_utilities
 from gramps.gen.lib import Family, Person, EventRef, EventRoleType, EventType
 from gramps.gen.fs.actions import (
     _bind_global_session,
@@ -188,7 +189,20 @@ def link_familysearch_id(dbstate, uistate, track, person, session, parent, edito
     dlg.show_all()
     resp = dlg.run()
     if resp == Gtk.ResponseType.OK:
-        _set_fs_id(target_person, entry.get_text())
+        fsid = entry.get_text()
+        _set_fs_id(target_person, fsid)
+
+        # A link, once made, should be durable even if the live person
+        # editor is later cancelled -- persist it onto the database's
+        # own copy of this person, independent of any other unsaved
+        # edits sitting in the editor.
+        handle = getattr(target_person, "handle", None)
+        try:
+            fs_utilities.link_gramps_fs_id_by_handle(
+                dbstate.db, handle, target_person, fsid
+            )
+        except Exception:
+            pass
 
         if editor is not None and hasattr(editor, "attr_list"):
             try:

--- a/gramps/gui/fs/compare/window.py
+++ b/gramps/gui/fs/compare/window.py
@@ -107,18 +107,13 @@ class CompareWindow:
                     db = self.dbstate.get_database()
 
                 # self.person may be the live, in-progress object from an
-                # open person editor. Link/commit a fresh copy loaded from
-                # the db instead, so any of the editor's other unsaved
-                # field edits are never persisted as a side effect of
-                # opening the compare window.
-                commit_target = self.person
-                if isinstance(person_handle, str) and person_handle:
-                    try:
-                        commit_target = db.get_person_from_handle(person_handle)
-                    except Exception:
-                        commit_target = self.person
-
-                fs_utilities.link_gramps_fs_id(db, commit_target, self.fsid)
+                # open person editor. Link/commit the db's own copy
+                # instead, so any of the editor's other unsaved field
+                # edits are never persisted as a side effect of opening
+                # the compare window.
+                fs_utilities.link_gramps_fs_id_by_handle(
+                    db, person_handle, self.person, self.fsid
+                )
         except Exception:
             pass
 

--- a/gramps/gui/fs/compare/window.py
+++ b/gramps/gui/fs/compare/window.py
@@ -96,21 +96,34 @@ class CompareWindow:
         except Exception:
             pass
 
+        # person handle
+        person_handle = getattr(self.person, "handle", None) or self.person
+
         try:
             if self.fsid:
                 try:
                     db = self.dbstate.db
                 except Exception:
                     db = self.dbstate.get_database()
-                fs_utilities.link_gramps_fs_id(db, self.person, self.fsid)
+
+                # self.person may be the live, in-progress object from an
+                # open person editor. Link/commit a fresh copy loaded from
+                # the db instead, so any of the editor's other unsaved
+                # field edits are never persisted as a side effect of
+                # opening the compare window.
+                commit_target = self.person
+                if isinstance(person_handle, str) and person_handle:
+                    try:
+                        commit_target = db.get_person_from_handle(person_handle)
+                    except Exception:
+                        commit_target = self.person
+
+                fs_utilities.link_gramps_fs_id(db, commit_target, self.fsid)
         except Exception:
             pass
 
         # parent window
         parent_win = self.parent or getattr(self.uistate, "window", None)
-
-        # person handle
-        person_handle = getattr(self.person, "handle", None) or self.person
 
         class _UistateProxy:
             """

--- a/gramps/gui/fs/fs_import/__init__.py
+++ b/gramps/gui/fs/fs_import/__init__.py
@@ -23,5 +23,6 @@ from __future__ import annotations
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 
 _ = glocale.translation.gettext
+ngettext = glocale.translation.ngettext
 
-__all__ = ["_"]
+__all__ = ["_", "ngettext"]

--- a/gramps/gui/fs/fs_import/importer.py
+++ b/gramps/gui/fs/fs_import/importer.py
@@ -23,6 +23,11 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import json
 from typing import Any
 
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk  # noqa: E402
+
 from gramps.gen.db import DbTxn
 from gramps.gui.dialog import WarningDialog
 from gramps.gui.utils import ProgressMeter
@@ -40,6 +45,19 @@ from gramps.gen.fs import utils as fs_utilities
 import gramps.gui.fs.person.fsg_sync as FSG_Sync
 from gramps.gui.fs.utils.index import build_fs_index
 from gramps.gen.fs.compare import compare_fs_to_gramps
+
+
+def _pump_gtk_events() -> None:
+    """
+    Process pending GTK events.
+
+    The bulk download phases block the main thread on network I/O in
+    ThreadPoolExecutor batches, so without this the window manager sees an
+    unresponsive main loop and offers to force-quit the app even though the
+    download is progressing normally.
+    """
+    while Gtk.events_pending():
+        Gtk.main_iteration()
 
 
 class FSToGrampsImporter(CoreFSToGrampsImporter):
@@ -93,7 +111,9 @@ class FSToGrampsImporter(CoreFSToGrampsImporter):
         )
         print(_("Downloading person…"))
         if self.FS_ID:
-            self.fs_TreeImp.add_persons([self.FS_ID])
+            self.fs_TreeImp.add_persons(
+                [self.FS_ID], progress_callback=_pump_gtk_events
+            )
         else:
             if signals_disabled:
                 caller.dbstate.db.enable_signals()
@@ -112,7 +132,12 @@ class FSToGrampsImporter(CoreFSToGrampsImporter):
                 break
             done |= todo
             print(_("Downloading %d generations of ancestors…") % (i + 1))
-            todo = self.fs_TreeImp.add_parents(set(todo)) - done
+            todo = (
+                self.fs_TreeImp.add_parents(
+                    set(todo), progress_callback=_pump_gtk_events
+                )
+                - done
+            )
 
         progress.set_pass(_("Downloading descendants… (5/11)"), self.desc)
         todo = set(self.fs_TreeImp._persons.keys())
@@ -123,7 +148,12 @@ class FSToGrampsImporter(CoreFSToGrampsImporter):
                 break
             done |= todo
             print(_("Downloading %d generations of descendants…") % (i + 1))
-            todo = self.fs_TreeImp.add_children(set(todo)) - done
+            todo = (
+                self.fs_TreeImp.add_children(
+                    set(todo), progress_callback=_pump_gtk_events
+                )
+                - done
+            )
 
         if self.include_spouses:
             progress.set_pass(
@@ -131,7 +161,7 @@ class FSToGrampsImporter(CoreFSToGrampsImporter):
             )
             print(_("Downloading spouses…"))
             todo = set(self.fs_TreeImp._persons.keys())
-            self.fs_TreeImp.add_spouses(set(todo))
+            self.fs_TreeImp.add_spouses(set(todo), progress_callback=_pump_gtk_events)
 
         if self.include_notes or self.include_sources:
             progress.set_pass(
@@ -193,6 +223,7 @@ class FSToGrampsImporter(CoreFSToGrampsImporter):
                             raw_payloads[url] = future.result()
                         except Exception as exc:
                             print(f"WARNING: failed to fetch {url}: {exc}")
+                        _pump_gtk_events()
 
             # Deserializing mutates shared tree state, so do it sequentially
             # in the main thread even though the fetches above ran

--- a/gramps/gui/fs/fs_import/importer.py
+++ b/gramps/gui/fs/fs_import/importer.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import json
+import logging
+import time
 from typing import Any
 
 import gi
@@ -45,6 +47,12 @@ from gramps.gen.fs import utils as fs_utilities
 import gramps.gui.fs.person.fsg_sync as FSG_Sync
 from gramps.gui.fs.utils.index import build_fs_index
 from gramps.gen.fs.compare import compare_fs_to_gramps
+
+LOG = logging.getLogger(__name__)
+
+# Log (and print) any single person's comparison refresh that takes longer
+# than this, to help pinpoint slow/stalled FamilySearch requests.
+_SLOW_COMPARE_THRESHOLD_S = 1.0
 
 
 def _pump_gtk_events() -> None:
@@ -306,8 +314,6 @@ class FSToGrampsImporter(CoreFSToGrampsImporter):
         self.txn = None
 
         print("import done.")
-        caller.uistate.set_busy_cursor(False)
-        progress.close()
 
         # Keep existing post-import compare refresh behavior in the GUI
         # layer, batched into a single transaction with signals suppressed.
@@ -316,17 +322,38 @@ class FSToGrampsImporter(CoreFSToGrampsImporter):
         # commits, each firing a live GUI signal and growing the undo
         # history by one entry -- effectively O(N) commits/signals/undo
         # entries instead of one.
+        #
+        # This pass can be slow: compare_fs_to_gramps() may issue a
+        # synchronous FamilySearch HEAD request per person if the person's
+        # Last-Modified wasn't already captured during download. The
+        # progress dialog is kept open (rather than closed before this
+        # loop, as before) so progress.step() keeps pumping GTK events and
+        # the app doesn't look hung while this runs.
+        compare_people = list(self.fs_TreeImp.persons or [])
+        progress.set_pass(
+            _("Refreshing comparison status…"),
+            len(compare_people) or 1,
+        )
+        print(_("Refreshing comparison status for %d people…") % len(compare_people))
+        compare_start = time.monotonic()
+        compared = 0
+        failed = 0
         caller.dbstate.db.disable_signals()
         try:
             with DbTxn(
                 "FamilySearch: refresh comparison status", caller.dbstate.db
             ) as compare_txn:
-                for fs_person in list(self.fs_TreeImp.persons or []):
+                for done, fs_person in enumerate(compare_people, start=1):
+                    progress.step()
                     gr_handle = fs_utilities.FS_INDEX_PEOPLE.get(fs_person.id)
                     if not gr_handle:
                         continue
                     gr_person = caller.dbstate.db.get_person_from_handle(gr_handle)
-                    if gr_person:
+                    if not gr_person:
+                        continue
+
+                    person_start = time.monotonic()
+                    try:
                         compare_fs_to_gramps(
                             fs_person,
                             gr_person,
@@ -334,10 +361,45 @@ class FSToGrampsImporter(CoreFSToGrampsImporter):
                             None,
                             txn=compare_txn,
                         )
+                        compared += 1
+                    except Exception:
+                        failed += 1
+                        LOG.warning(
+                            "Comparison refresh failed for FamilySearch id %s",
+                            fs_person.id,
+                            exc_info=True,
+                        )
+
+                    elapsed = time.monotonic() - person_start
+                    if elapsed > _SLOW_COMPARE_THRESHOLD_S:
+                        print(
+                            _("  …comparison for %(fsid)s took %(elapsed).1fs")
+                            % {"fsid": fs_person.id, "elapsed": elapsed}
+                        )
+                    if done == 1 or done % 25 == 0 or done == len(compare_people):
+                        print(
+                            _("  …comparison status: %(done)d/%(total)d")
+                            % {"done": done, "total": len(compare_people)}
+                        )
         except Exception:
-            pass
+            LOG.warning("Comparison refresh loop aborted early", exc_info=True)
         finally:
             caller.dbstate.db.enable_signals()
+
+        print(
+            _(
+                "Comparison status refresh done in %(elapsed).1fs "
+                "(%(compared)d compared, %(failed)d failed)"
+            )
+            % {
+                "elapsed": time.monotonic() - compare_start,
+                "compared": compared,
+                "failed": failed,
+            }
+        )
+
+        caller.uistate.set_busy_cursor(False)
+        progress.close()
 
         if signals_disabled and self.added_person:
             caller.dbstate.db.request_rebuild()

--- a/gramps/gui/fs/fs_import/importer.py
+++ b/gramps/gui/fs/fs_import/importer.py
@@ -19,7 +19,9 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor, as_completed
 import json
+from typing import Any
 
 from gramps.gen.db import DbTxn
 from gramps.gui.dialog import WarningDialog
@@ -138,52 +140,74 @@ class FSToGrampsImporter(CoreFSToGrampsImporter):
             )
             print(_("Downloading notes and sources…"))
 
-            def _fetch_into_tree(url_path: str) -> None:
+            def _fetch_raw(url_path: str) -> Any:
                 sess = getattr(tree, "_fs_session", None)
                 if sess is None:
-                    return
+                    return None
 
                 fn = getattr(sess, "get_jsonurl", None) or getattr(
                     sess, "get_json", None
                 )
                 if not callable(fn):
-                    return
+                    return None
 
-                payload = fn(url_path)
-                self._strip_unknowns(payload)
-                deserialize.deserialize_json(self.fs_TreeImp, payload)
-
-            def _load_person_extras(person_id: str) -> None:
-                _fetch_into_tree(f"/platform/tree/persons/{person_id}/notes")
-                _fetch_into_tree(f"/platform/tree/persons/{person_id}/sources")
-                _fetch_into_tree(f"/platform/tree/persons/{person_id}/memories")
-
-            def _load_couple_extras(rel_id: str) -> None:
-                _fetch_into_tree(f"/platform/tree/couple-relationships/{rel_id}/notes")
-                _fetch_into_tree(
-                    f"/platform/tree/couple-relationships/{rel_id}/sources"
-                )
+                return fn(url_path)
 
             fs_persons = list(self.fs_TreeImp.persons or [])
             fs_families = list(self.fs_TreeImp.relationships or [])
             total = len(fs_persons) + len(fs_families)
-            done = 0
 
-            for fs_person in fs_persons:
+            # Group the URLs to fetch per person/family (for progress
+            # reporting), but fetch all of them concurrently -- matching
+            # the worker count Tree.add_persons already uses for the
+            # ancestor/descendant/spouse phases. This was previously a
+            # fully serial loop: 3 requests per person + 2 per couple,
+            # one at a time, which was by far the slowest part of a bulk
+            # import.
+            work_items: list[list[str]] = [
+                [
+                    f"/platform/tree/persons/{fs_person.id}/notes",
+                    f"/platform/tree/persons/{fs_person.id}/sources",
+                    f"/platform/tree/persons/{fs_person.id}/memories",
+                ]
+                for fs_person in fs_persons
+            ] + [
+                [
+                    f"/platform/tree/couple-relationships/{fs_family.id}/notes",
+                    f"/platform/tree/couple-relationships/{fs_family.id}/sources",
+                ]
+                for fs_family in fs_families
+            ]
+
+            all_urls = [url for urls in work_items for url in urls]
+            raw_payloads: dict[str, Any] = {}
+            if all_urls:
+                max_workers = min(8, len(all_urls))
+                with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                    futures = {
+                        executor.submit(_fetch_raw, url): url for url in all_urls
+                    }
+                    for future in as_completed(futures):
+                        url = futures[future]
+                        try:
+                            raw_payloads[url] = future.result()
+                        except Exception as exc:
+                            print(f"WARNING: failed to fetch {url}: {exc}")
+
+            # Deserializing mutates shared tree state, so do it sequentially
+            # in the main thread even though the fetches above ran
+            # concurrently.
+            done = 0
+            for urls in work_items:
                 progress.step()
-                _load_person_extras(fs_person.id)
+                for url in urls:
+                    payload = raw_payloads.get(url)
+                    if not payload:
+                        continue
+                    self._strip_unknowns(payload)
+                    deserialize.deserialize_json(self.fs_TreeImp, payload)
                 done += 1
                 if done == 1 or done % 25 == 0 or done == total:
-                    print(
-                        _("  …notes/sources: %(done)d/%(total)d")
-                        % {"done": done, "total": total}
-                    )
-
-            for fs_family in fs_families:
-                progress.step()
-                _load_couple_extras(fs_family.id)
-                done += 1
-                if done % 25 == 0 or done == total:
                     print(
                         _("  …notes/sources: %(done)d/%(total)d")
                         % {"done": done, "total": total}

--- a/gramps/gui/fs/fs_import/importer.py
+++ b/gramps/gui/fs/fs_import/importer.py
@@ -254,22 +254,38 @@ class FSToGrampsImporter(CoreFSToGrampsImporter):
         caller.uistate.set_busy_cursor(False)
         progress.close()
 
-        if signals_disabled:
-            caller.dbstate.db.enable_signals()
-            if self.added_person:
-                caller.dbstate.db.request_rebuild()
-
-        # keep existing post-import compare refresh behavior in GUI layer
+        # Keep existing post-import compare refresh behavior in the GUI
+        # layer, batched into a single transaction with signals suppressed.
+        # Without this, compare_fs_to_gramps() opens its own DbTxn per
+        # person, which for a large bulk import meant thousands of separate
+        # commits, each firing a live GUI signal and growing the undo
+        # history by one entry -- effectively O(N) commits/signals/undo
+        # entries instead of one.
+        caller.dbstate.db.disable_signals()
         try:
-            for fs_person in list(self.fs_TreeImp.persons or []):
-                gr_handle = fs_utilities.FS_INDEX_PEOPLE.get(fs_person.id)
-                if not gr_handle:
-                    continue
-                gr_person = caller.dbstate.db.get_person_from_handle(gr_handle)
-                if gr_person:
-                    compare_fs_to_gramps(fs_person, gr_person, caller.dbstate.db, None)
+            with DbTxn(
+                "FamilySearch: refresh comparison status", caller.dbstate.db
+            ) as compare_txn:
+                for fs_person in list(self.fs_TreeImp.persons or []):
+                    gr_handle = fs_utilities.FS_INDEX_PEOPLE.get(fs_person.id)
+                    if not gr_handle:
+                        continue
+                    gr_person = caller.dbstate.db.get_person_from_handle(gr_handle)
+                    if gr_person:
+                        compare_fs_to_gramps(
+                            fs_person,
+                            gr_person,
+                            caller.dbstate.db,
+                            None,
+                            txn=compare_txn,
+                        )
         except Exception:
             pass
+        finally:
+            caller.dbstate.db.enable_signals()
+
+        if signals_disabled and self.added_person:
+            caller.dbstate.db.request_rebuild()
 
         if active_handle:
             caller.uistate.set_active(active_handle, "Person")

--- a/gramps/gui/fs/fs_import/importer.py
+++ b/gramps/gui/fs/fs_import/importer.py
@@ -34,7 +34,7 @@ from gramps.gen.db import DbTxn
 from gramps.gui.dialog import WarningDialog
 from gramps.gui.utils import ProgressMeter
 
-from . import _
+from . import _, ngettext
 from gramps.gen.fs import tree
 from gramps.gen.fs.fs_import import deserializer as deserialize
 from gramps.gen.fs.fs_import.sources import fetch_source_dates
@@ -148,8 +148,10 @@ class FSToGrampsImporter(CoreFSToGrampsImporter):
                 break
             done |= todo
             print(
-                _(
-                    "Downloading ancestor generation %(gen)d/%(total)d… (%(count)d people)"
+                ngettext(
+                    "Downloading ancestor generation %(gen)d/%(total)d… (%(count)d person)",
+                    "Downloading ancestor generation %(gen)d/%(total)d… (%(count)d people)",
+                    len(todo),
                 )
                 % {"gen": i + 1, "total": self.asc, "count": len(todo)}
             )
@@ -172,8 +174,10 @@ class FSToGrampsImporter(CoreFSToGrampsImporter):
                 break
             done |= todo
             print(
-                _(
-                    "Downloading descendant generation %(gen)d/%(total)d… (%(count)d people)"
+                ngettext(
+                    "Downloading descendant generation %(gen)d/%(total)d… (%(count)d person)",
+                    "Downloading descendant generation %(gen)d/%(total)d… (%(count)d people)",
+                    len(todo),
                 )
                 % {"gen": i + 1, "total": self.desc, "count": len(todo)}
             )
@@ -191,7 +195,14 @@ class FSToGrampsImporter(CoreFSToGrampsImporter):
                 _("Downloading spouses… (6/11)"), mode=ProgressMeter.MODE_ACTIVITY
             )
             todo = set(self.fs_TreeImp._persons.keys())
-            print(_("Downloading spouses for %d people…") % len(todo))
+            print(
+                ngettext(
+                    "Downloading spouses for %d person…",
+                    "Downloading spouses for %d people…",
+                    len(todo),
+                )
+                % len(todo)
+            )
             self.fs_TreeImp.add_spouses(set(todo), progress_callback=progress.step)
 
         if self.include_notes or self.include_sources:
@@ -370,14 +381,23 @@ class FSToGrampsImporter(CoreFSToGrampsImporter):
             _("Resolving FamilySearch timestamps…"), mode=ProgressMeter.MODE_ACTIVITY
         )
         print(
-            _("Resolving FamilySearch timestamps for %d people…") % len(compare_pairs)
+            ngettext(
+                "Resolving FamilySearch timestamps for %d person…",
+                "Resolving FamilySearch timestamps for %d people…",
+                len(compare_pairs),
+            )
+            % len(compare_pairs)
         )
         backfill_start = time.monotonic()
         backfilled = backfill_last_modified(
             caller.dbstate.db, compare_pairs, progress_callback=progress.step
         )
         print(
-            _("Resolved %(count)d FamilySearch timestamps in %(elapsed).1fs")
+            ngettext(
+                "Resolved %(count)d FamilySearch timestamp in %(elapsed).1fs",
+                "Resolved %(count)d FamilySearch timestamps in %(elapsed).1fs",
+                backfilled,
+            )
             % {"count": backfilled, "elapsed": time.monotonic() - backfill_start}
         )
 
@@ -385,7 +405,14 @@ class FSToGrampsImporter(CoreFSToGrampsImporter):
             _("Refreshing comparison status…"),
             len(compare_pairs) or 1,
         )
-        print(_("Refreshing comparison status for %d people…") % len(compare_pairs))
+        print(
+            ngettext(
+                "Refreshing comparison status for %d person…",
+                "Refreshing comparison status for %d people…",
+                len(compare_pairs),
+            )
+            % len(compare_pairs)
+        )
         compare_start = time.monotonic()
         compared = 0
         failed = 0

--- a/gramps/gui/fs/fs_import/importer.py
+++ b/gramps/gui/fs/fs_import/importer.py
@@ -46,7 +46,7 @@ from gramps.gen.fs import utils as fs_utilities
 
 import gramps.gui.fs.person.fsg_sync as FSG_Sync
 from gramps.gui.fs.utils.index import build_fs_index
-from gramps.gen.fs.compare import compare_fs_to_gramps
+from gramps.gen.fs.compare import compare_fs_to_gramps, backfill_last_modified
 
 LOG = logging.getLogger(__name__)
 
@@ -352,12 +352,40 @@ class FSToGrampsImporter(CoreFSToGrampsImporter):
         # progress dialog is kept open (rather than closed before this
         # loop, as before) so progress.step() keeps pumping GTK events and
         # the app doesn't look hung while this runs.
-        compare_people = list(self.fs_TreeImp.persons or [])
+        compare_pairs: list[tuple[Any, Any]] = []
+        for fs_person in list(self.fs_TreeImp.persons or []):
+            gr_handle = fs_utilities.FS_INDEX_PEOPLE.get(fs_person.id)
+            if not gr_handle:
+                continue
+            gr_person = caller.dbstate.db.get_person_from_handle(gr_handle)
+            if gr_person:
+                compare_pairs.append((fs_person, gr_person))
+
+        # Resolve Last-Modified/Etag for the whole batch concurrently first,
+        # so the sequential loop below finds it already cached and skips
+        # its own per-person HEAD request. Without this, resolving each
+        # person's Last-Modified serially (one HTTP round trip at a time)
+        # was by far the slowest part of a large bulk import.
+        progress.set_pass(
+            _("Resolving FamilySearch timestamps…"), mode=ProgressMeter.MODE_ACTIVITY
+        )
+        print(
+            _("Resolving FamilySearch timestamps for %d people…") % len(compare_pairs)
+        )
+        backfill_start = time.monotonic()
+        backfilled = backfill_last_modified(
+            caller.dbstate.db, compare_pairs, progress_callback=progress.step
+        )
+        print(
+            _("Resolved %(count)d FamilySearch timestamps in %(elapsed).1fs")
+            % {"count": backfilled, "elapsed": time.monotonic() - backfill_start}
+        )
+
         progress.set_pass(
             _("Refreshing comparison status…"),
-            len(compare_people) or 1,
+            len(compare_pairs) or 1,
         )
-        print(_("Refreshing comparison status for %d people…") % len(compare_people))
+        print(_("Refreshing comparison status for %d people…") % len(compare_pairs))
         compare_start = time.monotonic()
         compared = 0
         failed = 0
@@ -366,14 +394,8 @@ class FSToGrampsImporter(CoreFSToGrampsImporter):
             with DbTxn(
                 "FamilySearch: refresh comparison status", caller.dbstate.db
             ) as compare_txn:
-                for done, fs_person in enumerate(compare_people, start=1):
+                for done, (fs_person, gr_person) in enumerate(compare_pairs, start=1):
                     progress.step()
-                    gr_handle = fs_utilities.FS_INDEX_PEOPLE.get(fs_person.id)
-                    if not gr_handle:
-                        continue
-                    gr_person = caller.dbstate.db.get_person_from_handle(gr_handle)
-                    if not gr_person:
-                        continue
 
                     person_start = time.monotonic()
                     try:
@@ -399,10 +421,10 @@ class FSToGrampsImporter(CoreFSToGrampsImporter):
                             _("  …comparison for %(fsid)s took %(elapsed).1fs")
                             % {"fsid": fs_person.id, "elapsed": elapsed}
                         )
-                    if done == 1 or done % 25 == 0 or done == len(compare_people):
+                    if done == 1 or done % 25 == 0 or done == len(compare_pairs):
                         print(
                             _("  …comparison status: %(done)d/%(total)d")
-                            % {"done": done, "total": len(compare_people)}
+                            % {"done": done, "total": len(compare_pairs)}
                         )
         except Exception:
             LOG.warning("Comparison refresh loop aborted early", exc_info=True)

--- a/gramps/gui/fs/fs_import/importer.py
+++ b/gramps/gui/fs/fs_import/importer.py
@@ -164,13 +164,30 @@ class FSToGrampsImporter(CoreFSToGrampsImporter):
                     f"/platform/tree/couple-relationships/{rel_id}/sources"
                 )
 
-            for fs_person in list(self.fs_TreeImp.persons or []):
+            fs_persons = list(self.fs_TreeImp.persons or [])
+            fs_families = list(self.fs_TreeImp.relationships or [])
+            total = len(fs_persons) + len(fs_families)
+            done = 0
+
+            for fs_person in fs_persons:
                 progress.step()
                 _load_person_extras(fs_person.id)
+                done += 1
+                if done == 1 or done % 25 == 0 or done == total:
+                    print(
+                        _("  …notes/sources: %(done)d/%(total)d")
+                        % {"done": done, "total": total}
+                    )
 
-            for fs_family in list(self.fs_TreeImp.relationships or []):
+            for fs_family in fs_families:
                 progress.step()
                 _load_couple_extras(fs_family.id)
+                done += 1
+                if done % 25 == 0 or done == total:
+                    print(
+                        _("  …notes/sources: %(done)d/%(total)d")
+                        % {"done": done, "total": total}
+                    )
 
             fetch_source_dates(self.fs_TreeImp)
 

--- a/gramps/gui/fs/fs_import/importer.py
+++ b/gramps/gui/fs/fs_import/importer.py
@@ -131,35 +131,58 @@ class FSToGrampsImporter(CoreFSToGrampsImporter):
                 caller.uistate.set_active(active_handle, "Person")
             return
 
-        progress.set_pass(_("Downloading ancestors… (4/11)"), self.asc)
+        # Each generation can involve fetching anywhere from a handful to
+        # thousands of people, so a single progress.step() per generation
+        # (the previous behavior) made the bar sit still for the entire
+        # duration of a large generation's fetch. Use activity mode and
+        # pulse/pump once per person actually fetched instead, via the
+        # progress_callback Tree.add_parents/add_children/add_spouses
+        # invoke for each completed network request.
+        progress.set_pass(
+            _("Downloading ancestors… (4/11)"), mode=ProgressMeter.MODE_ACTIVITY
+        )
         todo = set(self.fs_TreeImp._persons.keys())
         done = set()
         for i in range(self.asc):
-            progress.step()
             if not todo:
                 break
             done |= todo
-            print(_("Downloading %d generations of ancestors…") % (i + 1))
-            todo = (
-                self.fs_TreeImp.add_parents(
-                    set(todo), progress_callback=_pump_gtk_events
+            print(
+                _(
+                    "Downloading ancestor generation %(gen)d/%(total)d… (%(count)d people)"
                 )
+                % {"gen": i + 1, "total": self.asc, "count": len(todo)}
+            )
+            progress.set_header(
+                _("Downloading ancestors… (4/11) — generation %(gen)d/%(total)d")
+                % {"gen": i + 1, "total": self.asc}
+            )
+            todo = (
+                self.fs_TreeImp.add_parents(set(todo), progress_callback=progress.step)
                 - done
             )
 
-        progress.set_pass(_("Downloading descendants… (5/11)"), self.desc)
+        progress.set_pass(
+            _("Downloading descendants… (5/11)"), mode=ProgressMeter.MODE_ACTIVITY
+        )
         todo = set(self.fs_TreeImp._persons.keys())
         done = set()
         for i in range(self.desc):
-            progress.step()
             if not todo:
                 break
             done |= todo
-            print(_("Downloading %d generations of descendants…") % (i + 1))
-            todo = (
-                self.fs_TreeImp.add_children(
-                    set(todo), progress_callback=_pump_gtk_events
+            print(
+                _(
+                    "Downloading descendant generation %(gen)d/%(total)d… (%(count)d people)"
                 )
+                % {"gen": i + 1, "total": self.desc, "count": len(todo)}
+            )
+            progress.set_header(
+                _("Downloading descendants… (5/11) — generation %(gen)d/%(total)d")
+                % {"gen": i + 1, "total": self.desc}
+            )
+            todo = (
+                self.fs_TreeImp.add_children(set(todo), progress_callback=progress.step)
                 - done
             )
 
@@ -167,9 +190,9 @@ class FSToGrampsImporter(CoreFSToGrampsImporter):
             progress.set_pass(
                 _("Downloading spouses… (6/11)"), mode=ProgressMeter.MODE_ACTIVITY
             )
-            print(_("Downloading spouses…"))
             todo = set(self.fs_TreeImp._persons.keys())
-            self.fs_TreeImp.add_spouses(set(todo), progress_callback=_pump_gtk_events)
+            print(_("Downloading spouses for %d people…") % len(todo))
+            self.fs_TreeImp.add_spouses(set(todo), progress_callback=progress.step)
 
         if self.include_notes or self.include_sources:
             progress.set_pass(

--- a/gramps/gui/fs/tools_window.py
+++ b/gramps/gui/fs/tools_window.py
@@ -33,7 +33,7 @@ import weakref
 from dataclasses import dataclass
 from typing import Any, Callable, Optional, cast
 
-from gi.repository import GdkPixbuf, GLib, Gtk
+from gi.repository import Gdk, GdkPixbuf, GLib, Gtk
 
 from gramps.gen.const import DATA_DIR, GRAMPS_LOCALE as glocale
 from gramps.gen.const import IMAGE_DIR as _GRAMPS_IMAGE_DIR
@@ -41,6 +41,7 @@ from gramps.gen.display.name import displayer as name_displayer
 from gramps.gen.errors import HandleError
 from gramps.gen.fs.actions import _get_fs_id
 from gramps.gui.dialog import ErrorDialog
+from gramps.gui.display import display_url
 from gramps.gui.editors.editperson import EditPerson
 
 from . import actions
@@ -354,9 +355,11 @@ class FamilySearchToolsWindow:
         name_row.pack_start(self.active_label, True, True, 0)
 
         self.btn_link = Gtk.Button(label=_("Link FamilySearch ID"))
-        link_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
+        self.btn_open_person = Gtk.Button(label=_("Open Person in FamilySearch"))
+        link_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
         link_row.get_style_context().add_class("fs-link-row")
         link_row.pack_start(self.btn_link, False, False, 0)
+        link_row.pack_start(self.btn_open_person, False, False, 0)
         outer.pack_start(link_row, False, False, 0)
 
         outer.pack_start(
@@ -449,6 +452,7 @@ class FamilySearchToolsWindow:
             bottom_bar.pack_start(status_widget, False, False, 0)
 
         self.btn_link.connect("clicked", self._on_link)
+        self.btn_open_person.connect("clicked", self._on_open_person)
         self.btn_cmp.connect("clicked", self._on_compare)
         self.btn_sync.connect("clicked", self._on_sync)
         self.btn_sync_to.connect("clicked", self._on_sync_to)
@@ -628,6 +632,7 @@ class FamilySearchToolsWindow:
 
         wrapper = Gtk.EventBox()
         wrapper.set_visible_window(True)
+        wrapper.set_tooltip_text(_("Open FamilySearch.org"))
         wrapper.get_style_context().add_class("fs-banner")
 
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
@@ -643,7 +648,17 @@ class FamilySearchToolsWindow:
         self._set_logo_width(width)
 
         wrapper.connect("size-allocate", self._on_banner_size_allocate)
+        wrapper.connect("button-press-event", self._on_logo_clicked)
+        wrapper.connect("realize", self._on_banner_realize)
         return wrapper
+
+    def _on_banner_realize(self, widget: Gtk.Widget) -> None:
+        widget.get_window().set_cursor(
+            Gdk.Cursor.new_for_display(Gdk.Display.get_default(), Gdk.CursorType.HAND2)
+        )
+
+    def _on_logo_clicked(self, *_args: Any) -> None:
+        display_url("https://www.familysearch.org/")
 
     def _load_logo_pixbuf(self) -> Optional[GdkPixbuf.Pixbuf]:
         candidates: list[str] = []
@@ -729,30 +744,6 @@ class FamilySearchToolsWindow:
             getattr(self.session, "access_token", None)
         )
 
-    def _editor_person_obj(self) -> Any:
-        # Return the db-backed editor person when possible
-        # The DB copy is the one that matters for compare/sync logic.
-        person_handle = _LAST_EDITOR.person_handle
-        dbstate = _LAST_EDITOR.dbstate
-
-        if person_handle and dbstate is not None:
-            db = getattr(dbstate, "db", None)
-            if db is not None:
-                try:
-                    return db.get_person_from_handle(person_handle)
-                except HandleError:
-                    pass
-                except Exception as exc:
-                    _dbg(
-                        f"Could not get person from db for handle {person_handle}: {exc}"
-                    )
-
-        person = _LAST_EDITOR.person_obj()
-        if person is not None:
-            return person
-
-        return None
-
     def _live_person_obj(self) -> Any:
         """Return the live in-memory person from the editor (not the DB copy)."""
         person = _LAST_EDITOR.person_obj()
@@ -765,7 +756,7 @@ class FamilySearchToolsWindow:
 
     def _update_label(self) -> None:
         """Refresh the label that shows which editor person were on"""
-        person = self._editor_person_obj()
+        person = self._live_person_obj()
         if person is None:
             self.active_label.set_text(_("Editor person: (none)"))
             return
@@ -807,6 +798,7 @@ class FamilySearchToolsWindow:
         if enabled and not has_fsid:
             self.btn_link.set_sensitive(True)
             self.btn_link.set_label(_("Add FamilySearch ID"))
+            self.btn_open_person.set_sensitive(True)
             for button in other_buttons:
                 button.set_sensitive(False)
         else:
@@ -816,6 +808,7 @@ class FamilySearchToolsWindow:
                 if (enabled and has_fsid)
                 else _("Link FamilySearch ID")
             )
+            self.btn_open_person.set_sensitive(enabled)
             for button in other_buttons:
                 button.set_sensitive(enabled)
 
@@ -869,7 +862,7 @@ class FamilySearchToolsWindow:
             )
             return None
 
-        person = self._editor_person_obj()
+        person = self._live_person_obj()
         if person is None:
             _show_info(
                 self.window,
@@ -984,6 +977,15 @@ class FamilySearchToolsWindow:
             return
 
         self._call_action(actions.link_familysearch_id, "Link failed", ctx)
+
+    def _on_open_person(self, *_args: Any) -> None:
+        ctx = self._ctx()
+        if not ctx:
+            return
+
+        self._call_action(
+            actions.open_person_in_familysearch, "Open in FamilySearch failed", ctx
+        )
 
     def _on_compare(self, *_args: Any) -> None:
         ctx = self._ctx()

--- a/gramps/gui/fs/tools_window.py
+++ b/gramps/gui/fs/tools_window.py
@@ -793,12 +793,12 @@ class FamilySearchToolsWindow:
             self.btn_imp_spo,
             self.btn_imp_chi,
             self.btn_bulk_import,
+            self.btn_open_person,
         )
 
         if enabled and not has_fsid:
             self.btn_link.set_sensitive(True)
             self.btn_link.set_label(_("Add FamilySearch ID"))
-            self.btn_open_person.set_sensitive(True)
             for button in other_buttons:
                 button.set_sensitive(False)
         else:
@@ -808,7 +808,6 @@ class FamilySearchToolsWindow:
                 if (enabled and has_fsid)
                 else _("Link FamilySearch ID")
             )
-            self.btn_open_person.set_sensitive(enabled)
             for button in other_buttons:
                 button.set_sensitive(enabled)
 


### PR DESCRIPTION
## Bug fixes

- **Compare button used a stale, already-committed copy of the person instead of the one open in the editor.** After adding a FamilySearch ID attribute in the Edit Person dialog (but before saving), the Compare button correctly became enabled — but clicking it raised an error that the person didn't have the attribute. The button's enable/disable check (`_tick` → `_live_person_obj`) and the click handlers (`_require_ready` → `_editor_person_obj`) were reading two different copies of the person: one live from the editor, one re-fetched from the database. Unified both paths to always use the live, in-progress `Person` object from the open editor, so Compare/Sync/Import/Link all see attributes as soon as they're added, without needing to save first.
- **Bulk import could hang indefinitely while downloading notes/sources.** The FamilySearch `Session` class never set an HTTP request timeout, so a single stalled connection anywhere in a bulk import (which can issue thousands of sequential requests for a deep ancestor/descendant pull) would hang forever with no way to recover short of killing the app. Added a default 30s timeout (overridable via `GRAMPS_FS_API_TIMEOUT`), applied centrally in `_route_api_request` so it covers every API call. Timeouts are already handled gracefully by `get_jsonurl` (logs and returns `None`), so this doesn't introduce new crashes — a stalled request now just gets skipped instead of freezing the app.
- **Bulk import could freeze for a very long time (and eventually get OOM-killed) *after* the import itself finished.** The post-import comparison-status refresh called `compare_fs_to_gramps()` once per imported person, and that function opened its own database transaction on every call. For a large import this meant thousands of separate commits, each firing a live GUI update signal and adding a new entry to the undo history, instead of one batched update — this happens after "import done." is printed. Added an optional shared `txn` parameter to `compare_fs_to_gramps()`/`FSStatusDB.commit()` so the whole post-import refresh loop now runs inside a single transaction with signals suppressed, and the GUI is rebuilt once at the end instead of once per person.
- **Bulk import could trigger the OS's "app not responding" / Force Quit dialog during every download phase, even though the import was working normally.** Each download phase (persons, ancestors, descendants, spouses, notes/sources) fetches concurrently via a `ThreadPoolExecutor`, but the main GTK thread just blocked on `as_completed()` until the whole batch finished, never returning control to the event loop — long enough for the window manager to decide the app had hung. Added an optional `progress_callback` to `Tree.add_persons()` (and `add_parents`/`add_children`/`add_spouses`, which delegate to it), invoked once per completed fetch; the GUI layer passes in a callback that pumps pending GTK events, keeping the interface responsive throughout every download phase.
- **The same "not responding" freeze could also happen *after* "import done." was printed, during the post-import comparison-status refresh.** That pass closed the progress dialog and busy cursor *before* looping over every downloaded person, so there was no progress reporting or GTK event pumping at all during what can be a genuinely slow pass — `compare_fs_to_gramps()` can issue a synchronous FamilySearch HEAD request per person when `Last-Modified` wasn't already captured during download. The whole loop was also wrapped in a single bare `except Exception: pass`, so one failed request would silently abort comparison-refresh for every remaining person with no log output at all. Kept the progress dialog open through this pass so `progress.step()` keeps pumping GTK events, moved exception handling inside the loop so one failure doesn't cancel the rest, and added debug output: periodic done/total progress, a warning whenever a single person's comparison takes over a second (to surface slow/stalled FamilySearch requests), and a final summary of elapsed time plus compared/failed counts.

## Performance

- **Parallelized the notes/sources download phase of a bulk import.** This phase fetched notes, sources, and memories one HTTP request at a time — 3 requests per person plus 2 per couple relationship, fully serial — making it by far the slowest phase for a large import, unlike the ancestor/descendant/spouse phases which already fetch each generation concurrently via a thread pool in `Tree.add_persons`. Now fetches all the raw JSON payloads concurrently (up to 8 worker threads, matching `Tree.add_persons`), then deserializes them sequentially in the main thread since deserializing mutates shared tree state that isn't safe to touch from multiple threads at once. Also added periodic progress printing during this phase, since it previously printed nothing until the whole (potentially very long) phase finished, making it look stuck even when working normally.
- **Progress bar sat frozen for long stretches during the ancestor/descendant/spouse download phases.** Those phases advanced the bar by one tick per *generation*, regardless of how many people that generation involved — later generations of a deep pull can contain hundreds or thousands of people, so the bar (and console) went quiet for the entire time it took to fetch a large generation, even though the download was proceeding normally. Switched these passes to activity mode and pass `progress.step` itself as the `progress_callback`, so the bar now pulses once per person actually fetched. Also print each generation's frontier size before fetching it and update the dialog's header text per generation, so both the console and GUI show concrete, moving feedback throughout a large pull.
- **Comparison-status refresh was the slowest part of a large bulk import.** The new per-person debug output surfaced the cause directly: `compare_fs_to_gramps()` issues a synchronous FamilySearch HEAD request per person, one at a time, whenever `Last-Modified` wasn't already captured during download — confirmed on a real 1849-person import where many individual people were each taking 1–2.5s in this pass, entirely serially. Added `backfill_last_modified()`, which resolves `Last-Modified`/`Etag` (following FSID redirects) for a batch of people concurrently via a thread pool, matching the pattern already used for notes/sources downloads. The GUI importer now runs this once, concurrently, right before the comparison loop; `compare_fs_to_gramps()` is unchanged and still resolves it itself when called standalone (e.g. the single-person Compare button), but during bulk import it now finds the value already cached and skips its own per-person network call entirely.

## Feature additions

- **"Open Person in FamilySearch" button.** Added next to the "Link/Edit FamilySearch ID" button. Opens the linked person's page at `https://www.familysearch.org/<lang>/tree/person/details/<fsid>` in a web browser, using the current Gramps UI locale for `<lang>` (falling back to `en`). Only enabled once a FamilySearch ID is actually linked (same gating as Compare/Sync/Import).
- **Clickable FamilySearch logo banner.** The logo at the top of the FamilySearch Tools window now opens `https://www.familysearch.org/` when clicked, with a pointer cursor and tooltip on hover so it reads as clickable.

## Test plan

- [x] `black --check` passes on all changed files
- [x] `mypy` passes on all changed files
- [x] `gen/fs/test/tree_test.py`, `tags_test.py`, `compare/test/comparators_test.py`, `compare/test/datmod_attr_test.py`, `compare/test/aggregate_test.py`, `fs_import/test/importer_test.py`, and `person/mixins/test/cache_test.py` all pass
- [ ] Manually verified: add a FamilySearch ID attribute in Edit Person (unsaved), confirm Compare/Sync/Import work without saving first
- [ ] Manually verified: "Open Person in FamilySearch" opens the correct browser page
- [ ] Manually verified: clicking the logo banner opens familysearch.org
- [ ] Manually verified: bulk import of a large tree no longer hangs during notes/sources download or freezes/OOMs afterward during the comparison-status refresh, and completes noticeably faster
- [ ] Manually verified: bulk import of a large tree no longer triggers the OS "not responding" / Force Quit dialog during download or comparison-status refresh, and debug output in the console shows per-phase and per-person progress
- [ ] Manually verified: during a deep ancestor/descendant pull, the progress bar visibly pulses throughout each generation's download instead of sitting still until the whole generation finishes
- [ ] Manually verified: comparison-status refresh on a large tree no longer shows repeated 1s+ per-person delays in the debug output, and completes noticeably faster than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

