### PR TITLE
Add last changed timestamp to metadata

### DIFF
--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -880,6 +880,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         """
         # Save metadata
         self._set_metadata("version", str(self.VERSION[0]))
+        self._set_metadata("last_changed", time.time())
         self._set_metadata("name_formats", self.name_formats)
         self._set_metadata("researcher", self.owner)
 
@@ -2815,6 +2816,9 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
     def set_schema_version(self, value):
         """set the current schema version"""
         self._set_metadata("version", str(value))
+
+    def get_last_changed_time(self):
+        return self._get_metadata("last_changed", default=0)
 
     def set_serializer(self, serializer_name):
         """


### PR DESCRIPTION
(Feature PR against **6.2** branch.)

This PR adds a single new metadata entry, namely a last change timestamp.

Currently, the file modification date of the empty file `meta_data.db` in the database directory is used for this purpose. Gramps Web API's undo transaction log relies heavily on this timestamp.

Storing the timestamp in the database instead is much more robust.

This would allow the Gramps Web Sync addon to rely on it, too, making time-based sync more reliable.

A database migration is not needed as this change is backward compatible.

Note that the timestamp is stored as float for higher accuracy, not as int as the object change column. Consequently, it is guaranteed to always be larger than the largest change timestamp in the database.