### PR TITLE
Use geocode-glib-2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Python bindings for Oracle Berkeley database. Only needed to upgrade older Gramp
  to a place name. This is used if you already have osmgpsmap installed.
  If installed, when you add or link a place from the map, you have a red line
  at the end of the table for selection.
- The package name is usually gir1.2-geocodeglib-1.0 or geocode-glib.
+ The package name is usually gir1.2-geocodeglib-2.0 or geocode-glib.
 
 * [**fontconfig**](https://www.freedesktop.org/wiki/Software/fontconfig/)
 

--- a/debian/control
+++ b/debian/control
@@ -41,7 +41,7 @@ Recommends:
  gir1.2-gexiv2-0.10,
  gir1.2-osmgpsmap-1.0,
  python3-icu,
- gir1.2-geocodeglib-1.0,
+ gir1.2-geocodeglib-2.0,
  python3-fontconfig
 Suggests:
  fonts-freefont-ttf,

--- a/gramps/grampsapp.py
+++ b/gramps/grampsapp.py
@@ -453,7 +453,7 @@ def show_settings():
         rcs_ver = _("not found")
 
     try:
-        gi.require_version("GeocodeGlib", "1.0")
+        gi.require_version("GeocodeGlib", "2.0")
         from gi.repository import GeocodeGlib
 
         geocodeglib_ver = str(GeocodeGlib._version)

--- a/gramps/plugins/lib/maps/placeselection.py
+++ b/gramps/plugins/lib/maps/placeselection.py
@@ -51,7 +51,7 @@ from .osmgps import OsmGps
 #
 # -------------------------------------------------------------------------
 try:
-    gi.require_version("GeocodeGlib", "1.0")
+    gi.require_version("GeocodeGlib", "2.0")
     from gi.repository import GeocodeGlib
 
     GEOCODEGLIB = True


### PR DESCRIPTION
It uses `libsoup3` instead of the old, unmaintained `libsoup2`.