### PR TITLE
Clarify when ngettext is required in agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,7 +202,31 @@ All user-visible strings must be wrapped with `_()` for translation support:
 raise ValueError(_("Invalid handle: %s") % handle)
 ```
 The alias `_(string , context)` is preferred to `pgettext(context, message)`.
-Use `ngettext(singular, plural, n)` for plural forms.
+
+Use `ngettext(singular, plural, n)` instead of `_()` whenever a formatted
+string embeds a count next to a noun whose English form changes between 1
+and 2+ (person/people, entry/entries, generation/generations, match/matches,
+timestamp/timestamps, etc.):
+
+```python
+ngettext(
+    "%(count)d person",
+    "%(count)d people",
+    count,
+) % {"count": count}
+```
+
+Before finishing a change, check every `_("...%d..."` / `_("...%(name)d..."`
+string you wrote or touched against this rule — `_("Found %d people")`
+produces "Found 1 people" for translators with no way to fix it.
+
+Ordinal or fraction displays with no inflecting noun (`"page %(cur)d/%(total)d"`,
+`"generation %(gen)d/%(total)d"`, `"row %(row)d"`) do *not* need `ngettext` —
+only convert a string when an actual noun in it would change form.
+
+If a package centralizes its `_` alias (e.g. `_ = glocale.translation.gettext`
+in an `__init__.py`), also export `ngettext = glocale.translation.ngettext`
+there, so submodules can import both together.
 
 ## Submodule Import Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,10 +203,13 @@ raise ValueError(_("Invalid handle: %s") % handle)
 ```
 The alias `_(string , context)` is preferred to `pgettext(context, message)`.
 
-Use `ngettext(singular, plural, n)` instead of `_()` whenever a formatted
-string embeds a count next to a noun whose English form changes between 1
-and 2+ (person/people, entry/entries, generation/generations, match/matches,
-timestamp/timestamps, etc.):
+Use `ngettext(singular, plural, n)` instead of `_()` for any formatted
+string that counts a noun — even if the English singular and plural read
+the same, or `n` can never be 1 in your code path. English's binary
+singular/plural is not a reliable guide: many languages have richer plural
+rules than English (e.g. separate forms for 2-4 vs 5+, or a dual form for
+exactly 2), and gettext only applies the target language's actual rule
+when the string goes through `ngettext`:
 
 ```python
 ngettext(
@@ -217,12 +220,15 @@ ngettext(
 ```
 
 Before finishing a change, check every `_("...%d..."` / `_("...%(name)d..."`
-string you wrote or touched against this rule — `_("Found %d people")`
-produces "Found 1 people" for translators with no way to fix it.
+string you wrote or touched against this rule. `_("Found %d people")` is
+wrong even though "people" happens to read fine in English at any count —
+a language with a 2-4 plural form has no way to produce it from a single
+hardcoded string.
 
-Ordinal or fraction displays with no inflecting noun (`"page %(cur)d/%(total)d"`,
-`"generation %(gen)d/%(total)d"`, `"row %(row)d"`) do *not* need `ngettext` —
-only convert a string when an actual noun in it would change form.
+Ordinal or positional references with no counted noun (`"page %(cur)d/%(total)d"`,
+`"generation %(gen)d/%(total)d"`, `"row %(row)d"`) do not need `ngettext` —
+these don't quantify anything, they just label a specific position. Convert
+a string only when it is actually counting instances of something.
 
 If a package centralizes its `_` alias (e.g. `_ = glocale.translation.gettext`
 in an `__init__.py`), also export `ngettext = glocale.translation.ngettext`


### PR DESCRIPTION
## Summary

- The `AGENTS.md` Internationalization section said *what* to use (`ngettext(singular, plural, n)`) but not *when* a string actually needs it. That gap let several count-embedding strings ship with a plain `_()` call in a recent FamilySearch import PR (#2475) — e.g. `_("%d people") % 1` reads as "1 people" for translators, with no way to fix it downstream since the English source string is already wrong.
- Adds a concrete trigger (a formatted count next to a noun whose English form changes between singular and plural), a code example matching the codebase's dominant `%` formatting style, an explicit counter-example for ordinal/fraction displays that don't need it (e.g. `"generation %(gen)d/%(total)d"`), and a note to also export `ngettext` alongside a centralized `_` alias in package `__init__.py` files.

## Test plan

- [x] Docs-only change; no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
