### PR TITLE
Set prgname to application ID

### DIFF
--- a/gramps/gui/grampsgui.py
+++ b/gramps/gui/grampsgui.py
@@ -580,6 +580,8 @@ class Gramps:
         from .tipofday import TipOfDay
         import gettext
 
+        GLib.set_prgname("org.gramps_project.Gramps")
+
         # Append image directory to the theme search path
         theme = Gtk.IconTheme.get_default()
         theme.append_search_path(IMAGE_DIR)


### PR DESCRIPTION
Using the application ID ensures that Wayland compositors could match the window with the application and show the appropriate icon for them.

References:
- https://honk.sigxcpu.org/con/GTK__and_the_application_id.html
- https://docs.gtk.org/gtk4/migrating-3to4.html#set-a-proper-application-id