### PR TITLE
Add from/to date modifiers to DTD/RNG schema.

### DIFF
--- a/data/grampsxml.dtd
+++ b/data/grampsxml.dtd
@@ -450,12 +450,12 @@ SHARED ELEMENTS
 
 <!ELEMENT dateval EMPTY>
 <!ATTLIST dateval
-        val       CDATA                  #REQUIRED
-        type      (before|after|about)   #IMPLIED
-        quality   (estimated|calculated) #IMPLIED
-        cformat   CDATA                  #IMPLIED
-        dualdated (0|1)                  #IMPLIED
-        newyear   CDATA                  #IMPLIED
+        val       CDATA                        #REQUIRED
+        type      (before|after|about|from|to) #IMPLIED
+        quality   (estimated|calculated)       #IMPLIED
+        cformat   CDATA                        #IMPLIED
+        dualdated (0|1)                        #IMPLIED
+        newyear   CDATA                        #IMPLIED
 >
 
 <!ELEMENT datestr EMPTY>

--- a/data/grampsxml.rng
+++ b/data/grampsxml.rng
@@ -310,6 +310,8 @@
                 <value>before</value>
                 <value>after</value>
                 <value>about</value>
+                <value>from</value>
+                <value>to</value>
             </choice></attribute></optional>
             <optional><attribute name="quality"><choice>
                 <value>estimated</value>

--- a/example/gramps/data.gramps
+++ b/example/gramps/data.gramps
@@ -283,6 +283,7 @@
     </event>
     <event handle="_a701e8fe3ee581802d8" change="1198197326" id="E0044">
       <type>Occupation</type>
+      <dateval val="1966" type="from"/>
       <description>Retail Manager</description>
     </event>
     <event handle="_a701e8fe40453c7a8c6" change="1198197326" id="E0045">
@@ -352,6 +353,7 @@
     </event>
     <event handle="_a701e8fe7334aab749d" change="1198197326" id="E0056">
       <type>Occupation</type>
+      <dateval val="1990" type="to"/>
       <description>Software Engineer</description>
       <noteref hlink="_aef30789ea73e9b5b10"/>
     </event>


### PR DESCRIPTION
The PR #1124 added TO and FROM modifiers. They have, however, not been added to the validation schema, parsing a Gramps XML for my own report generator failed.