### PR TITLE
Add personal translation override mechanism

### DIFF
--- a/gramps/gen/const.py
+++ b/gramps/gen/const.py
@@ -143,6 +143,8 @@ VERSION_DIR = os.path.join(USER_CONFIG, VERSION_DIR_NAME)
 USER_DATA_VERSION = os.path.join(USER_DATA, VERSION_DIR_NAME)
 
 CUSTOM_FILTERS = os.path.join(VERSION_DIR, "custom_filters.xml")
+# Not version-specific: user translation overrides should survive upgrades.
+CUSTOM_TRANSLATIONS = os.path.join(USER_DATA, "custom_translations.json")
 REPORT_OPTIONS = os.path.join(USER_CONFIG, "report_options.xml")
 TOOL_OPTIONS = os.path.join(USER_CONFIG, "tool_options.xml")
 PLACE_FORMATS = os.path.join(USER_CONFIG, "place_formats.xml")

--- a/gramps/gen/utils/grampslocale.py
+++ b/gramps/gen/utils/grampslocale.py
@@ -693,6 +693,12 @@ class GrampsLocale:
             addon_translator = self._get_translation(domain, path, languages=languages)
         else:
             addon_translator = self._get_translation(domain, path)
+        gramps_translator.set_overrides(
+            get_overrides_for_language(gramps_translator.lang)
+        )
+        addon_translator.set_overrides(
+            get_overrides_for_language(addon_translator.lang)
+        )
         gramps_translator.add_fallback(addon_translator)
         return gramps_translator  # with a language fallback
 

--- a/gramps/gen/utils/grampslocale.py
+++ b/gramps/gen/utils/grampslocale.py
@@ -41,6 +41,7 @@ import time
 
 
 from .grampstranslation import GrampsTranslations, GrampsNullTranslations
+from .translationoverride import get_overrides_for_language
 
 if sys.platform == "darwin":
     from .maclocale import mac_setup_localization
@@ -497,6 +498,10 @@ class GrampsLocale:
             )
             self.translation = GrampsNullTranslations()
             self.translation.lang = "en"
+
+        self.translation.set_overrides(
+            get_overrides_for_language(self.translation.lang)
+        )
 
         if _HDLR:
             LOG.removeHandler(_HDLR)

--- a/gramps/gen/utils/grampstranslation.py
+++ b/gramps/gen/utils/grampstranslation.py
@@ -162,7 +162,27 @@ class Lexeme(str):
         return self._forms
 
 
-class GrampsTranslations(gettext.GNUTranslations):
+class TranslationOverrideMixin:
+    """
+    Adds support for user-defined translation overrides, consulted before
+    the normal translation catalog. See
+    :mod:`gramps.gen.utils.translationoverride`.
+    """
+
+    _overrides: dict[tuple[str, str], str] = {}
+
+    def set_overrides(self, overrides: dict[tuple[str, str], str]) -> None:
+        """
+        Install user-defined (context, msgid) -> text overrides.
+
+        :param overrides: mapping of (context, msgid) to the replacement
+                           text the user wants used instead.
+        :type overrides: dict[tuple[str, str], str]
+        """
+        self._overrides = overrides
+
+
+class GrampsTranslations(TranslationOverrideMixin, gettext.GNUTranslations):
     """
     Overrides and extends gettext.GNUTranslations. See the Python gettext
     "Class API" documentation for how to use this.
@@ -195,6 +215,9 @@ class GrampsTranslations(gettext.GNUTranslations):
         # and that's not what we want.
         if len((context + msgid).strip()) == 0:
             return msgid
+        override = self._overrides.get((context, msgid))
+        if override is not None:
+            return override
         if context:
             return self.pgettext(context, msgid)
         return gettext.GNUTranslations.gettext(self, msgid)
@@ -274,6 +297,9 @@ class GrampsTranslations(gettext.GNUTranslations):
         """
         Copied from python 3.8
         """
+        override = self._overrides.get((context, message))
+        if override is not None:
+            return override
         ctxt_msg_id = self.CONTEXT % (context, message)
         missing = object()
         tmsg = self._catalog.get(ctxt_msg_id, missing)
@@ -284,7 +310,7 @@ class GrampsTranslations(gettext.GNUTranslations):
         return tmsg
 
 
-class GrampsNullTranslations(gettext.NullTranslations):
+class GrampsNullTranslations(TranslationOverrideMixin, gettext.NullTranslations):
     """
     Extends gettext.NullTranslations to provide the sgettext method.
 
@@ -296,6 +322,9 @@ class GrampsNullTranslations(gettext.NullTranslations):
         """
         Apply the context if there is one, otherwise just pass it on.
         """
+        override = self._overrides.get((context, msgid))
+        if override is not None:
+            return override
         if context:
             return self.pgettext(context, msgid)
         return gettext.NullTranslations.gettext(self, msgid)
@@ -322,6 +351,9 @@ class GrampsNullTranslations(gettext.NullTranslations):
         """
         Copied from python 3.8
         """
+        override = self._overrides.get((context, message))
+        if override is not None:
+            return override
         if self._fallback:
             return self._fallback.pgettext(context, message)
         return message

--- a/gramps/gen/utils/test/grampslocale_test.py
+++ b/gramps/gen/utils/test/grampslocale_test.py
@@ -137,6 +137,62 @@ class AddonTranslatorTest(unittest.TestCase):
         self.assertEqual(self._("Untranslated string"), "Untranslated string")
 
 
+class AddonTranslatorOverrideTest(unittest.TestCase):
+    """
+    Tests that get_addon_translator() applies user-defined translation
+    overrides to both the addon-domain translator and its gramps-domain
+    fallback.
+    """
+
+    def setUp(self):
+        import json
+        import os
+        import tempfile
+
+        from ...const import GRAMPS_LOCALE as glocale
+        import gramps.gen.const as const
+
+        fd, self.filename = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+        with open(self.filename, "w", encoding="utf-8") as fp:
+            json.dump(
+                [
+                    {
+                        "language": "fr",
+                        "context": "",
+                        "msgid": "Test Message",
+                        "msgstr": "Overridden Addon Message",
+                    },
+                    {
+                        "language": "fr",
+                        "context": "",
+                        "msgid": "United States of America",
+                        "msgstr": "Overridden Gramps Message",
+                    },
+                ],
+                fp,
+            )
+        self._orig_custom_translations = const.CUSTOM_TRANSLATIONS
+        const.CUSTOM_TRANSLATIONS = self.filename
+        self._ = glocale.get_addon_translator(__file__, languages=["fr"]).gettext
+
+    def tearDown(self):
+        import os
+
+        import gramps.gen.const as const
+
+        const.CUSTOM_TRANSLATIONS = self._orig_custom_translations
+        os.remove(self.filename)
+
+    def testAddonDomainOverrideApplied(self):
+        self.assertEqual(self._("Test Message"), "Overridden Addon Message")
+
+    def testGrampsDomainFallbackOverrideApplied(self):
+        self.assertEqual(
+            self._("United States of America"), "Overridden Gramps Message"
+        )
+
+
 class SortKeyTest(unittest.TestCase):
     """
     Tests for GrampsLocale.sort_key().

--- a/gramps/gen/utils/test/grampstranslation_test.py
+++ b/gramps/gen/utils/test/grampstranslation_test.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Unit tests for the translation-override support in
+gramps.gen.utils.grampstranslation.
+"""
+
+import unittest
+
+from ..grampstranslation import GrampsNullTranslations, GrampsTranslations
+
+
+class GrampsNullTranslationsOverrideTest(unittest.TestCase):
+    def setUp(self):
+        self.trans = GrampsNullTranslations()
+
+    def test_no_overrides_passes_through(self):
+        self.assertEqual(self.trans.gettext("Nisan", "Hebrew month lexeme"), "Nisan")
+
+    def test_override_applied(self):
+        self.trans.set_overrides({("Hebrew month lexeme", "Nisan"): "Nissan"})
+        self.assertEqual(self.trans.gettext("Nisan", "Hebrew month lexeme"), "Nissan")
+
+    def test_override_applied_via_pgettext(self):
+        self.trans.set_overrides({("Hebrew month lexeme", "Nisan"): "Nissan"})
+        self.assertEqual(self.trans.pgettext("Hebrew month lexeme", "Nisan"), "Nissan")
+
+    def test_override_applied_via_sgettext(self):
+        self.trans.set_overrides({("Hebrew month lexeme", "Nisan"): "Nissan"})
+        self.assertEqual(self.trans.sgettext("Nisan", "Hebrew month lexeme"), "Nissan")
+
+    def test_override_does_not_match_wrong_context(self):
+        self.trans.set_overrides({("Hebrew month lexeme", "Nisan"): "Nissan"})
+        self.assertEqual(self.trans.gettext("Nisan", "French month lexeme"), "Nisan")
+
+    def test_override_does_not_match_wrong_msgid(self):
+        self.trans.set_overrides({("Hebrew month lexeme", "Nisan"): "Nissan"})
+        self.assertEqual(
+            self.trans.gettext("Heshvan", "Hebrew month lexeme"), "Heshvan"
+        )
+
+    def test_override_without_context(self):
+        self.trans.set_overrides({("", "January"): "Jan-uary"})
+        self.assertEqual(self.trans.gettext("January"), "Jan-uary")
+
+
+class GrampsTranslationsOverrideTest(unittest.TestCase):
+    def setUp(self):
+        # An empty catalog: overrides must work even with no real .mo
+        # loaded (falls back to returning the msgid itself when absent).
+        self.trans = GrampsTranslations(fp=None)
+        self.trans._catalog = {}
+
+    def test_no_overrides_passes_through(self):
+        self.assertEqual(self.trans.gettext("Nisan", "Hebrew month lexeme"), "Nisan")
+
+    def test_override_applied(self):
+        self.trans.set_overrides({("Hebrew month lexeme", "Nisan"): "Nissan"})
+        self.assertEqual(self.trans.gettext("Nisan", "Hebrew month lexeme"), "Nissan")
+
+    def test_override_applied_via_pgettext(self):
+        self.trans.set_overrides({("Hebrew month lexeme", "Nisan"): "Nissan"})
+        self.assertEqual(self.trans.pgettext("Hebrew month lexeme", "Nisan"), "Nissan")
+
+    def test_override_applied_via_lexgettext(self):
+        self.trans.set_overrides({("Hebrew month lexeme", "Nisan"): "Nissan"})
+        self.assertEqual(
+            self.trans.lexgettext("Nisan", "Hebrew month lexeme"), "Nissan"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gen/utils/test/translationoverride_test.py
+++ b/gramps/gen/utils/test/translationoverride_test.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Unit tests for gramps.gen.utils.translationoverride.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+
+from ..translationoverride import (
+    get_overrides_for_language,
+    load_custom_translations,
+    save_custom_translations,
+)
+
+
+class LoadCustomTranslationsTest(unittest.TestCase):
+    def setUp(self):
+        fd, self.filename = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+        os.remove(self.filename)  # start with a missing file
+
+    def tearDown(self):
+        if os.path.exists(self.filename):
+            os.remove(self.filename)
+
+    def test_missing_file_returns_empty_list(self):
+        self.assertEqual(load_custom_translations(self.filename), [])
+
+    def test_malformed_json_returns_empty_list(self):
+        with open(self.filename, "w", encoding="utf-8") as fp:
+            fp.write("not valid json")
+        self.assertEqual(load_custom_translations(self.filename), [])
+
+    def test_non_list_json_returns_empty_list(self):
+        with open(self.filename, "w", encoding="utf-8") as fp:
+            json.dump({"not": "a list"}, fp)
+        self.assertEqual(load_custom_translations(self.filename), [])
+
+    def test_round_trip(self):
+        entries = [
+            {
+                "language": "fr",
+                "context": "Hebrew month lexeme",
+                "msgid": "Nisan",
+                "msgstr": "Nissan",
+            }
+        ]
+        save_custom_translations(entries, self.filename)
+        self.assertEqual(load_custom_translations(self.filename), entries)
+
+
+class GetOverridesForLanguageTest(unittest.TestCase):
+    def setUp(self):
+        fd, self.filename = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+
+    def tearDown(self):
+        os.remove(self.filename)
+
+    def _write(self, entries):
+        save_custom_translations(entries, self.filename)
+
+    def test_exact_language_match(self):
+        self._write(
+            [
+                {
+                    "language": "fr",
+                    "context": "Hebrew month lexeme",
+                    "msgid": "Nisan",
+                    "msgstr": "Nissan",
+                }
+            ]
+        )
+        overrides = get_overrides_for_language("fr", self.filename)
+        self.assertEqual(overrides[("Hebrew month lexeme", "Nisan")], "Nissan")
+
+    def test_other_language_not_applied(self):
+        self._write(
+            [
+                {
+                    "language": "fr",
+                    "context": "Hebrew month lexeme",
+                    "msgid": "Nisan",
+                    "msgstr": "Nissan",
+                }
+            ]
+        )
+        overrides = get_overrides_for_language("en", self.filename)
+        self.assertNotIn(("Hebrew month lexeme", "Nisan"), overrides)
+
+    def test_subtag_match(self):
+        # An override registered for the bare "en" subtag should apply
+        # when the active language is a region variant like "en_GB".
+        self._write(
+            [
+                {
+                    "language": "en",
+                    "context": "Hebrew month lexeme",
+                    "msgid": "Heshvan",
+                    "msgstr": "Cheshvan",
+                }
+            ]
+        )
+        overrides = get_overrides_for_language("en_GB.UTF-8", self.filename)
+        self.assertEqual(overrides[("Hebrew month lexeme", "Heshvan")], "Cheshvan")
+
+    def test_exact_locale_wins_over_subtag(self):
+        self._write(
+            [
+                {
+                    "language": "en",
+                    "context": "Hebrew month lexeme",
+                    "msgid": "Heshvan",
+                    "msgstr": "generic-en-spelling",
+                },
+                {
+                    "language": "en_GB",
+                    "context": "Hebrew month lexeme",
+                    "msgid": "Heshvan",
+                    "msgstr": "gb-specific-spelling",
+                },
+            ]
+        )
+        overrides = get_overrides_for_language("en_GB", self.filename)
+        self.assertEqual(
+            overrides[("Hebrew month lexeme", "Heshvan")], "gb-specific-spelling"
+        )
+
+    def test_malformed_entry_is_skipped(self):
+        self._write([{"language": "en", "msgid": "Nisan"}])  # missing msgstr
+        overrides = get_overrides_for_language("en", self.filename)
+        self.assertEqual(overrides, {})
+
+    def test_default_context_when_absent(self):
+        self._write([{"language": "en", "msgid": "January", "msgstr": "Jan-uary"}])
+        overrides = get_overrides_for_language("en", self.filename)
+        self.assertEqual(overrides[("", "January")], "Jan-uary")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gen/utils/test/xmltranslate_test.py
+++ b/gramps/gen/utils/test/xmltranslate_test.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Unit tests for gramps.gen.utils.xmltranslate.
+"""
+
+import unittest
+import xml.etree.ElementTree as ET
+
+from .. import xmltranslate
+
+
+class FakeTranslation:
+    def sgettext(self, msgid: str, context: str = "") -> str:
+        if context:
+            return f"[{context}:{msgid}]"
+        return f"[{msgid}]"
+
+
+class FakeGlocale:
+    def __init__(self):
+        self.translation = FakeTranslation()
+
+
+class XmlTranslateTest(unittest.TestCase):
+    def setUp(self):
+        self._real_glocale = xmltranslate.glocale
+        xmltranslate.glocale = FakeGlocale()
+
+    def tearDown(self):
+        xmltranslate.glocale = self._real_glocale
+
+    def test_translatable_text_replaced_and_attrs_stripped(self):
+        xml = (
+            '<interface><property name="label" translatable="yes">'
+            "Hello</property></interface>"
+        )
+        root = ET.fromstring(xml)
+        xmltranslate.translate_xml_tree(root)
+        elem = root.find("property")
+        self.assertEqual(elem.text, "[Hello]")
+        self.assertNotIn("translatable", elem.attrib)
+        self.assertNotIn("context", elem.attrib)
+
+    def test_context_is_passed_through(self):
+        xml = (
+            '<interface><attribute name="label" translatable="yes" '
+            'context="Given names">_Given:</attribute></interface>'
+        )
+        root = ET.fromstring(xml)
+        xmltranslate.translate_xml_tree(root)
+        elem = root.find("attribute")
+        self.assertEqual(elem.text, "[Given names:_Given:]")
+        self.assertNotIn("translatable", elem.attrib)
+        self.assertNotIn("context", elem.attrib)
+
+    def test_comments_attribute_is_stripped(self):
+        xml = (
+            '<interface><property translatable="yes" comments="note">'
+            "Hi</property></interface>"
+        )
+        root = ET.fromstring(xml)
+        xmltranslate.translate_xml_tree(root)
+        elem = root.find("property")
+        self.assertNotIn("comments", elem.attrib)
+
+    def test_non_translatable_element_untouched(self):
+        xml = '<interface><property name="visible">True</property></interface>'
+        root = ET.fromstring(xml)
+        xmltranslate.translate_xml_tree(root)
+        elem = root.find("property")
+        self.assertEqual(elem.text, "True")
+        self.assertEqual(elem.attrib, {"name": "visible"})
+
+    def test_mutates_tree_in_place(self):
+        xml = '<interface><property translatable="yes">Foo</property></interface>'
+        root = ET.fromstring(xml)
+        result = xmltranslate.translate_xml_tree(root)
+        self.assertIsNone(result)
+        self.assertEqual(root.find("property").text, "[Foo]")
+
+    def test_translate_xml_string_returns_translated_xml(self):
+        xml = '<interface><property translatable="yes">Foo</property></interface>'
+        result = xmltranslate.translate_xml_string(xml)
+        root = ET.fromstring(result)
+        self.assertEqual(root.find("property").text, "[Foo]")
+        self.assertNotIn("translatable", root.find("property").attrib)
+
+    def test_non_ascii_translation_survives_ascii_serialization(self):
+        # gramps/gui/uimanager.py serializes its translated tree with
+        # ET.tostring(editable).decode(encoding="ascii"); confirm that
+        # non-ASCII replacement text survives that specific round trip
+        # (ET emits numeric character references for non-ASCII bytes-mode
+        # output, which a GtkBuilder XML parser reads back correctly).
+        class AccentTranslation:
+            def sgettext(self, msgid: str, context: str = "") -> str:
+                return "Café résumé"
+
+        xmltranslate.glocale.translation = AccentTranslation()
+        xml = '<interface><property translatable="yes">Foo</property></interface>'
+        root = ET.fromstring(xml)
+        xmltranslate.translate_xml_tree(root)
+        xml_str = ET.tostring(root).decode(encoding="ascii")
+        reparsed = ET.fromstring(xml_str)
+        self.assertEqual(reparsed.find("property").text, "Café résumé")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gen/utils/translationoverride.py
+++ b/gramps/gen/utils/translationoverride.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+User-defined translation overrides.
+
+Lets a user replace a specific translated string (e.g. a calendar month
+lexeme such as "Nisan") with their own preferred spelling, without editing
+any installed .po/.mo file. Overrides are stored in a single JSON file
+that is independent of the Gramps version directory, so it survives
+upgrades, and are shaped like a PO/Weblate translation unit
+(language, context, msgid, msgstr) to keep the door open for future
+interoperability with Gramps' Weblate-hosted translations.
+"""
+
+from __future__ import annotations
+
+# -------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import json
+import logging
+import os
+
+LOG = logging.getLogger(".gen.utils.translationoverride")
+
+
+def _default_filename() -> str:
+    """
+    Return the default custom translations file path.
+
+    Imported lazily to avoid a circular import: gramps.gen.const imports
+    gramps.gen.utils.grampslocale, which imports this module.
+    """
+    from ..const import CUSTOM_TRANSLATIONS
+
+    return CUSTOM_TRANSLATIONS
+
+
+def _primary_subtag(lang: str) -> str:
+    """
+    Return the primary language subtag of a language code, e.g. "fr" for
+    both "fr" and "fr_FR.UTF-8".
+    """
+    return lang.split(".")[0].split("_")[0].lower()
+
+
+def load_custom_translations(filename: str | None = None) -> list[dict]:
+    """
+    Load the raw list of custom translation override entries from disk.
+
+    :returns: the entries found in the file, or an empty list if the file
+              doesn't exist or can't be parsed as a JSON list.
+    :rtype: list[dict]
+    """
+    if filename is None:
+        filename = _default_filename()
+    if not os.path.exists(filename):
+        return []
+    try:
+        with open(filename, "r", encoding="utf-8") as fp:
+            data = json.load(fp)
+    except (OSError, ValueError) as err:
+        LOG.warning("Unable to read custom translations file %s: %s", filename, err)
+        return []
+    if not isinstance(data, list):
+        LOG.warning(
+            "Custom translations file %s does not contain a JSON list; ignoring",
+            filename,
+        )
+        return []
+    return data
+
+
+def save_custom_translations(entries: list[dict], filename: str | None = None) -> None:
+    """
+    Write the list of custom translation override entries to disk.
+
+    :param entries: entries with "language", "context", "msgid", and
+                     "msgstr" keys.
+    :type entries: list[dict]
+    """
+    if filename is None:
+        filename = _default_filename()
+    with open(filename, "w", encoding="utf-8") as fp:
+        json.dump(entries, fp, indent=2, ensure_ascii=False)
+
+
+def get_overrides_for_language(
+    active_lang: str, filename: str | None = None
+) -> dict[tuple[str, str], str]:
+    """
+    Resolve the custom translation entries that apply to one active
+    language.
+
+    An entry whose "language" is an exact match for ``active_lang`` takes
+    precedence over one that only matches the primary language subtag
+    (e.g. an "en_GB" entry wins over an "en" entry when ``active_lang``
+    is "en_GB").
+
+    :param active_lang: the language code of the translation currently in
+                         use, e.g. "fr_FR" or "en".
+    :type active_lang: str
+    :returns: mapping of (context, msgid) to the user's replacement text,
+              ready to pass to
+              :meth:`~gramps.gen.utils.grampstranslation.TranslationOverrideMixin.set_overrides`.
+    :rtype: dict[tuple[str, str], str]
+    """
+    active_subtag = _primary_subtag(active_lang)
+    exact: dict[tuple[str, str], str] = {}
+    by_subtag: dict[tuple[str, str], str] = {}
+    for entry in load_custom_translations(filename):
+        try:
+            lang = entry["language"]
+            context = entry.get("context", "")
+            msgid = entry["msgid"]
+            msgstr = entry["msgstr"]
+        except (KeyError, TypeError):
+            LOG.warning("Skipping malformed custom translation entry: %r", entry)
+            continue
+        key = (context, msgid)
+        if lang == active_lang:
+            exact[key] = msgstr
+        elif _primary_subtag(lang) == active_subtag:
+            by_subtag[key] = msgstr
+    return {**by_subtag, **exact}

--- a/gramps/gen/utils/xmltranslate.py
+++ b/gramps/gen/utils/xmltranslate.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Translation of GtkBuilder XML.
+
+Gtk.Builder translates ``translatable="yes"`` XML attributes itself, via
+GLib's C-level gettext binding, straight from the compiled .mo catalog. It
+never calls into Gramps' own translation object, so user-defined translation
+overrides (see :mod:`gramps.gen.utils.translationoverride`) are never
+consulted for menu, toolbar, or .glade dialog text defined this way.
+
+The functions here pre-resolve that text in Python, through the same
+override-aware path an ordinary ``_()`` call already uses, before the XML is
+ever handed to Gtk.Builder.
+"""
+
+from __future__ import annotations
+
+# -------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import xml.etree.ElementTree as ET
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from ..const import GRAMPS_LOCALE as glocale
+
+
+def translate_xml_tree(root: ET.Element) -> None:
+    """
+    Resolve ``translatable="yes"`` GtkBuilder XML text in place.
+
+    Each such element's text is replaced with its translation (consulting
+    user overrides first, then the normal catalog), and its
+    ``translatable``, ``context``, and ``comments`` attributes are removed
+    so Gtk.Builder does not attempt to translate it again.
+
+    :param root: the root of the XML tree to translate, mutated in place.
+    :type root: :py:class:`xml.etree.ElementTree.Element`
+    """
+    for elem in root.iter():
+        if elem.get("translatable") == "yes":
+            if elem.text:
+                context = elem.get("context", "")
+                elem.text = glocale.translation.sgettext(elem.text, context)
+            del elem.attrib["translatable"]
+            elem.attrib.pop("context", None)
+            elem.attrib.pop("comments", None)
+
+
+def translate_xml_string(xml_str: str) -> str:
+    """
+    Resolve ``translatable="yes"`` GtkBuilder XML text in a serialized
+    XML string.
+
+    :param xml_str: GtkBuilder XML source.
+    :type xml_str: str
+    :returns: the same XML with translatable text resolved and the
+              ``translatable``/``context``/``comments`` attributes removed.
+    :rtype: str
+    """
+    root = ET.fromstring(xml_str)
+    translate_xml_tree(root)
+    return ET.tostring(root, encoding="unicode")

--- a/gramps/gui/editors/editprimary.py
+++ b/gramps/gui/editors/editprimary.py
@@ -49,6 +49,7 @@ from ..utils import is_right_click
 from ..display import display_help
 from ..dialog import SaveDialog
 from gramps.gen.lib import PrimaryObject
+from gramps.gen.utils.xmltranslate import translate_xml_string
 from ..dbguielement import DbGUIElement
 from ..uimanager import ActionGroup
 
@@ -348,7 +349,7 @@ class EditPrimary(ManagedWindow, DbGUIElement, metaclass=abc.ABCMeta):
             </interface>"""
         )
 
-        builder = Gtk.Builder.new_from_string(popupui, -1)
+        builder = Gtk.Builder.new_from_string(translate_xml_string(popupui), -1)
 
         self.action_group = ActionGroup("EditPopup" + prefix, actions, prefix)
         act_grp = SimpleActionGroup()

--- a/gramps/gui/glade.py
+++ b/gramps/gui/glade.py
@@ -46,6 +46,7 @@ from gi.repository import Gtk
 # ------------------------------------------------------------------------
 from gramps.gen.const import GLADE_DIR, GRAMPS_LOCALE as glocale
 from gramps.gen.constfunc import is_quartz
+from gramps.gen.utils.xmltranslate import translate_xml_string
 
 # ------------------------------------------------------------------------
 #
@@ -159,6 +160,7 @@ class Glade(Gtk.Builder):
                 data = builder_file.read()
                 if is_quartz():
                     data = data.replace("GDK_CONTROL_MASK", "GDK_META_MASK")
+                data = translate_xml_string(data)
                 self.add_objects_from_string(data, loadlist)
             self.__toplevel = self.get_object(toplevel)
         # toplevel not given
@@ -167,6 +169,7 @@ class Glade(Gtk.Builder):
                 data = builder_file.read()
                 if is_quartz():
                     data = data.replace("GDK_CONTROL_MASK", "GDK_META_MASK")
+                data = translate_xml_string(data)
                 self.add_from_string(data)
             # first, use filename as possible toplevel widget name
             self.__toplevel = self.get_object(filename.rpartition(".")[0])

--- a/gramps/gui/plug/_dialogs.py
+++ b/gramps/gui/plug/_dialogs.py
@@ -43,6 +43,7 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
 from gramps.gen.const import PLUGINS_GLADE
 from gramps.gen.plug.report._constants import standalone_categories
+from gramps.gen.utils.xmltranslate import translate_xml_string
 from . import tool
 from gramps.gen.plug import REPORT
 from .report import report
@@ -101,7 +102,9 @@ class PluginDialog(ManagedWindow):
 
         self.dialog = Gtk.Builder()
         self.dialog.set_translation_domain(glocale.get_localedomain())
-        self.dialog.add_from_file(PLUGINS_GLADE)
+        with open(PLUGINS_GLADE, "r", encoding="utf-8") as builder_file:
+            data = translate_xml_string(builder_file.read())
+        self.dialog.add_from_string(data)
         self.dialog.connect_signals(
             {
                 "on_report_apply_clicked": self.on_apply_clicked,

--- a/gramps/gui/uimanager.py
+++ b/gramps/gui/uimanager.py
@@ -30,6 +30,7 @@ from gi.repository import GLib, Gio, Gtk
 
 from ..gen.const import GRAMPS_LOCALE as glocale
 from ..gen.config import config
+from ..gen.utils.xmltranslate import translate_xml_tree
 
 LOG = logging.getLogger("gui.uimanager")
 
@@ -228,6 +229,7 @@ class UIManager:
         editable = copy.deepcopy(self.et_xml)
         iterator(editable)  # clean up tree to builder specifications
         del iterator  # Needed for garbage collection
+        translate_xml_tree(editable)  # resolve translatable="yes" text
         # The following should work, but seems to have a Gtk bug
         # xml_str = ET.tostring(editable, encoding="unicode")
 

--- a/gramps/gui/widgets/styledtexteditor.py
+++ b/gramps/gui/widgets/styledtexteditor.py
@@ -67,6 +67,7 @@ from ..display import display_url
 from ..utils import SystemFonts, match_primary_mask, get_link_color
 from gramps.gen.config import config
 from gramps.gen.constfunc import has_display, mac
+from gramps.gen.utils.xmltranslate import translate_xml_string
 from ..uimanager import ActionGroup
 
 # -------------------------------------------------------------------------
@@ -618,7 +619,7 @@ class StyledTextEditor(Gtk.TextView):
         # build the toolbar
         builder = Gtk.Builder()
         builder.set_translation_domain(glocale.get_localedomain())
-        builder.add_from_string(FORMAT_TOOLBAR)
+        builder.add_from_string(translate_xml_string(FORMAT_TOOLBAR))
 
         # define the actions...
         _actions = [


### PR DESCRIPTION
## Summary

Adds a foundational mechanism for **local overrides of translations**: a
JSON file (`custom_translations.json`, in the user's Gramps data
directory, version-independent so it survives upgrades) that maps
`(context, msgid)` pairs to replacement text for a specific language.

`GrampsLocale` loads and installs these overrides on every locale
instance, and `GrampsTranslations`/`GrampsNullTranslations` consult them
before falling back to the normal `.mo` catalog, via a shared
`TranslationOverrideMixin`. Because both text display and date-string
*parsing* route through the same `gettext`/`pgettext` lookup, a single
override entry affects both what Gramps shows and what it accepts as
typed input — without any calendar- or date-specific code.

This is deliberately scoped to just the file format, loader, and lookup
interception — **no editor UI yet**. It's the base mechanism a larger
"local overrides for translations" feature builds on — see the full
design writeup in **#2481** for personal overrides, pulling updates
from Weblate between releases, and pushing local fixes back to
Weblate: https://github.com/gramps-project/gramps/discussions/2481

## Test plan

- [x] `black --check` passes on all changed/new files
- [x] `mypy` passes on all changed/new files
- [x] New unit tests in `gramps/gen/utils/test/translationoverride_test.py`
      and `gramps/gen/utils/test/grampstranslation_test.py` (21 tests, all
      passing) cover: loading/saving the override file (missing file,
      malformed JSON, non-list JSON, round-trip), language/subtag
      resolution and precedence, and override application through
      `gettext`, `pgettext`, `sgettext`, and `lexgettext` on both
      `GrampsTranslations` and `GrampsNullTranslations`.
- [x] Manually verified against a running Gramps install: overriding
      "January" changed both the displayed month name and what the date
      parser accepted as input.
