### PR TITLE
Fix broken layout in the Multiple Surnames editor

### DIFF
--- a/gramps/gui/editors/displaytabs/embeddedlist.py
+++ b/gramps/gui/editors/displaytabs/embeddedlist.py
@@ -121,6 +121,12 @@ class EmbeddedList(ButtonTab):
         self.col_icons = {}
         self.columns = []
         self.build_columns()
+        # restore_column_size() is called here rather than at the end of
+        # build_columns() because some subclasses (e.g. SurnameTab) append
+        # additional columns of their own after calling the base
+        # build_columns(); restoring saved widths must wait until all
+        # columns exist, or the extra columns never get their sizes back.
+        self.tree.restore_column_size()
 
         if self._DND_TYPE:
             self._set_dnd()
@@ -562,7 +568,6 @@ class EmbeddedList(ButtonTab):
             self.columns.append(column)
             self.tree.append_column(column)
         self.track_ref_for_deletion("columns")
-        self.tree.restore_column_size()
 
     def get_config_name(self):
         """used to associate the selector config name to the PersistentTreeView"""

--- a/gramps/gui/editors/displaytabs/surnametab.py
+++ b/gramps/gui/editors/displaytabs/surnametab.py
@@ -75,11 +75,11 @@ class SurnameTab(EmbeddedList):
     # index = column in model. Value =
     #  (name, sortcol in model, width, markup/text
     _column_names = [
-        (_("Prefix"), 0, 150, TEXT_EDIT_COL, -1, None),
+        (_("Prefix"), 0, 170, TEXT_EDIT_COL, -1, None),
         (_("Surname", "Multiple surnames"), 1, -1, TEXT_EDIT_COL, -1, None),
-        (_("Connector"), 2, 100, TEXT_EDIT_COL, -1, None),
+        (_("Connector"), 2, 130, TEXT_EDIT_COL, -1, None),
     ]
-    _column_combo = (_("Origin"), -1, 150, 3)  # name, sort, width, modelcol
+    _column_combo = (_("Origin"), -1, 160, 3)  # name, sort, width, modelcol
     _column_toggle = (_("Primary", "Name"), -1, 80, 4)
 
     def __init__(
@@ -147,7 +147,11 @@ class SurnameTab(EmbeddedList):
         column = Gtk.TreeViewColumn(name, renderer, text=self._column_combo[3])
         column.set_resizable(True)
         column.set_sort_column_id(self._column_combo[1])
-        column.set_min_width(self._column_combo[2])
+        # FIXED sizing (matching the other columns) is required for the
+        # resize handle to behave predictably; without it GTK falls back to
+        # GROW_ONLY, which resists shrinking and makes dragging feel stuck.
+        column.set_sizing(Gtk.TreeViewColumnSizing.FIXED)
+        column.set_fixed_width(self._column_combo[2])
         column.set_expand(False)
         self.columns.append(column)
         self.tree.append_column(column)


### PR DESCRIPTION
## Summary
- Column widths in the Person Editor's "Multiple Surnames" table (Prefix, Surname, Connector, Origin, Primary) did not persist across dialog opens. `SurnameTab` appends its Origin and Primary columns *after* calling the base `EmbeddedList.build_columns()`, but that method restored saved widths before those extra columns existed, so Origin/Primary always reset to their hard-coded defaults.
- The Origin column used `GROW_ONLY` sizing instead of `FIXED`, which made its resize handle (between Origin and Primary) resist shrinking and feel "stuck."
- Default widths for Prefix, Connector, and Origin were quite small (150/100/150px); widened slightly (170/130/160px) so they aren't cramped out of the box.

## Fix
- Moved `restore_column_size()` in `embeddedlist.py` to run after `build_columns()` fully completes (in `EmbeddedList.__init__`), instead of partway through, so subclasses that append extra columns (only `SurnameTab` does this) get all their saved widths restored correctly.
- Set `Gtk.TreeViewColumnSizing.FIXED` on the Origin column in `surnametab.py`, matching the other columns, so drag-resizing behaves consistently.
- Bumped the default column widths.

## Test plan
- [x] `black --check` passes on changed files and repo-wide
- [x] Manually verified in a running instance: resized all 5 columns, closed and reopened the Person Editor's Multiple Surnames table, confirmed all widths (including Origin and Primary) persisted
- [ ] Reviewer: please verify on your own family tree

Fixes 0013365.
