### PR TITLE
Update mini-installed addon Python dependencies on Update click

### DIFF
--- a/gramps/gen/utils/pypi.py
+++ b/gramps/gen/utils/pypi.py
@@ -945,6 +945,7 @@ def _gather_requirements(
     extras: frozenset[str],
     specs: dict[str, list[str]],
     seen: set[str],
+    force: bool = False,
 ) -> None:
     """
     Recursively collect version constraints for *package* and its transitive deps.
@@ -961,18 +962,25 @@ def _gather_requirements(
     :param extras: Extras active on *package*; gates ``extra == "..."`` markers.
     :param specs: Accumulated ``{canonical_name: [spec, ...]}`` mapping.
     :param seen: Canonical names already visited (prevents infinite loops).
+    :param force: When True, gather *package*'s own requirements even if it is
+        already importable (used for upgrade checks).  Only applies to this
+        call; recursive calls for dependencies always use the normal
+        already-importable skip.
     """
     canonical = package.lower().replace("-", "_")
     if canonical in seen:
         return
     seen.add(canonical)
     # If already importable, skip: the install pass will also skip it, so its
-    # transitive constraints do not affect the resolution outcome.
-    try:
-        importlib.import_module(canonical)
-        return
-    except ImportError:
-        pass
+    # transitive constraints do not affect the resolution outcome.  In upgrade
+    # mode this skip is bypassed for the top-level package so a newer release's
+    # dependency list is still gathered.
+    if not force:
+        try:
+            importlib.import_module(canonical)
+            return
+        except ImportError:
+            pass
     try:
         meta = _pypi_metadata(package)
     except PyPIInstallError:
@@ -1166,7 +1174,10 @@ def _pip_available() -> bool:
 #
 # -------------------------------------------------------------------------
 def install_package(
-    package: str, target: str, extras: frozenset[str] = frozenset()
+    package: str,
+    target: str,
+    extras: frozenset[str] = frozenset(),
+    upgrade: bool = False,
 ) -> list[str]:
     """
     Download and install *package* from PyPI into *target*.
@@ -1189,6 +1200,10 @@ def install_package(
         ``"requests[security]"``.
     :param target: Filesystem path to install into (e.g. ``LIB_PATH``).
     :param extras: Set of extras to activate on *package*.
+    :param upgrade: When True, an already-importable *package* is not skipped
+        outright; the newest version on PyPI is looked up and *package* is
+        reinstalled unless the already-installed version is at least that
+        new.  Has no effect when *package* is not installed at all.
     :returns: List of package names that were installed.
     :raises PyPIInstallError: if the package or a dependency cannot be
         installed, or if no version satisfies the combined constraints.
@@ -1200,9 +1215,17 @@ def install_package(
         parsed = frozenset(e.strip() for e in em.group(2).split(",") if e.strip())
         extras = extras | parsed
 
+    # In upgrade mode, require at least the newest available version so the
+    # already-importable skip in _install_one() only fires when up to date.
+    top_version_spec = ""
+    if upgrade:
+        latest = _find_satisfying_version(package, "")
+        if latest is not None:
+            top_version_spec = f">={latest}"
+
     # Pass 1: gather all transitive version constraints from PyPI JSON metadata.
     specs: dict[str, list[str]] = {}
-    _gather_requirements(package, extras, specs, set())
+    _gather_requirements(package, extras, specs, set(), force=upgrade)
 
     # Pass 2: resolve a satisfying version for each constrained package.
     resolved: dict[str, str] = {}
@@ -1218,8 +1241,56 @@ def install_package(
 
     # Pass 3: install with pinned versions from the resolver.
     installed: list[str] = []
-    _install_one(package, target, installed, set(), extras=extras, resolved=resolved)
+    _install_one(
+        package,
+        target,
+        installed,
+        set(),
+        version_spec=top_version_spec,
+        extras=extras,
+        resolved=resolved,
+    )
     return installed
+
+
+def _uninstall_from_target(canonical: str, target: str) -> None:
+    """
+    Remove a previously mini-installed distribution of *canonical* from *target*.
+
+    Called before reinstalling a package during an upgrade so the old
+    version's ``dist-info`` cannot shadow the new one in subsequent
+    ``importlib.metadata`` lookups.  Only removes files belonging to a
+    distribution whose root is *target* itself; a distribution found
+    elsewhere on ``sys.path`` (system site-packages, a virtualenv, ...) is
+    left untouched since Gramps does not own it.
+    """
+    target_abs = os.path.abspath(target)
+    for name in (canonical, canonical.replace("_", "-")):
+        try:
+            dist = importlib.metadata.distribution(name)
+        except importlib.metadata.PackageNotFoundError:
+            continue
+        try:
+            root = os.path.abspath(str(dist.locate_file("")))
+        except Exception:
+            continue
+        if root != target_abs or not dist.files:
+            continue
+        dirs: set[str] = set()
+        for rel_path in dist.files:
+            abs_path = os.path.abspath(str(dist.locate_file(rel_path)))
+            if os.path.isfile(abs_path):
+                try:
+                    os.remove(abs_path)
+                except OSError:
+                    pass
+                dirs.add(os.path.dirname(abs_path))
+        # Best-effort cleanup of now-empty package directories.
+        for directory in sorted(dirs, key=len, reverse=True):
+            try:
+                os.removedirs(directory)
+            except OSError:
+                pass
 
 
 def _install_one(
@@ -1266,6 +1337,8 @@ def _install_one(
             canonical,
             version_spec,
         )
+        _uninstall_from_target(canonical, target)
+        importlib.invalidate_caches()
     except ImportError:
         pass
 

--- a/gramps/gen/utils/test/pypi_e2e_test.py
+++ b/gramps/gen/utils/test/pypi_e2e_test.py
@@ -54,7 +54,7 @@ import zipfile
 from ..pypi import (
     PyPIInstallError,
     _fetch_url,
-    _install_one,
+    _find_satisfying_version,
     _is_pure_wheel,
     _pick_wheel,
     _pypi_metadata,
@@ -84,6 +84,21 @@ _NODEP_PACKAGE = "iniconfig"
 # A small pure-Python package that is unlikely to be pre-installed in
 # the test environment, used to exercise the actual download path.
 _DOWNLOAD_PACKAGE = "tomli"
+
+
+def _force_extract(package: str, version: str, target: str) -> None:
+    """Download and extract a specific *version* of *package* into *target*.
+
+    Bypasses install_package()'s importability guard entirely by calling the
+    download/extract steps directly, so upgrade-test fixtures can be seeded
+    regardless of whether *package* happens to already be installed
+    elsewhere in the environment (e.g. as a build-tool dependency in CI).
+    """
+    meta = _pypi_metadata(package)
+    file_info = _pick_wheel(meta, package, version=version)
+    data = _fetch_url(file_info["url"])
+    with zipfile.ZipFile(io.BytesIO(data)) as whl:
+        whl.extractall(target)
 
 
 # -------------------------------------------------------------------------
@@ -304,7 +319,9 @@ class TestUpgradeE2E(unittest.TestCase):
             (
                 ver
                 for ver, files in meta.get("releases", {}).items()
-                if files and not all(f.get("yanked") for f in files)
+                if files
+                and not all(f.get("yanked") for f in files)
+                and any(f.get("filename", "").endswith(".whl") for f in files)
             ),
             key=_version_sort_key,
         )
@@ -313,17 +330,12 @@ class TestUpgradeE2E(unittest.TestCase):
         )
         old_version = stable_versions[0]
 
-        # Force-install the oldest available release directly into target,
-        # simulating a stale mini-installed dependency.
-        installed = []
-        _install_one(
-            _DOWNLOAD_PACKAGE,
-            self.target,
-            installed,
-            set(),
-            resolved={self.canonical: old_version},
-        )
-        self.assertEqual(installed, [_DOWNLOAD_PACKAGE])
+        # Seed target with the oldest release, bypassing install_package()'s
+        # importability guard so this works regardless of whether the real
+        # package is already installed elsewhere in the environment (e.g. as
+        # a build-tool dependency in CI).  self.target sits at sys.path[0],
+        # so this fixture shadows any such copy for the rest of the test.
+        _force_extract(_DOWNLOAD_PACKAGE, old_version, self.target)
         importlib.invalidate_caches()
         self.assertEqual(importlib.metadata.version(self.canonical), old_version)
 
@@ -348,9 +360,14 @@ class TestUpgradeE2E(unittest.TestCase):
         if self.canonical in sys.modules:
             self.skipTest(f"{self.canonical!r} already imported in this process")
 
-        installed = install_package(_DOWNLOAD_PACKAGE, self.target)
-        self.assertEqual(installed, [_DOWNLOAD_PACKAGE])
+        latest = _find_satisfying_version(_DOWNLOAD_PACKAGE, "")
+        self.assertIsNotNone(latest, "could not determine latest version from PyPI")
+
+        # Seed target directly at the newest release (see comment above on
+        # why this bypasses install_package() rather than calling it).
+        _force_extract(_DOWNLOAD_PACKAGE, latest, self.target)
         importlib.invalidate_caches()
+        self.assertEqual(importlib.metadata.version(self.canonical), latest)
 
         installed_again = install_package(_DOWNLOAD_PACKAGE, self.target, upgrade=True)
         self.assertEqual(installed_again, [])

--- a/gramps/gen/utils/test/pypi_e2e_test.py
+++ b/gramps/gen/utils/test/pypi_e2e_test.py
@@ -35,6 +35,7 @@ Run explicitly with:
 # -------------------------------------------------------------------------
 import hashlib
 import importlib
+import importlib.metadata
 import io
 import json
 import os
@@ -53,9 +54,11 @@ import zipfile
 from ..pypi import (
     PyPIInstallError,
     _fetch_url,
+    _install_one,
     _is_pure_wheel,
     _pick_wheel,
     _pypi_metadata,
+    _version_sort_key,
     install_package,
 )
 
@@ -266,6 +269,91 @@ class TestInstallPackageBehaviourE2E(unittest.TestCase):
         installed = install_package("os", self.target)
         self.assertEqual(installed, [])
         self.assertEqual(os.listdir(self.target), [])
+
+
+# -------------------------------------------------------------------------
+#
+# TestUpgradeE2E
+#
+# -------------------------------------------------------------------------
+class TestUpgradeE2E(unittest.TestCase):
+    """Tests of install_package(upgrade=True) against real PyPI."""
+
+    def setUp(self):
+        self.target = tempfile.mkdtemp()
+        self.canonical = _DOWNLOAD_PACKAGE.lower().replace("-", "_")
+        sys.path.insert(0, self.target)
+
+    def tearDown(self):
+        if self.target in sys.path:
+            sys.path.remove(self.target)
+        shutil.rmtree(self.target, ignore_errors=True)
+        # Drop the module we forced into sys.modules so later tests (in this
+        # file or others sharing the process) resolve it fresh.
+        sys.modules.pop(self.canonical, None)
+        importlib.invalidate_caches()
+
+    @_skip_offline
+    def test_upgrade_replaces_outdated_version(self):
+        """upgrade=True replaces an outdated mini-installed version."""
+        if self.canonical in sys.modules:
+            self.skipTest(f"{self.canonical!r} already imported in this process")
+
+        meta = _pypi_metadata(_DOWNLOAD_PACKAGE)
+        stable_versions = sorted(
+            (
+                ver
+                for ver, files in meta.get("releases", {}).items()
+                if files and not all(f.get("yanked") for f in files)
+            ),
+            key=_version_sort_key,
+        )
+        self.assertGreaterEqual(
+            len(stable_versions), 2, "test package needs 2+ releases"
+        )
+        old_version = stable_versions[0]
+
+        # Force-install the oldest available release directly into target,
+        # simulating a stale mini-installed dependency.
+        installed = []
+        _install_one(
+            _DOWNLOAD_PACKAGE,
+            self.target,
+            installed,
+            set(),
+            resolved={self.canonical: old_version},
+        )
+        self.assertEqual(installed, [_DOWNLOAD_PACKAGE])
+        importlib.invalidate_caches()
+        self.assertEqual(importlib.metadata.version(self.canonical), old_version)
+
+        # Upgrading should replace it with a newer release.
+        installed = install_package(_DOWNLOAD_PACKAGE, self.target, upgrade=True)
+        importlib.invalidate_caches()
+        self.assertEqual(installed, [_DOWNLOAD_PACKAGE])
+        new_version = importlib.metadata.version(self.canonical)
+        self.assertGreater(
+            _version_sort_key(new_version), _version_sort_key(old_version)
+        )
+
+        # The old dist-info must be gone, not merely shadowed.
+        dist_info_dirs = [
+            d for d in os.listdir(self.target) if d.endswith(".dist-info")
+        ]
+        self.assertTrue(all(old_version not in d for d in dist_info_dirs))
+
+    @_skip_offline
+    def test_upgrade_is_noop_when_already_latest(self):
+        """upgrade=True does not reinstall a package already at the newest version."""
+        if self.canonical in sys.modules:
+            self.skipTest(f"{self.canonical!r} already imported in this process")
+
+        installed = install_package(_DOWNLOAD_PACKAGE, self.target)
+        self.assertEqual(installed, [_DOWNLOAD_PACKAGE])
+        importlib.invalidate_caches()
+
+        installed_again = install_package(_DOWNLOAD_PACKAGE, self.target, upgrade=True)
+        self.assertEqual(installed_again, [])
 
 
 if __name__ == "__main__":

--- a/gramps/gui/plug/_windows.py
+++ b/gramps/gui/plug/_windows.py
@@ -292,13 +292,22 @@ class AddonRow(Gtk.ListBoxRow):
         vbox.pack_start(bb, False, False, 0)
         vbox.show_all()
 
-    def _install_python_deps(self, button: Gtk.Button, addon: dict) -> bool:
+    def _install_python_deps(
+        self, button: Gtk.Button, addon: dict, upgrade: bool = False
+    ) -> bool:
         """Install Python module dependencies declared by *addon*.
+
+        When *upgrade* is False (the default, used on Install) only modules
+        that are not yet importable are installed.  When *upgrade* is True
+        (used on Update) every declared module is checked against the newest
+        version on PyPI and reinstalled if the installed copy is older;
+        modules already at the latest version are left alone.
 
         Returns True on success.  On failure, disables *button*, shows an
         error dialog, and returns False.
         """
-        for package in self.req.install(addon):
+        packages = addon.get("rm", []) if upgrade else self.req.install(addon)
+        for package in packages:
             # Translate import names (e.g. "PIL") to PyPI names ("Pillow").
             pypi_name = resolve_pypi_name(package)
             try:
@@ -306,21 +315,24 @@ class AddonRow(Gtk.ListBoxRow):
                     # Frozen bundles (cx_Freeze/AIO, macOS .app) and pip-less
                     # environments (Flatpak, stripped Docker): use the stdlib
                     # wheel installer, which now supports manylinux/musllinux.
-                    install_package(pypi_name, LIB_PATH)
+                    install_package(pypi_name, LIB_PATH, upgrade=upgrade)
                 else:
-                    # Source / snap installs where pip is available.
-                    subprocess.check_output(
-                        [
-                            sys.executable,
-                            "-m",
-                            "pip",
-                            "install",
-                            "--target",
-                            LIB_PATH,
-                            pypi_name,
-                        ],
-                        stderr=subprocess.STDOUT,
-                    )
+                    # Source / snap installs where pip is available.  Note
+                    # that pip's own "--target --upgrade" combination is
+                    # known to leave files from the old version behind
+                    # (pypa/pip#8799); it still fetches the newer release.
+                    cmd = [
+                        sys.executable,
+                        "-m",
+                        "pip",
+                        "install",
+                        "--target",
+                        LIB_PATH,
+                    ]
+                    if upgrade:
+                        cmd.append("--upgrade")
+                    cmd.append(pypi_name)
+                    subprocess.check_output(cmd, stderr=subprocess.STDOUT)
             except (PyPIInstallError, subprocess.CalledProcessError) as err:
                 button.set_sensitive(False)
                 InfoDialog(
@@ -392,8 +404,12 @@ class AddonRow(Gtk.ListBoxRow):
 
     def __on_update_clicked(self, button, addon):
         """
-        Update the addon.
+        Update the addon and its Python module dependencies.
         """
+        if not self._install_python_deps(button, addon, upgrade=True):
+            return
+        importlib.invalidate_caches()
+
         path = addon["_u"] + "/download/" + addon["z"]
         load_addon_file(path)
         self.manager.update_addon(addon["i"])


### PR DESCRIPTION
[_I'm going to call this a bug fix, because if a pip-installed package needs to be updated, you'd have to find it, delete it, uninstall the addon, and re-install. This PR does require that the addon itself be updated too, but then can update the pip-installed package. -Doug_]

## Summary
- Clicking **Update** on an addon previously only refreshed the addon's own code — a Python module dependency already mini-installed via the stdlib PyPI wheel installer (or pip) was never checked against a newer release, so it could go stale indefinitely.
- `install_package()` in `gramps/gen/utils/pypi.py` gains an `upgrade` mode: it looks up the newest version on PyPI, and if the installed copy is older, removes the old `dist-info`/files (only when they live under the target mini-install directory, never touching system/venv installs) and reinstalls.
- The Update button now runs dependency installation in this mode before refreshing the addon code; the pip subprocess path passes `--upgrade` for the same effect on source/snap installs.

## Known limitation
The Update button's visibility is still driven only by the addon's own code version (`_v` vs `v` in `gramps/gui/plug/_windows.py`), not by whether a declared Python dependency has a newer release on PyPI. So this only refreshes a stale dependency as a side effect of clicking Update for some other reason (e.g. the addon's own version was bumped) — it does not yet surface "this addon's Python dependency is outdated" as its own condition. Keeping that out of scope for this PR to keep it simple; a follow-up could have the addon row check its `rm` packages against PyPI independently.

## Test plan
- [x] `python3 -m unittest gramps.gen.utils.test.pypi_test -v` (200 tests, existing coverage)
- [x] `python3 -m unittest gramps.gen.utils.test.pypi_e2e_test -v` (14 tests, including 2 new upgrade-mode tests against real PyPI)
- [x] `black --check` on all changed files
- [x] `mypy` on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)