### PR TITLE
Add bsddb files back into AIO build

### DIFF
--- a/aio/build.sh
+++ b/aio/build.sh
@@ -48,6 +48,7 @@ pacman -S --needed --noconfirm \
     git \
     intltool \
     mingw-w64-ucrt-x86_64-adwaita-icon-theme \
+	mingw-w64-ucrt-x86_64-db \
     mingw-w64-ucrt-x86_64-geocode-glib \
     mingw-w64-ucrt-x86_64-gexiv2 \
     mingw-w64-ucrt-x86_64-ghostscript \
@@ -57,6 +58,7 @@ pacman -S --needed --noconfirm \
     mingw-w64-ucrt-x86_64-nsis \
     mingw-w64-ucrt-x86_64-osm-gps-map \
     mingw-w64-ucrt-x86_64-python \
+	mingw-w64-ucrt-x86_64-python-bsddb3 \
     mingw-w64-ucrt-x86_64-python-build \
     mingw-w64-ucrt-x86_64-python-cairo \
     mingw-w64-ucrt-x86_64-python-cffi \


### PR DESCRIPTION
I noticed that the recent 6.1 AIO would not load/upgrade older bsddb trees.
So I went back and looked at the UCRT repo at MSYS2 to see if they had dropped bsddb and python-bsddb. The repo has recently updated versions of both so I installed them with pacman. The AIO build did not include these installs.

I could then load/upgrade the old bsddb trees with Family Tree manager.

Berkeley Database library (bsddb3: 6.2.32) (python-bsddb3 adapter : 6.2.9)