### PR TITLE
Cache and freeze get_schema() to speed up XML import

### DIFF
--- a/gramps/gen/lib/address.py
+++ b/gramps/gen/lib/address.py
@@ -27,9 +27,17 @@ Address class for Gramps.
 
 # -------------------------------------------------------------------------
 #
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import functools
+
+# -------------------------------------------------------------------------
+#
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .citationbase import CitationBase
 from .const import DIFFERENT, EQUAL, IDENTICAL
@@ -90,6 +98,7 @@ class Address(
         return self
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -100,33 +109,35 @@ class Address(
         # pylint: disable=import-outside-toplevel
         from .date import Date
 
-        return {
-            "type": "object",
-            "title": _("Address"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "private": {"type": "boolean", "title": _("Private")},
-                "citation_list": {
-                    "type": "array",
-                    "title": _("Citations"),
-                    "items": {"type": "string", "maxLength": 50},
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Address"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "private": {"type": "boolean", "title": _("Private")},
+                    "citation_list": {
+                        "type": "array",
+                        "title": _("Citations"),
+                        "items": {"type": "string", "maxLength": 50},
+                    },
+                    "note_list": {
+                        "type": "array",
+                        "title": _("Notes"),
+                        "items": {"type": "string", "maxLength": 50},
+                    },
+                    "date": Date.get_schema(),
+                    "street": {"type": "string", "title": _("Street")},
+                    "locality": {"type": "string", "title": _("Locality")},
+                    "city": {"type": "string", "title": _("City")},
+                    "county": {"type": "string", "title": _("County")},
+                    "state": {"type": "string", "title": _("State")},
+                    "country": {"type": "string", "title": _("Country")},
+                    "postal": {"type": "string", "title": _("Postal Code")},
+                    "phone": {"type": "string", "title": _("Phone")},
                 },
-                "note_list": {
-                    "type": "array",
-                    "title": _("Notes"),
-                    "items": {"type": "string", "maxLength": 50},
-                },
-                "date": Date.get_schema(),
-                "street": {"type": "string", "title": _("Street")},
-                "locality": {"type": "string", "title": _("Locality")},
-                "city": {"type": "string", "title": _("City")},
-                "county": {"type": "string", "title": _("County")},
-                "state": {"type": "string", "title": _("State")},
-                "country": {"type": "string", "title": _("Country")},
-                "postal": {"type": "string", "title": _("Postal Code")},
-                "phone": {"type": "string", "title": _("Phone")},
-            },
-        }
+            }
+        )
 
     def get_text_data_list(self):
         """

--- a/gramps/gen/lib/attribute.py
+++ b/gramps/gen/lib/attribute.py
@@ -26,9 +26,17 @@ Attribute class for Gramps.
 
 # -------------------------------------------------------------------------
 #
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import functools
+
+# -------------------------------------------------------------------------
+#
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .attrtype import AttributeType
 from .citationbase import CitationBase
@@ -230,6 +238,7 @@ class Attribute(AttributeRoot, CitationBase, NoteBase):
         return self
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -237,26 +246,28 @@ class Attribute(AttributeRoot, CitationBase, NoteBase):
         :returns: Returns a dict containing the schema.
         :rtype: dict
         """
-        return {
-            "type": "object",
-            "title": _("Attribute"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "private": {"type": "boolean", "title": _("Private")},
-                "citation_list": {
-                    "type": "array",
-                    "title": _("Citations"),
-                    "items": {"type": "string", "maxLength": 50},
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Attribute"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "private": {"type": "boolean", "title": _("Private")},
+                    "citation_list": {
+                        "type": "array",
+                        "title": _("Citations"),
+                        "items": {"type": "string", "maxLength": 50},
+                    },
+                    "note_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Notes"),
+                    },
+                    "type": AttributeType.get_schema(),
+                    "value": {"type": "string", "title": _("Value")},
                 },
-                "note_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Notes"),
-                },
-                "type": AttributeType.get_schema(),
-                "value": {"type": "string", "title": _("Value")},
-            },
-        }
+            }
+        )
 
     def get_referenced_handles(self):
         """

--- a/gramps/gen/lib/childref.py
+++ b/gramps/gen/lib/childref.py
@@ -27,9 +27,17 @@ Child Reference class for Gramps.
 
 # -------------------------------------------------------------------------
 #
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import functools
+
+# -------------------------------------------------------------------------
+#
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .childreftype import ChildRefType
 from .citationbase import CitationBase
@@ -93,6 +101,7 @@ class ChildRef(SecondaryObject, PrivacyBase, CitationBase, NoteBase, RefBase):
         return self
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -100,31 +109,33 @@ class ChildRef(SecondaryObject, PrivacyBase, CitationBase, NoteBase, RefBase):
         :returns: Returns a dict containing the schema.
         :rtype: dict
         """
-        return {
-            "type": "object",
-            "title": _("Child Reference"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "private": {"type": "boolean", "title": _("Private")},
-                "citation_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Citations"),
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Child Reference"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "private": {"type": "boolean", "title": _("Private")},
+                    "citation_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Citations"),
+                    },
+                    "note_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Notes"),
+                    },
+                    "ref": {
+                        "type": "string",
+                        "maxLength": 50,
+                        "title": _("Handle"),
+                    },
+                    "frel": ChildRefType.get_schema(),
+                    "mrel": ChildRefType.get_schema(),
                 },
-                "note_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Notes"),
-                },
-                "ref": {
-                    "type": "string",
-                    "maxLength": 50,
-                    "title": _("Handle"),
-                },
-                "frel": ChildRefType.get_schema(),
-                "mrel": ChildRefType.get_schema(),
-            },
-        }
+            }
+        )
 
     def get_text_data_list(self):
         """

--- a/gramps/gen/lib/citation.py
+++ b/gramps/gen/lib/citation.py
@@ -29,6 +29,7 @@ Citation object for Gramps.
 # Python modules
 #
 # -------------------------------------------------------------------------
+import functools
 import logging
 
 # -------------------------------------------------------------------------
@@ -36,6 +37,7 @@ import logging
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .attrbase import SrcAttributeBase
 from .citationbase import IndirectCitationBase
@@ -89,6 +91,7 @@ class Citation(
         SrcAttributeBase.__init__(self)  #  8
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -101,54 +104,56 @@ class Citation(
         from .mediaref import MediaRef
         from .srcattribute import SrcAttribute
 
-        return {
-            "type": "object",
-            "title": _("Citation"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "handle": {
-                    "type": "string",
-                    "maxLength": 50,
-                    "title": _("Handle"),
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Citation"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "handle": {
+                        "type": "string",
+                        "maxLength": 50,
+                        "title": _("Handle"),
+                    },
+                    "gramps_id": {"type": "string", "title": _("Gramps ID")},
+                    "date": Date.get_schema(),
+                    "page": {"type": "string", "title": _("Page")},
+                    "confidence": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 4,
+                        "title": _("Confidence"),
+                    },
+                    "source_handle": {
+                        "type": "string",
+                        "maxLength": 50,
+                        "title": _("Source"),
+                    },
+                    "note_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Notes"),
+                    },
+                    "media_list": {
+                        "type": "array",
+                        "items": MediaRef.get_schema(),
+                        "title": _("Media"),
+                    },
+                    "attribute_list": {
+                        "type": "array",
+                        "items": SrcAttribute.get_schema(),
+                        "title": _("Source Attributes"),
+                    },
+                    "change": {"type": "integer", "title": _("Last changed")},
+                    "tag_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Tags"),
+                    },
+                    "private": {"type": "boolean", "title": _("Private")},
                 },
-                "gramps_id": {"type": "string", "title": _("Gramps ID")},
-                "date": Date.get_schema(),
-                "page": {"type": "string", "title": _("Page")},
-                "confidence": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 4,
-                    "title": _("Confidence"),
-                },
-                "source_handle": {
-                    "type": "string",
-                    "maxLength": 50,
-                    "title": _("Source"),
-                },
-                "note_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Notes"),
-                },
-                "media_list": {
-                    "type": "array",
-                    "items": MediaRef.get_schema(),
-                    "title": _("Media"),
-                },
-                "attribute_list": {
-                    "type": "array",
-                    "items": SrcAttribute.get_schema(),
-                    "title": _("Source Attributes"),
-                },
-                "change": {"type": "integer", "title": _("Last changed")},
-                "tag_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Tags"),
-                },
-                "private": {"type": "boolean", "title": _("Private")},
-            },
-        }
+            }
+        )
 
     def serialize(self, no_text_date=False):
         """

--- a/gramps/gen/lib/date.py
+++ b/gramps/gen/lib/date.py
@@ -29,6 +29,7 @@
 #
 # ------------------------------------------------------------------------
 import calendar
+import functools
 import logging
 import time
 
@@ -37,6 +38,7 @@ import time
 # Gramps modules
 #
 # ------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from .baseobj import BaseObject
 from ..config import config
 from ..const import GRAMPS_LOCALE as glocale
@@ -773,6 +775,7 @@ class Date(BaseObject):
         super().set_object_state(attr_dict)
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -780,24 +783,26 @@ class Date(BaseObject):
         :returns: Returns a dict containing the schema.
         :rtype: dict
         """
-        return {
-            "type": "object",
-            "title": _("Date"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "calendar": {"type": "integer", "title": _("Calendar")},
-                "modifier": {"type": "integer", "title": _("Modifier")},
-                "quality": {"type": "integer", "title": _("Quality")},
-                "dateval": {
-                    "type": "array",
-                    "title": _("Values"),
-                    "items": {"type": ["integer", "boolean"]},
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Date"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "calendar": {"type": "integer", "title": _("Calendar")},
+                    "modifier": {"type": "integer", "title": _("Modifier")},
+                    "quality": {"type": "integer", "title": _("Quality")},
+                    "dateval": {
+                        "type": "array",
+                        "title": _("Values"),
+                        "items": {"type": ["integer", "boolean"]},
+                    },
+                    "text": {"type": "string", "title": _("Text")},
+                    "sortval": {"type": "integer", "title": _("Sort value")},
+                    "newyear": {"type": "integer", "title": _("New year begins")},
                 },
-                "text": {"type": "string", "title": _("Text")},
-                "sortval": {"type": "integer", "title": _("Sort value")},
-                "newyear": {"type": "integer", "title": _("New year begins")},
-            },
-        }
+            }
+        )
 
     def copy(self, source):
         """

--- a/gramps/gen/lib/event.py
+++ b/gramps/gen/lib/event.py
@@ -29,6 +29,7 @@ Event object for Gramps.
 # Python modules
 #
 # -------------------------------------------------------------------------
+import functools
 import logging
 
 # -------------------------------------------------------------------------
@@ -36,6 +37,7 @@ import logging
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .attrbase import AttributeBase
 from .citationbase import CitationBase
@@ -158,6 +160,7 @@ class Event(
         super().set_object_state(attr_dict)
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -170,54 +173,56 @@ class Event(
         from .date import Date
         from .mediaref import MediaRef
 
-        return {
-            "type": "object",
-            "title": _("Event"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "handle": {
-                    "type": "string",
-                    "maxLength": 50,
-                    "title": _("Handle"),
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Event"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "handle": {
+                        "type": "string",
+                        "maxLength": 50,
+                        "title": _("Handle"),
+                    },
+                    "gramps_id": {"type": "string", "title": _("Gramps ID")},
+                    "type": EventType.get_schema(),
+                    "date": Date.get_schema(),
+                    "description": {"type": "string", "title": _("Description")},
+                    "place": {
+                        "type": ["string", "null"],
+                        "maxLength": 50,
+                        "title": _("Place"),
+                    },
+                    "citation_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Citations"),
+                    },
+                    "note_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Notes"),
+                    },
+                    "media_list": {
+                        "type": "array",
+                        "items": MediaRef.get_schema(),
+                        "title": _("Media"),
+                    },
+                    "attribute_list": {
+                        "type": "array",
+                        "items": Attribute.get_schema(),
+                        "title": _("Attributes"),
+                    },
+                    "change": {"type": "integer", "title": _("Last changed")},
+                    "tag_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Tags"),
+                    },
+                    "private": {"type": "boolean", "title": _("Private")},
                 },
-                "gramps_id": {"type": "string", "title": _("Gramps ID")},
-                "type": EventType.get_schema(),
-                "date": Date.get_schema(),
-                "description": {"type": "string", "title": _("Description")},
-                "place": {
-                    "type": ["string", "null"],
-                    "maxLength": 50,
-                    "title": _("Place"),
-                },
-                "citation_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Citations"),
-                },
-                "note_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Notes"),
-                },
-                "media_list": {
-                    "type": "array",
-                    "items": MediaRef.get_schema(),
-                    "title": _("Media"),
-                },
-                "attribute_list": {
-                    "type": "array",
-                    "items": Attribute.get_schema(),
-                    "title": _("Attributes"),
-                },
-                "change": {"type": "integer", "title": _("Last changed")},
-                "tag_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Tags"),
-                },
-                "private": {"type": "boolean", "title": _("Private")},
-            },
-        }
+            }
+        )
 
     def unserialize(self, data):
         """

--- a/gramps/gen/lib/eventref.py
+++ b/gramps/gen/lib/eventref.py
@@ -27,9 +27,17 @@ Event Reference class for Gramps
 
 # -------------------------------------------------------------------------
 #
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import functools
+
+# -------------------------------------------------------------------------
+#
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .attrbase import AttributeBase
 from .citationbase import CitationBase
@@ -106,6 +114,7 @@ class EventRef(
         super().set_object_state(attr_dict)
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -116,31 +125,33 @@ class EventRef(
         # pylint: disable=import-outside-toplevel
         from .attribute import Attribute
 
-        return {
-            "type": "object",
-            "title": _("Event reference"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "private": {"type": "boolean", "title": _("Private")},
-                "citation_list": {
-                    "type": "array",
-                    "title": _("Citations"),
-                    "items": {"type": "string", "maxLength": 50},
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Event reference"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "private": {"type": "boolean", "title": _("Private")},
+                    "citation_list": {
+                        "type": "array",
+                        "title": _("Citations"),
+                        "items": {"type": "string", "maxLength": 50},
+                    },
+                    "note_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Notes"),
+                    },
+                    "attribute_list": {
+                        "type": "array",
+                        "items": Attribute.get_schema(),
+                        "title": _("Attributes"),
+                    },
+                    "ref": {"type": "string", "maxLength": 50, "title": _("Event")},
+                    "role": EventRoleType.get_schema(),
                 },
-                "note_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Notes"),
-                },
-                "attribute_list": {
-                    "type": "array",
-                    "items": Attribute.get_schema(),
-                    "title": _("Attributes"),
-                },
-                "ref": {"type": "string", "maxLength": 50, "title": _("Event")},
-                "role": EventRoleType.get_schema(),
-            },
-        }
+            }
+        )
 
     def unserialize(self, data):
         """

--- a/gramps/gen/lib/family.py
+++ b/gramps/gen/lib/family.py
@@ -29,6 +29,7 @@ Family object for Gramps.
 # Python modules
 #
 # -------------------------------------------------------------------------
+import functools
 import logging
 
 # -------------------------------------------------------------------------
@@ -36,6 +37,7 @@ import logging
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .attrbase import AttributeBase
 from .childref import ChildRef
@@ -143,6 +145,7 @@ class Family(
         )
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -155,68 +158,70 @@ class Family(
         from .ldsord import LdsOrd
         from .mediaref import MediaRef
 
-        return {
-            "type": "object",
-            "title": _("Family"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "handle": {"type": "string", "maxLength": 50, "title": _("Handle")},
-                "gramps_id": {"type": "string", "title": _("Gramps ID")},
-                "father_handle": {
-                    "type": ["string", "null"],
-                    "maxLength": 50,
-                    "title": _("Father"),
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Family"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "handle": {"type": "string", "maxLength": 50, "title": _("Handle")},
+                    "gramps_id": {"type": "string", "title": _("Gramps ID")},
+                    "father_handle": {
+                        "type": ["string", "null"],
+                        "maxLength": 50,
+                        "title": _("Father"),
+                    },
+                    "mother_handle": {
+                        "type": ["string", "null"],
+                        "maxLength": 50,
+                        "title": _("Mother"),
+                    },
+                    "child_ref_list": {
+                        "type": "array",
+                        "items": ChildRef.get_schema(),
+                        "title": _("Children"),
+                    },
+                    "type": FamilyRelType.get_schema(),
+                    "event_ref_list": {
+                        "type": "array",
+                        "items": EventRef.get_schema(),
+                        "title": _("Events"),
+                    },
+                    "media_list": {
+                        "type": "array",
+                        "items": MediaRef.get_schema(),
+                        "title": _("Media"),
+                    },
+                    "attribute_list": {
+                        "type": "array",
+                        "items": Attribute.get_schema(),
+                        "title": _("Attributes"),
+                    },
+                    "lds_ord_list": {
+                        "type": "array",
+                        "items": LdsOrd.get_schema(),
+                        "title": _("LDS ordinances"),
+                    },
+                    "citation_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Citations"),
+                    },
+                    "note_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Notes"),
+                    },
+                    "change": {"type": "integer", "title": _("Last changed")},
+                    "tag_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Tags"),
+                    },
+                    "private": {"type": "boolean", "title": _("Private")},
                 },
-                "mother_handle": {
-                    "type": ["string", "null"],
-                    "maxLength": 50,
-                    "title": _("Mother"),
-                },
-                "child_ref_list": {
-                    "type": "array",
-                    "items": ChildRef.get_schema(),
-                    "title": _("Children"),
-                },
-                "type": FamilyRelType.get_schema(),
-                "event_ref_list": {
-                    "type": "array",
-                    "items": EventRef.get_schema(),
-                    "title": _("Events"),
-                },
-                "media_list": {
-                    "type": "array",
-                    "items": MediaRef.get_schema(),
-                    "title": _("Media"),
-                },
-                "attribute_list": {
-                    "type": "array",
-                    "items": Attribute.get_schema(),
-                    "title": _("Attributes"),
-                },
-                "lds_ord_list": {
-                    "type": "array",
-                    "items": LdsOrd.get_schema(),
-                    "title": _("LDS ordinances"),
-                },
-                "citation_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Citations"),
-                },
-                "note_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Notes"),
-                },
-                "change": {"type": "integer", "title": _("Last changed")},
-                "tag_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Tags"),
-                },
-                "private": {"type": "boolean", "title": _("Private")},
-            },
-        }
+            }
+        )
 
     def unserialize(self, data):
         """

--- a/gramps/gen/lib/fs/familysearchsync.py
+++ b/gramps/gen/lib/fs/familysearchsync.py
@@ -22,7 +22,10 @@
 FamilySearch sync secondary object for Gramps.
 """
 
+import functools
+
 from ...const import GRAMPS_LOCALE as glocale
+from ..schemautils import freeze_schema
 from ..secondaryobj import SecondaryObject
 
 _ = glocale.translation.gettext
@@ -64,40 +67,46 @@ class FamilySearchSync(SecondaryObject):
         }
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON schema for this class.
         """
-        return {
-            "type": "object",
-            "title": _("FamilySearch sync"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "fsid": {"type": ["string", "null"], "title": _("FamilySearch ID")},
-                "is_root": {"type": "boolean", "title": _("Is root")},
-                "status_ts": {
-                    "type": ["integer", "null"],
-                    "title": _("Status timestamp"),
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("FamilySearch sync"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "fsid": {
+                        "type": ["string", "null"],
+                        "title": _("FamilySearch ID"),
+                    },
+                    "is_root": {"type": "boolean", "title": _("Is root")},
+                    "status_ts": {
+                        "type": ["integer", "null"],
+                        "title": _("Status timestamp"),
+                    },
+                    "confirmed_ts": {
+                        "type": ["integer", "null"],
+                        "title": _("Confirmed timestamp"),
+                    },
+                    "gramps_modified_ts": {
+                        "type": ["integer", "null"],
+                        "title": _("Gramps modified timestamp"),
+                    },
+                    "fs_modified_ts": {
+                        "type": ["integer", "null"],
+                        "title": _("FamilySearch modified timestamp"),
+                    },
+                    "essential_conflict": {
+                        "type": "boolean",
+                        "title": _("Essential conflict"),
+                    },
+                    "conflict": {"type": "boolean", "title": _("Conflict")},
                 },
-                "confirmed_ts": {
-                    "type": ["integer", "null"],
-                    "title": _("Confirmed timestamp"),
-                },
-                "gramps_modified_ts": {
-                    "type": ["integer", "null"],
-                    "title": _("Gramps modified timestamp"),
-                },
-                "fs_modified_ts": {
-                    "type": ["integer", "null"],
-                    "title": _("FamilySearch modified timestamp"),
-                },
-                "essential_conflict": {
-                    "type": "boolean",
-                    "title": _("Essential conflict"),
-                },
-                "conflict": {"type": "boolean", "title": _("Conflict")},
-            },
-        }
+            }
+        )
 
     def unserialize(self, data):
         """

--- a/gramps/gen/lib/grampstype.py
+++ b/gramps/gen/lib/grampstype.py
@@ -29,6 +29,7 @@ Base type for all gramps types.
 #
 # -------------------------------------------------------------------------
 from __future__ import annotations
+import functools
 from functools import singledispatchmethod
 from typing import Any
 
@@ -37,6 +38,7 @@ from typing import Any
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 
 _ = glocale.translation.gettext
@@ -255,6 +257,7 @@ class GrampsType(metaclass=GrampsTypeMeta):
         return cls.__get_str(data.value, data.string)
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -262,15 +265,17 @@ class GrampsType(metaclass=GrampsTypeMeta):
         :returns: Returns a dict containing the schema.
         :rtype: dict
         """
-        return {
-            "type": "object",
-            "title": _("Type"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "string": {"type": "string", "title": _("Custom type")},
-                "value": {"type": "integer", "title": _("Type code")},
-            },
-        }
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Type"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "string": {"type": "string", "title": _("Custom type")},
+                    "value": {"type": "integer", "title": _("Type code")},
+                },
+            }
+        )
 
     def unserialize(self, data):
         """Convert a serialized tuple of data to an object."""

--- a/gramps/gen/lib/ldsord.py
+++ b/gramps/gen/lib/ldsord.py
@@ -30,6 +30,7 @@ LDS Ordinance class for Gramps.
 # Python modules
 #
 # -------------------------------------------------------------------------
+import functools
 from warnings import warn
 
 # -------------------------------------------------------------------------
@@ -37,6 +38,7 @@ from warnings import warn
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .citationbase import CitationBase
 from .const import DIFFERENT, EQUAL, IDENTICAL
@@ -172,6 +174,7 @@ class LdsOrd(SecondaryObject, CitationBase, NoteBase, DateBase, PlaceBase, Priva
         return self
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -182,30 +185,32 @@ class LdsOrd(SecondaryObject, CitationBase, NoteBase, DateBase, PlaceBase, Priva
         # pylint: disable=import-outside-toplevel
         from .date import Date
 
-        return {
-            "type": "object",
-            "title": _("LDS Ordinance"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "citation_list": {
-                    "type": "array",
-                    "title": _("Citations"),
-                    "items": {"type": "string", "maxLength": 50},
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("LDS Ordinance"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "citation_list": {
+                        "type": "array",
+                        "title": _("Citations"),
+                        "items": {"type": "string", "maxLength": 50},
+                    },
+                    "note_list": {
+                        "type": "array",
+                        "title": _("Notes"),
+                        "items": {"type": "string", "maxLength": 50},
+                    },
+                    "date": Date.get_schema(),
+                    "type": {"type": "integer", "title": _("Type")},
+                    "place": {"type": "string", "title": _("Place")},
+                    "famc": {"type": ["null", "string"], "title": _("Family")},
+                    "temple": {"type": "string", "title": _("Temple")},
+                    "status": {"type": "integer", "title": _("Status")},
+                    "private": {"type": "boolean", "title": _("Private")},
                 },
-                "note_list": {
-                    "type": "array",
-                    "title": _("Notes"),
-                    "items": {"type": "string", "maxLength": 50},
-                },
-                "date": Date.get_schema(),
-                "type": {"type": "integer", "title": _("Type")},
-                "place": {"type": "string", "title": _("Place")},
-                "famc": {"type": ["null", "string"], "title": _("Family")},
-                "temple": {"type": "string", "title": _("Temple")},
-                "status": {"type": "integer", "title": _("Status")},
-                "private": {"type": "boolean", "title": _("Private")},
-            },
-        }
+            }
+        )
 
     def get_text_data_list(self):
         """

--- a/gramps/gen/lib/location.py
+++ b/gramps/gen/lib/location.py
@@ -26,9 +26,17 @@ Location class for Gramps.
 
 # -------------------------------------------------------------------------
 #
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import functools
+
+# -------------------------------------------------------------------------
+#
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .const import DIFFERENT, IDENTICAL
 from .locationbase import LocationBase
@@ -76,6 +84,7 @@ class Location(SecondaryObject, LocationBase):
         return self
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -83,22 +92,24 @@ class Location(SecondaryObject, LocationBase):
         :returns: Returns a dict containing the schema.
         :rtype: dict
         """
-        return {
-            "type": "object",
-            "title": _("Location"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "street": {"type": "string", "title": _("Street")},
-                "locality": {"type": "string", "title": _("Locality")},
-                "city": {"type": "string", "title": _("City")},
-                "county": {"type": "string", "title": _("County")},
-                "state": {"type": "string", "title": _("State")},
-                "country": {"type": "string", "title": _("Country")},
-                "postal": {"type": "string", "title": _("Postal Code")},
-                "phone": {"type": "string", "title": _("Phone")},
-                "parish": {"type": "string", "title": _("Parish")},
-            },
-        }
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Location"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "street": {"type": "string", "title": _("Street")},
+                    "locality": {"type": "string", "title": _("Locality")},
+                    "city": {"type": "string", "title": _("City")},
+                    "county": {"type": "string", "title": _("County")},
+                    "state": {"type": "string", "title": _("State")},
+                    "country": {"type": "string", "title": _("Country")},
+                    "postal": {"type": "string", "title": _("Postal Code")},
+                    "phone": {"type": "string", "title": _("Phone")},
+                    "parish": {"type": "string", "title": _("Parish")},
+                },
+            }
+        )
 
     def get_text_data_list(self):
         """

--- a/gramps/gen/lib/media.py
+++ b/gramps/gen/lib/media.py
@@ -29,6 +29,7 @@ Media object for Gramps.
 # Python modules
 #
 # -------------------------------------------------------------------------
+import functools
 import logging
 import os
 from urllib.parse import urlparse
@@ -38,6 +39,7 @@ from urllib.parse import urlparse
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .attrbase import AttributeBase
 from .citationbase import CitationBase
@@ -126,6 +128,7 @@ class Media(CitationBase, NoteBase, DateBase, AttributeBase, PrimaryObject):
         )
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -137,46 +140,48 @@ class Media(CitationBase, NoteBase, DateBase, AttributeBase, PrimaryObject):
         from .attribute import Attribute
         from .date import Date
 
-        return {
-            "type": "object",
-            "title": _("Media"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "handle": {
-                    "type": "string",
-                    "maxLength": 50,
-                    "title": _("Handle"),
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Media"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "handle": {
+                        "type": "string",
+                        "maxLength": 50,
+                        "title": _("Handle"),
+                    },
+                    "gramps_id": {"type": "string", "title": _("Gramps ID")},
+                    "path": {"type": "string", "title": _("Path")},
+                    "mime": {"type": "string", "title": _("MIME")},
+                    "desc": {"type": "string", "title": _("Description")},
+                    "checksum": {"type": "string", "title": _("Checksum")},
+                    "attribute_list": {
+                        "type": "array",
+                        "items": Attribute.get_schema(),
+                        "title": _("Attributes"),
+                    },
+                    "citation_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Citations"),
+                    },
+                    "note_list": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "title": _("Notes"),
+                    },
+                    "change": {"type": "integer", "title": _("Last changed")},
+                    "date": Date.get_schema(),
+                    "tag_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Tags"),
+                    },
+                    "private": {"type": "boolean", "title": _("Private")},
                 },
-                "gramps_id": {"type": "string", "title": _("Gramps ID")},
-                "path": {"type": "string", "title": _("Path")},
-                "mime": {"type": "string", "title": _("MIME")},
-                "desc": {"type": "string", "title": _("Description")},
-                "checksum": {"type": "string", "title": _("Checksum")},
-                "attribute_list": {
-                    "type": "array",
-                    "items": Attribute.get_schema(),
-                    "title": _("Attributes"),
-                },
-                "citation_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Citations"),
-                },
-                "note_list": {
-                    "type": "array",
-                    "items": {"type": "string"},
-                    "title": _("Notes"),
-                },
-                "change": {"type": "integer", "title": _("Last changed")},
-                "date": Date.get_schema(),
-                "tag_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Tags"),
-                },
-                "private": {"type": "boolean", "title": _("Private")},
-            },
-        }
+            }
+        )
 
     def unserialize(self, data):
         """

--- a/gramps/gen/lib/mediaref.py
+++ b/gramps/gen/lib/mediaref.py
@@ -27,9 +27,17 @@ Media Reference class for Gramps.
 
 # -------------------------------------------------------------------------
 #
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import functools
+
+# -------------------------------------------------------------------------
+#
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .attrbase import AttributeBase
 from .citationbase import CitationBase
@@ -80,6 +88,7 @@ class MediaRef(
         )
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -90,46 +99,48 @@ class MediaRef(
         # pylint: disable=import-outside-toplevel
         from .attribute import Attribute
 
-        return {
-            "type": "object",
-            "title": _("Media ref"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "private": {"type": "boolean", "title": _("Private")},
-                "citation_list": {
-                    "type": "array",
-                    "title": _("Citations"),
-                    "items": {"type": "string", "maxLength": 50},
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Media ref"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "private": {"type": "boolean", "title": _("Private")},
+                    "citation_list": {
+                        "type": "array",
+                        "title": _("Citations"),
+                        "items": {"type": "string", "maxLength": 50},
+                    },
+                    "note_list": {
+                        "type": "array",
+                        "title": _("Notes"),
+                        "items": {"type": "string", "maxLength": 50},
+                    },
+                    "attribute_list": {
+                        "type": "array",
+                        "title": _("Attributes"),
+                        "items": Attribute.get_schema(),
+                    },
+                    "ref": {
+                        "type": "string",
+                        "title": _("Handle"),
+                        "maxLength": 50,
+                    },
+                    "rect": {
+                        "oneOf": [
+                            {"type": "null"},
+                            {
+                                "type": "array",
+                                "items": {"type": "integer"},
+                                "minItems": 4,
+                                "maxItems": 4,
+                            },
+                        ],
+                        "title": _("Region"),
+                    },
                 },
-                "note_list": {
-                    "type": "array",
-                    "title": _("Notes"),
-                    "items": {"type": "string", "maxLength": 50},
-                },
-                "attribute_list": {
-                    "type": "array",
-                    "title": _("Attributes"),
-                    "items": Attribute.get_schema(),
-                },
-                "ref": {
-                    "type": "string",
-                    "title": _("Handle"),
-                    "maxLength": 50,
-                },
-                "rect": {
-                    "oneOf": [
-                        {"type": "null"},
-                        {
-                            "type": "array",
-                            "items": {"type": "integer"},
-                            "minItems": 4,
-                            "maxItems": 4,
-                        },
-                    ],
-                    "title": _("Region"),
-                },
-            },
-        }
+            }
+        )
 
     def unserialize(self, data):
         """

--- a/gramps/gen/lib/name.py
+++ b/gramps/gen/lib/name.py
@@ -27,9 +27,17 @@ Name class for Gramps.
 
 # -------------------------------------------------------------------------
 #
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import functools
+
+# -------------------------------------------------------------------------
+#
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .citationbase import CitationBase
 from .const import DIFFERENT, EQUAL, IDENTICAL
@@ -150,6 +158,7 @@ class Name(SecondaryObject, PrivacyBase, SurnameBase, CitationBase, NoteBase, Da
         )
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -160,40 +169,42 @@ class Name(SecondaryObject, PrivacyBase, SurnameBase, CitationBase, NoteBase, Da
         # pylint: disable=import-outside-toplevel
         from .surname import Surname
 
-        return {
-            "type": "object",
-            "title": _("Name"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "private": {"type": "boolean", "title": _("Private")},
-                "citation_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Citations"),
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Name"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "private": {"type": "boolean", "title": _("Private")},
+                    "citation_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Citations"),
+                    },
+                    "note_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Notes"),
+                    },
+                    "date": Date.get_schema(),
+                    "first_name": {"type": "string", "title": _("Given name")},
+                    "surname_list": {
+                        "type": "array",
+                        "items": Surname.get_schema(),
+                        "title": _("Surnames"),
+                    },
+                    "suffix": {"type": "string", "title": _("Suffix")},
+                    "title": {"type": "string", "title": _("Title")},
+                    "type": NameType.get_schema(),
+                    "group_as": {"type": "string", "title": _("Group as")},
+                    "sort_as": {"type": "integer", "title": _("Sort as")},
+                    "display_as": {"type": "integer", "title": _("Display as")},
+                    "call": {"type": "string", "title": _("Call name")},
+                    "nick": {"type": "string", "title": _("Nick name")},
+                    "famnick": {"type": "string", "title": _("Family nick name")},
                 },
-                "note_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Notes"),
-                },
-                "date": Date.get_schema(),
-                "first_name": {"type": "string", "title": _("Given name")},
-                "surname_list": {
-                    "type": "array",
-                    "items": Surname.get_schema(),
-                    "title": _("Surnames"),
-                },
-                "suffix": {"type": "string", "title": _("Suffix")},
-                "title": {"type": "string", "title": _("Title")},
-                "type": NameType.get_schema(),
-                "group_as": {"type": "string", "title": _("Group as")},
-                "sort_as": {"type": "integer", "title": _("Sort as")},
-                "display_as": {"type": "integer", "title": _("Display as")},
-                "call": {"type": "string", "title": _("Call name")},
-                "nick": {"type": "string", "title": _("Nick name")},
-                "famnick": {"type": "string", "title": _("Family nick name")},
-            },
-        }
+            }
+        )
 
     def is_empty(self):
         """

--- a/gramps/gen/lib/note.py
+++ b/gramps/gen/lib/note.py
@@ -26,9 +26,17 @@ Note class for Gramps.
 
 # -------------------------------------------------------------------------
 #
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import functools
+
+# -------------------------------------------------------------------------
+#
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .notetype import NoteType
 from .primaryobj import BasicPrimaryObject
@@ -93,6 +101,7 @@ class Note(BasicPrimaryObject):
         )
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -100,29 +109,31 @@ class Note(BasicPrimaryObject):
         :returns: Returns a dict containing the schema.
         :rtype: dict
         """
-        return {
-            "type": "object",
-            "title": _("Note"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "handle": {
-                    "type": "string",
-                    "maxLength": 50,
-                    "title": _("Handle"),
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Note"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "handle": {
+                        "type": "string",
+                        "maxLength": 50,
+                        "title": _("Handle"),
+                    },
+                    "gramps_id": {"type": "string", "title": _("Gramps ID")},
+                    "text": StyledText.get_schema(),
+                    "format": {"type": "integer", "title": _("Format")},
+                    "type": NoteType.get_schema(),
+                    "change": {"type": "integer", "title": _("Last changed")},
+                    "tag_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Tags"),
+                    },
+                    "private": {"type": "boolean", "title": _("Private")},
                 },
-                "gramps_id": {"type": "string", "title": _("Gramps ID")},
-                "text": StyledText.get_schema(),
-                "format": {"type": "integer", "title": _("Format")},
-                "type": NoteType.get_schema(),
-                "change": {"type": "integer", "title": _("Last changed")},
-                "tag_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Tags"),
-                },
-                "private": {"type": "boolean", "title": _("Private")},
-            },
-        }
+            }
+        )
 
     def unserialize(self, data):
         """Convert a serialized tuple of data to an object.

--- a/gramps/gen/lib/person.py
+++ b/gramps/gen/lib/person.py
@@ -27,9 +27,17 @@ Person object for Gramps.
 
 # -------------------------------------------------------------------------
 #
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import functools
+
+# -------------------------------------------------------------------------
+#
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .addressbase import AddressBase
 from .attrbase import AttributeBase
@@ -174,6 +182,7 @@ class Person(
         )
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -187,98 +196,100 @@ class Person(
         from .mediaref import MediaRef
         from .url import Url
 
-        return {
-            "type": "object",
-            "title": _("Person"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "handle": {"type": "string", "maxLength": 50, "title": _("Handle")},
-                "gramps_id": {"type": "string", "title": _("Gramps ID")},
-                "gender": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 3,
-                    "title": _("Gender"),
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Person"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "handle": {"type": "string", "maxLength": 50, "title": _("Handle")},
+                    "gramps_id": {"type": "string", "title": _("Gramps ID")},
+                    "gender": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 3,
+                        "title": _("Gender"),
+                    },
+                    "primary_name": Name.get_schema(),
+                    "alternate_names": {
+                        "type": "array",
+                        "items": Name.get_schema(),
+                        "title": _("Alternate names"),
+                    },
+                    "death_ref_index": {
+                        "type": "integer",
+                        "title": _("Death reference index"),
+                    },
+                    "birth_ref_index": {
+                        "type": "integer",
+                        "title": _("Birth reference index"),
+                    },
+                    "event_ref_list": {
+                        "type": "array",
+                        "items": EventRef.get_schema(),
+                        "title": _("Event references"),
+                    },
+                    "family_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Families"),
+                    },
+                    "parent_family_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Parent families"),
+                    },
+                    "media_list": {
+                        "type": "array",
+                        "items": MediaRef.get_schema(),
+                        "title": _("Media"),
+                    },
+                    "address_list": {
+                        "type": "array",
+                        "items": Address.get_schema(),
+                        "title": _("Addresses"),
+                    },
+                    "attribute_list": {
+                        "type": "array",
+                        "items": Attribute.get_schema(),
+                        "title": _("Attributes"),
+                    },
+                    "urls": {
+                        "type": "array",
+                        "items": Url.get_schema(),
+                        "title": _("URLs"),
+                    },
+                    "lds_ord_list": {
+                        "type": "array",
+                        "items": LdsOrd.get_schema(),
+                        "title": _("LDS ordinances"),
+                    },
+                    "citation_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Citations"),
+                    },
+                    "note_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Notes"),
+                    },
+                    "change": {"type": "integer", "title": _("Last changed")},
+                    "tag_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Tags"),
+                    },
+                    "private": {"type": "boolean", "title": _("Private")},
+                    "person_ref_list": {
+                        "type": "array",
+                        "items": PersonRef.get_schema(),
+                        "title": _("Person references"),
+                    },
+                    "familysearch_sync": FamilySearchSync.get_schema(),
                 },
-                "primary_name": Name.get_schema(),
-                "alternate_names": {
-                    "type": "array",
-                    "items": Name.get_schema(),
-                    "title": _("Alternate names"),
-                },
-                "death_ref_index": {
-                    "type": "integer",
-                    "title": _("Death reference index"),
-                },
-                "birth_ref_index": {
-                    "type": "integer",
-                    "title": _("Birth reference index"),
-                },
-                "event_ref_list": {
-                    "type": "array",
-                    "items": EventRef.get_schema(),
-                    "title": _("Event references"),
-                },
-                "family_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Families"),
-                },
-                "parent_family_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Parent families"),
-                },
-                "media_list": {
-                    "type": "array",
-                    "items": MediaRef.get_schema(),
-                    "title": _("Media"),
-                },
-                "address_list": {
-                    "type": "array",
-                    "items": Address.get_schema(),
-                    "title": _("Addresses"),
-                },
-                "attribute_list": {
-                    "type": "array",
-                    "items": Attribute.get_schema(),
-                    "title": _("Attributes"),
-                },
-                "urls": {
-                    "type": "array",
-                    "items": Url.get_schema(),
-                    "title": _("URLs"),
-                },
-                "lds_ord_list": {
-                    "type": "array",
-                    "items": LdsOrd.get_schema(),
-                    "title": _("LDS ordinances"),
-                },
-                "citation_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Citations"),
-                },
-                "note_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Notes"),
-                },
-                "change": {"type": "integer", "title": _("Last changed")},
-                "tag_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Tags"),
-                },
-                "private": {"type": "boolean", "title": _("Private")},
-                "person_ref_list": {
-                    "type": "array",
-                    "items": PersonRef.get_schema(),
-                    "title": _("Person references"),
-                },
-                "familysearch_sync": FamilySearchSync.get_schema(),
-            },
-        }
+            }
+        )
 
     def unserialize(self, data):
         """

--- a/gramps/gen/lib/personref.py
+++ b/gramps/gen/lib/personref.py
@@ -27,9 +27,17 @@ Person Reference class for Gramps.
 
 # -------------------------------------------------------------------------
 #
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import functools
+
+# -------------------------------------------------------------------------
+#
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .citationbase import CitationBase
 from .const import DIFFERENT, EQUAL, IDENTICAL
@@ -89,6 +97,7 @@ class PersonRef(SecondaryObject, PrivacyBase, CitationBase, NoteBase, RefBase):
         return self
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -96,30 +105,32 @@ class PersonRef(SecondaryObject, PrivacyBase, CitationBase, NoteBase, RefBase):
         :returns: Returns a dict containing the schema.
         :rtype: dict
         """
-        return {
-            "type": "object",
-            "title": _("Person ref"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "private": {"type": "boolean", "title": _("Private")},
-                "citation_list": {
-                    "type": "array",
-                    "title": _("Citations"),
-                    "items": {"type": "string", "maxLength": 50},
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Person ref"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "private": {"type": "boolean", "title": _("Private")},
+                    "citation_list": {
+                        "type": "array",
+                        "title": _("Citations"),
+                        "items": {"type": "string", "maxLength": 50},
+                    },
+                    "note_list": {
+                        "type": "array",
+                        "title": _("Notes"),
+                        "items": {"type": "string", "maxLength": 50},
+                    },
+                    "ref": {
+                        "type": "string",
+                        "title": _("Handle"),
+                        "maxLength": 50,
+                    },
+                    "rel": {"type": "string", "title": _("Association")},
                 },
-                "note_list": {
-                    "type": "array",
-                    "title": _("Notes"),
-                    "items": {"type": "string", "maxLength": 50},
-                },
-                "ref": {
-                    "type": "string",
-                    "title": _("Handle"),
-                    "maxLength": 50,
-                },
-                "rel": {"type": "string", "title": _("Association")},
-            },
-        }
+            }
+        )
 
     def get_text_data_list(self):
         """

--- a/gramps/gen/lib/place.py
+++ b/gramps/gen/lib/place.py
@@ -32,11 +32,14 @@ Place object for Gramps.
 # -------------------------------------------------------------------------
 from __future__ import annotations
 
+import functools
+
 # -------------------------------------------------------------------------
 #
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .citationbase import CitationBase
 from .location import Location
@@ -137,6 +140,7 @@ class Place(CitationBase, NoteBase, MediaBase, UrlBase, PrimaryObject):
         )
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -148,67 +152,69 @@ class Place(CitationBase, NoteBase, MediaBase, UrlBase, PrimaryObject):
         from .mediaref import MediaRef
         from .url import Url
 
-        return {
-            "type": "object",
-            "title": _("Place"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "handle": {
-                    "type": "string",
-                    "maxLength": 50,
-                    "title": _("Handle"),
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Place"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "handle": {
+                        "type": "string",
+                        "maxLength": 50,
+                        "title": _("Handle"),
+                    },
+                    "gramps_id": {"type": "string", "title": _("Gramps ID")},
+                    "title": {"type": "string", "title": _("Title")},
+                    "long": {"type": "string", "title": _("Longitude")},
+                    "lat": {"type": "string", "title": _("Latitude")},
+                    "placeref_list": {
+                        "type": "array",
+                        "items": PlaceRef.get_schema(),
+                        "title": _("Places"),
+                    },
+                    "name": PlaceName.get_schema(),
+                    "alt_names": {
+                        "type": "array",
+                        "items": PlaceName.get_schema(),
+                        "title": _("Alternate Names"),
+                    },
+                    "place_type": PlaceType.get_schema(),
+                    "code": {"type": "string", "title": _("Code")},
+                    "alt_loc": {
+                        "type": "array",
+                        "items": Location.get_schema(),
+                        "title": _("Alternate Locations"),
+                    },
+                    "urls": {
+                        "type": "array",
+                        "items": Url.get_schema(),
+                        "title": _("URLs"),
+                    },
+                    "media_list": {
+                        "type": "array",
+                        "items": MediaRef.get_schema(),
+                        "title": _("Media"),
+                    },
+                    "citation_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Citations"),
+                    },
+                    "note_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Notes"),
+                    },
+                    "change": {"type": "integer", "title": _("Last changed")},
+                    "tag_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Tags"),
+                    },
+                    "private": {"type": "boolean", "title": _("Private")},
                 },
-                "gramps_id": {"type": "string", "title": _("Gramps ID")},
-                "title": {"type": "string", "title": _("Title")},
-                "long": {"type": "string", "title": _("Longitude")},
-                "lat": {"type": "string", "title": _("Latitude")},
-                "placeref_list": {
-                    "type": "array",
-                    "items": PlaceRef.get_schema(),
-                    "title": _("Places"),
-                },
-                "name": PlaceName.get_schema(),
-                "alt_names": {
-                    "type": "array",
-                    "items": PlaceName.get_schema(),
-                    "title": _("Alternate Names"),
-                },
-                "place_type": PlaceType.get_schema(),
-                "code": {"type": "string", "title": _("Code")},
-                "alt_loc": {
-                    "type": "array",
-                    "items": Location.get_schema(),
-                    "title": _("Alternate Locations"),
-                },
-                "urls": {
-                    "type": "array",
-                    "items": Url.get_schema(),
-                    "title": _("URLs"),
-                },
-                "media_list": {
-                    "type": "array",
-                    "items": MediaRef.get_schema(),
-                    "title": _("Media"),
-                },
-                "citation_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Citations"),
-                },
-                "note_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Notes"),
-                },
-                "change": {"type": "integer", "title": _("Last changed")},
-                "tag_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Tags"),
-                },
-                "private": {"type": "boolean", "title": _("Private")},
-            },
-        }
+            }
+        )
 
     def unserialize(self, data):
         """

--- a/gramps/gen/lib/placename.py
+++ b/gramps/gen/lib/placename.py
@@ -24,9 +24,17 @@ Place name class for Gramps
 
 # -------------------------------------------------------------------------
 #
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import functools
+
+# -------------------------------------------------------------------------
+#
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .const import DIFFERENT, EQUAL, IDENTICAL
 from .datebase import DateBase
@@ -79,6 +87,7 @@ class PlaceName(SecondaryObject, DateBase):
         return self
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -89,16 +98,18 @@ class PlaceName(SecondaryObject, DateBase):
         # pylint: disable=import-outside-toplevel
         from .date import Date
 
-        return {
-            "type": "object",
-            "title": _("Place Name"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "value": {"type": "string", "title": _("Text")},
-                "date": Date.get_schema(),
-                "lang": {"type": "string", "title": _("Language")},
-            },
-        }
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Place Name"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "value": {"type": "string", "title": _("Text")},
+                    "date": Date.get_schema(),
+                    "lang": {"type": "string", "title": _("Language")},
+                },
+            }
+        )
 
     def get_text_data_list(self):
         """

--- a/gramps/gen/lib/placeref.py
+++ b/gramps/gen/lib/placeref.py
@@ -24,9 +24,17 @@ Place Reference class for Gramps
 
 # -------------------------------------------------------------------------
 #
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import functools
+
+# -------------------------------------------------------------------------
+#
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .const import DIFFERENT, EQUAL, IDENTICAL
 from .datebase import DateBase
@@ -72,6 +80,7 @@ class PlaceRef(RefBase, DateBase, SecondaryObject):
         return self
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -82,19 +91,21 @@ class PlaceRef(RefBase, DateBase, SecondaryObject):
         # pylint: disable=import-outside-toplevel
         from .date import Date
 
-        return {
-            "type": "object",
-            "title": _("Place ref"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "ref": {
-                    "type": "string",
-                    "title": _("Handle"),
-                    "maxLength": 50,
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Place ref"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "ref": {
+                        "type": "string",
+                        "title": _("Handle"),
+                        "maxLength": 50,
+                    },
+                    "date": Date.get_schema(),
                 },
-                "date": Date.get_schema(),
-            },
-        }
+            }
+        )
 
     def get_text_data_list(self):
         """

--- a/gramps/gen/lib/repo.py
+++ b/gramps/gen/lib/repo.py
@@ -26,9 +26,17 @@ Repository object for Gramps.
 
 # -------------------------------------------------------------------------
 #
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import functools
+
+# -------------------------------------------------------------------------
+#
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .addressbase import AddressBase
 from .citationbase import IndirectCitationBase
@@ -78,6 +86,7 @@ class Repository(NoteBase, AddressBase, UrlBase, IndirectCitationBase, PrimaryOb
         )
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -89,43 +98,45 @@ class Repository(NoteBase, AddressBase, UrlBase, IndirectCitationBase, PrimaryOb
         from .address import Address
         from .url import Url
 
-        return {
-            "type": "object",
-            "title": _("Repository"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "handle": {
-                    "type": "string",
-                    "maxLength": 50,
-                    "title": _("Handle"),
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Repository"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "handle": {
+                        "type": "string",
+                        "maxLength": 50,
+                        "title": _("Handle"),
+                    },
+                    "gramps_id": {"type": "string", "title": _("Gramps ID")},
+                    "type": RepositoryType.get_schema(),
+                    "name": {"type": "string", "title": _("Name")},
+                    "note_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Notes"),
+                    },
+                    "address_list": {
+                        "type": "array",
+                        "items": Address.get_schema(),
+                        "title": _("Addresses"),
+                    },
+                    "urls": {
+                        "type": "array",
+                        "items": Url.get_schema(),
+                        "title": _("URLs"),
+                    },
+                    "change": {"type": "integer", "title": _("Last changed")},
+                    "tag_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Tags"),
+                    },
+                    "private": {"type": "boolean", "title": _("Private")},
                 },
-                "gramps_id": {"type": "string", "title": _("Gramps ID")},
-                "type": RepositoryType.get_schema(),
-                "name": {"type": "string", "title": _("Name")},
-                "note_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Notes"),
-                },
-                "address_list": {
-                    "type": "array",
-                    "items": Address.get_schema(),
-                    "title": _("Addresses"),
-                },
-                "urls": {
-                    "type": "array",
-                    "items": Url.get_schema(),
-                    "title": _("URLs"),
-                },
-                "change": {"type": "integer", "title": _("Last changed")},
-                "tag_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Tags"),
-                },
-                "private": {"type": "boolean", "title": _("Private")},
-            },
-        }
+            }
+        )
 
     def unserialize(self, data):
         """

--- a/gramps/gen/lib/reporef.py
+++ b/gramps/gen/lib/reporef.py
@@ -26,9 +26,17 @@ Repository Reference class for Gramps
 
 # -------------------------------------------------------------------------
 #
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import functools
+
+# -------------------------------------------------------------------------
+#
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .const import DIFFERENT, EQUAL, IDENTICAL
 from .notebase import NoteBase
@@ -86,6 +94,7 @@ class RepoRef(SecondaryObject, PrivacyBase, NoteBase, RefBase):
         return self
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -93,26 +102,28 @@ class RepoRef(SecondaryObject, PrivacyBase, NoteBase, RefBase):
         :returns: Returns a dict containing the schema.
         :rtype: dict
         """
-        return {
-            "type": "object",
-            "title": _("Repository ref"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "note_list": {
-                    "type": "array",
-                    "title": _("Notes"),
-                    "items": {"type": "string", "maxLength": 50},
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Repository ref"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "note_list": {
+                        "type": "array",
+                        "title": _("Notes"),
+                        "items": {"type": "string", "maxLength": 50},
+                    },
+                    "ref": {
+                        "type": "string",
+                        "title": _("Handle"),
+                        "maxLength": 50,
+                    },
+                    "call_number": {"type": "string", "title": _("Call Number")},
+                    "media_type": SourceMediaType.get_schema(),
+                    "private": {"type": "boolean", "title": _("Private")},
                 },
-                "ref": {
-                    "type": "string",
-                    "title": _("Handle"),
-                    "maxLength": 50,
-                },
-                "call_number": {"type": "string", "title": _("Call Number")},
-                "media_type": SourceMediaType.get_schema(),
-                "private": {"type": "boolean", "title": _("Private")},
-            },
-        }
+            }
+        )
 
     def get_text_data_list(self):
         """

--- a/gramps/gen/lib/schemautils.py
+++ b/gramps/gen/lib/schemautils.py
@@ -1,0 +1,91 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Doug Blank <doug.blank@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Helper for freezing the JSON Schema dicts returned by ``get_schema()``.
+"""
+
+
+class FrozenDict(dict):
+    """
+    A ``dict`` that raises on any attempt to mutate it in place.
+
+    Subclassing ``dict`` (rather than using ``types.MappingProxyType``)
+    keeps ``isinstance(x, dict)`` true, which third-party consumers such as
+    the ``jsonschema`` library rely on to recognize a JSON Schema "object".
+    """
+
+    def _read_only(self, *args, **kwargs):
+        raise TypeError(f"{type(self).__name__} is read-only")
+
+    __setitem__ = _read_only
+    __delitem__ = _read_only
+    clear = _read_only
+    pop = _read_only
+    popitem = _read_only
+    setdefault = _read_only
+    update = _read_only
+
+
+class FrozenList(list):
+    """
+    A ``list`` that raises on any attempt to mutate it in place.
+
+    Subclassing ``list`` (rather than using ``tuple``) keeps
+    ``isinstance(x, list)`` true, for the same reason as :class:`FrozenDict`.
+    """
+
+    def _read_only(self, *args, **kwargs):
+        raise TypeError(f"{type(self).__name__} is read-only")
+
+    __setitem__ = _read_only
+    __delitem__ = _read_only
+    __iadd__ = _read_only
+    __imul__ = _read_only
+    append = _read_only
+    clear = _read_only
+    extend = _read_only
+    insert = _read_only
+    pop = _read_only
+    remove = _read_only
+    reverse = _read_only
+    sort = _read_only
+
+
+def freeze_schema(schema):
+    """
+    Recursively convert a JSON-schema-shaped value into a read-only
+    structure: dicts become :class:`FrozenDict` and lists become
+    :class:`FrozenList`.
+
+    ``get_schema()`` classmethods are cached (``functools.cache``) and
+    their return value is shared by every caller and by every composing
+    parent schema. Freezing it turns any accidental in-place mutation by
+    a caller into an immediate ``TypeError`` instead of silently
+    corrupting the cached schema for every other caller.
+
+    :param schema: A dict/list/scalar value, as returned by a
+                   ``get_schema()`` classmethod.
+    :returns: The same structure with all dicts and lists made read-only.
+    """
+    if isinstance(schema, dict):
+        return FrozenDict((key, freeze_schema(value)) for key, value in schema.items())
+    if isinstance(schema, list):
+        return FrozenList(freeze_schema(item) for item in schema)
+    return schema

--- a/gramps/gen/lib/src.py
+++ b/gramps/gen/lib/src.py
@@ -27,9 +27,17 @@ Source object for Gramps.
 
 # -------------------------------------------------------------------------
 #
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import functools
+
+# -------------------------------------------------------------------------
+#
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .attrbase import SrcAttributeBase
 from .citationbase import IndirectCitationBase
@@ -88,6 +96,7 @@ class Source(
         )  # 12
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -99,50 +108,52 @@ class Source(
         from .mediaref import MediaRef
         from .srcattribute import SrcAttribute
 
-        return {
-            "type": "object",
-            "title": _("Source"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "handle": {
-                    "type": "string",
-                    "maxLength": 50,
-                    "title": _("Handle"),
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Source"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "handle": {
+                        "type": "string",
+                        "maxLength": 50,
+                        "title": _("Handle"),
+                    },
+                    "gramps_id": {"type": "string", "title": _("Gramps ID")},
+                    "title": {"type": "string", "title": _("Title")},
+                    "author": {"type": "string", "title": _("Author")},
+                    "pubinfo": {"type": "string", "title": _("Publication info")},
+                    "note_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Notes"),
+                    },
+                    "media_list": {
+                        "type": "array",
+                        "items": MediaRef.get_schema(),
+                        "title": _("Media"),
+                    },
+                    "abbrev": {"type": "string", "title": _("Abbreviation")},
+                    "change": {"type": "integer", "title": _("Last changed")},
+                    "attribute_list": {
+                        "type": "array",
+                        "items": SrcAttribute.get_schema(),
+                        "title": _("Source Attributes"),
+                    },
+                    "reporef_list": {
+                        "type": "array",
+                        "items": RepoRef.get_schema(),
+                        "title": _("Repositories"),
+                    },
+                    "tag_list": {
+                        "type": "array",
+                        "items": {"type": "string", "maxLength": 50},
+                        "title": _("Tags"),
+                    },
+                    "private": {"type": "boolean", "title": _("Private")},
                 },
-                "gramps_id": {"type": "string", "title": _("Gramps ID")},
-                "title": {"type": "string", "title": _("Title")},
-                "author": {"type": "string", "title": _("Author")},
-                "pubinfo": {"type": "string", "title": _("Publication info")},
-                "note_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Notes"),
-                },
-                "media_list": {
-                    "type": "array",
-                    "items": MediaRef.get_schema(),
-                    "title": _("Media"),
-                },
-                "abbrev": {"type": "string", "title": _("Abbreviation")},
-                "change": {"type": "integer", "title": _("Last changed")},
-                "attribute_list": {
-                    "type": "array",
-                    "items": SrcAttribute.get_schema(),
-                    "title": _("Source Attributes"),
-                },
-                "reporef_list": {
-                    "type": "array",
-                    "items": RepoRef.get_schema(),
-                    "title": _("Repositories"),
-                },
-                "tag_list": {
-                    "type": "array",
-                    "items": {"type": "string", "maxLength": 50},
-                    "title": _("Tags"),
-                },
-                "private": {"type": "boolean", "title": _("Private")},
-            },
-        }
+            }
+        )
 
     def unserialize(self, data):
         """

--- a/gramps/gen/lib/srcattribute.py
+++ b/gramps/gen/lib/srcattribute.py
@@ -24,9 +24,17 @@ Source Attribute class for Gramps.
 
 # -------------------------------------------------------------------------
 #
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import functools
+
+# -------------------------------------------------------------------------
+#
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .attribute import AttributeRoot
 from .srcattrtype import SrcAttributeType
@@ -59,6 +67,7 @@ class SrcAttribute(AttributeRoot):
             self.value = ""
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -66,13 +75,15 @@ class SrcAttribute(AttributeRoot):
         :returns: Returns a dict containing the schema.
         :rtype: dict
         """
-        return {
-            "type": "object",
-            "title": _("Attribute"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "private": {"type": "boolean", "title": _("Private")},
-                "type": SrcAttributeType.get_schema(),
-                "value": {"type": "string", "title": _("Value")},
-            },
-        }
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Attribute"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "private": {"type": "boolean", "title": _("Private")},
+                    "type": SrcAttributeType.get_schema(),
+                    "value": {"type": "string", "title": _("Value")},
+                },
+            }
+        )

--- a/gramps/gen/lib/styledtext.py
+++ b/gramps/gen/lib/styledtext.py
@@ -27,12 +27,14 @@
 #
 # -------------------------------------------------------------------------
 from copy import copy
+import functools
 
 # -------------------------------------------------------------------------
 #
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .baseobj import BaseObject
 from .styledtexttag import StyledTextTag
@@ -327,6 +329,7 @@ class StyledText(BaseObject):
         return (self._string, the_tags)
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -334,19 +337,21 @@ class StyledText(BaseObject):
         :returns: Returns a dict containing the schema.
         :rtype: dict
         """
-        return {
-            "type": "object",
-            "title": _("Styled Text"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "string": {"type": "string", "title": _("Text")},
-                "tags": {
-                    "type": "array",
-                    "items": StyledTextTag.get_schema(),
-                    "title": _("Styled Text Tags"),
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Styled Text"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "string": {"type": "string", "title": _("Text")},
+                    "tags": {
+                        "type": "array",
+                        "items": StyledTextTag.get_schema(),
+                        "title": _("Styled Text Tags"),
+                    },
                 },
-            },
-        }
+            }
+        )
 
     def unserialize(self, data):
         """

--- a/gramps/gen/lib/styledtexttag.py
+++ b/gramps/gen/lib/styledtexttag.py
@@ -23,9 +23,17 @@
 
 # -------------------------------------------------------------------------
 #
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import functools
+
+# -------------------------------------------------------------------------
+#
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .baseobj import BaseObject
 from .styledtexttagtype import StyledTextTagType
@@ -102,6 +110,7 @@ class StyledTextTag(BaseObject):
         return self
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -109,25 +118,27 @@ class StyledTextTag(BaseObject):
         :returns: Returns a dict containing the schema.
         :rtype: dict
         """
-        return {
-            "type": "object",
-            "title": _("Tag"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "name": StyledTextTagType.get_schema(),
-                "value": {
-                    "type": ["null", "string", "integer"],
-                    "title": _("Value"),
-                },
-                "ranges": {
-                    "type": "array",
-                    "items": {
-                        "type": "array",
-                        "items": {"type": "integer"},
-                        "minItems": 2,
-                        "maxItems": 2,
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Tag"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "name": StyledTextTagType.get_schema(),
+                    "value": {
+                        "type": ["null", "string", "integer"],
+                        "title": _("Value"),
                     },
-                    "title": _("Ranges"),
+                    "ranges": {
+                        "type": "array",
+                        "items": {
+                            "type": "array",
+                            "items": {"type": "integer"},
+                            "minItems": 2,
+                            "maxItems": 2,
+                        },
+                        "title": _("Ranges"),
+                    },
                 },
-            },
-        }
+            }
+        )

--- a/gramps/gen/lib/surname.py
+++ b/gramps/gen/lib/surname.py
@@ -25,9 +25,17 @@ Surname class for Gramps.
 
 # -------------------------------------------------------------------------
 #
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import functools
+
+# -------------------------------------------------------------------------
+#
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .const import DIFFERENT, EQUAL, IDENTICAL
 from .nameorigintype import NameOriginType
@@ -100,6 +108,7 @@ class Surname(SecondaryObject):
         )
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -107,18 +116,20 @@ class Surname(SecondaryObject):
         :returns: Returns a dict containing the schema.
         :rtype: dict
         """
-        return {
-            "type": "object",
-            "title": _("Surname"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "surname": {"type": "string", "title": _("Surname")},
-                "prefix": {"type": "string", "title": _("Prefix")},
-                "primary": {"type": "boolean", "title": _("Primary")},
-                "origintype": NameOriginType.get_schema(),
-                "connector": {"type": "string", "title": _("Connector")},
-            },
-        }
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Surname"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "surname": {"type": "string", "title": _("Surname")},
+                    "prefix": {"type": "string", "title": _("Prefix")},
+                    "primary": {"type": "boolean", "title": _("Primary")},
+                    "origintype": NameOriginType.get_schema(),
+                    "connector": {"type": "string", "title": _("Connector")},
+                },
+            }
+        )
 
     def is_empty(self):
         """

--- a/gramps/gen/lib/tableobj.py
+++ b/gramps/gen/lib/tableobj.py
@@ -27,14 +27,16 @@ Table Object class for Gramps.
 # Python modules
 #
 # -------------------------------------------------------------------------
-import time
 from abc import abstractmethod
+import functools
+import time
 
 # -------------------------------------------------------------------------
 #
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .baseobj import BaseObject
 
@@ -142,13 +144,15 @@ class TableObject(BaseObject):
         return self.handle
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Return schema.
         """
-        return {}
+        return freeze_schema({})
 
     @classmethod
+    @functools.cache
     def get_secondary_fields(cls):
         """
         Return all secondary fields and their types
@@ -157,8 +161,9 @@ class TableObject(BaseObject):
         for key, value in cls.get_schema()["properties"].items():
             schema_type = value.get("type")
             if isinstance(schema_type, list):
-                schema_type.remove("null")
-                schema_type = schema_type[0]
+                # schema_type is part of the frozen, shared schema: build a
+                # new value instead of mutating it in place.
+                schema_type = [item for item in schema_type if item != "null"][0]
             elif isinstance(schema_type, dict):
                 schema_type = None
             if schema_type in ("string", "integer", "number", "boolean"):

--- a/gramps/gen/lib/tag.py
+++ b/gramps/gen/lib/tag.py
@@ -24,9 +24,17 @@ Tag object for Gramps.
 
 # -------------------------------------------------------------------------
 #
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import functools
+
+# -------------------------------------------------------------------------
+#
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .tableobj import TableObject
 
@@ -134,6 +142,7 @@ class Tag(TableObject):
         super().set_object_state(attr_dict)
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -141,30 +150,32 @@ class Tag(TableObject):
         :returns: Returns a dict containing the schema.
         :rtype: dict
         """
-        return {
-            "type": "object",
-            "title": _("Tag"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "handle": {
-                    "type": "string",
-                    "maxLength": 50,
-                    "title": _("Handle"),
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Tag"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "handle": {
+                        "type": "string",
+                        "maxLength": 50,
+                        "title": _("Handle"),
+                    },
+                    "name": {"type": "string", "title": _("Name")},
+                    "color": {
+                        "type": "string",
+                        "maxLength": 13,
+                        "title": _("Color"),
+                    },
+                    "priority": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "title": _("Priority"),
+                    },
+                    "change": {"type": "integer", "title": _("Last changed")},
                 },
-                "name": {"type": "string", "title": _("Name")},
-                "color": {
-                    "type": "string",
-                    "maxLength": 13,
-                    "title": _("Color"),
-                },
-                "priority": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "title": _("Priority"),
-                },
-                "change": {"type": "integer", "title": _("Last changed")},
-            },
-        }
+            }
+        )
 
     def get_text_data_list(self):
         """

--- a/gramps/gen/lib/url.py
+++ b/gramps/gen/lib/url.py
@@ -28,6 +28,7 @@ Url class for Gramps.
 # Python modules
 #
 # -------------------------------------------------------------------------
+import functools
 from urllib.parse import urlparse
 from warnings import warn
 
@@ -36,6 +37,7 @@ from warnings import warn
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from .schemautils import freeze_schema
 from ..const import GRAMPS_LOCALE as glocale
 from .const import DIFFERENT, EQUAL, IDENTICAL
 from .privacybase import PrivacyBase
@@ -77,6 +79,7 @@ class Url(SecondaryObject, PrivacyBase):
         return self
 
     @classmethod
+    @functools.cache
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -84,17 +87,19 @@ class Url(SecondaryObject, PrivacyBase):
         :returns: Returns a dict containing the schema.
         :rtype: dict
         """
-        return {
-            "type": "object",
-            "title": _("Url"),
-            "properties": {
-                "_class": {"enum": [cls.__name__]},
-                "private": {"type": "boolean", "title": _("Private")},
-                "path": {"type": "string", "title": _("Path")},
-                "desc": {"type": "string", "title": _("Description")},
-                "type": UrlType.get_schema(),
-            },
-        }
+        return freeze_schema(
+            {
+                "type": "object",
+                "title": _("Url"),
+                "properties": {
+                    "_class": {"enum": [cls.__name__]},
+                    "private": {"type": "boolean", "title": _("Private")},
+                    "path": {"type": "string", "title": _("Path")},
+                    "desc": {"type": "string", "title": _("Description")},
+                    "type": UrlType.get_schema(),
+                },
+            }
+        )
 
     def get_text_data_list(self):
         """


### PR DESCRIPTION
## Summary
- `get_schema()` rebuilt its JSON Schema dict from scratch on every call, recursing into every composed class's own `get_schema()` and doing a `gettext` lookup per field title. Profiling a large XML import (16k people) showed this at ~34% of total import time (7M `gettext` calls, `commit_person`/`get_secondary_fields` dominating the profile).
- `get_schema()` is a pure function of the class (verified: no config/env/random reads in any of the 30 definitions, only static literals + gettext + recursive `get_schema()` calls), so it's now cached with `functools.cache`.
- Since the cached object is shared across every caller and every composing parent schema, it's also made read-only via `FrozenDict`/`FrozenList` (`gramps/gen/lib/schemautils.py`) — `dict`/`list` subclasses that raise `TypeError` on mutation but stay `isinstance(x, dict)`/`isinstance(x, list)`, since libraries like `jsonschema` rely on that for type-checking (a `MappingProxyType`/`tuple`-based freeze was tried first and broke `jsonschema.validate()` outright — confirmed against `schema_test.py`).
- This also fixes a latent mutation bug in `get_secondary_fields()` (`gramps/gen/lib/tableobj.py`), which called `.remove("null")` on the list returned by `get_schema()` in place — harmless before caching (fresh dict every call), a real corruption risk once shared.
- Import benchmark (synthetic XML, fresh SQLite DB, family-chain structure): **~41–44% faster** at 8k–16k people; `get_schema`/`get_secondary_fields` drop out of the profiler's top 30 entirely.
- Checked both known non-desktop consumers for anything that mutates the returned schema: `addons-source` (`ImportMerge`, `PostgreSQL`, `SharedPostgreSQL`) only read it; `gramps-web-api` had one mutation site, now fixed there (gramps-project/gramps-web-api#926) to copy before patching.

## Test plan
- [x] `gramps.gen.lib.test.schema_test` (real `jsonschema.validate()` against ~10,500 instances loaded from `example.gramps`) — 10,493 passed.
- [x] `gramps.gen.lib.test.{serialize,datadict,grampstype,styledtext,date,merge}_test` — 21,261 passed.
- [x] `black --check` and `mypy` clean on all 32 changed files.
- [x] Manual checks: per-class cache isolation (e.g. `EventType`/`NameType`/`Person`/`Family` don't collide), mutation attempts raise `TypeError` immediately instead of silently corrupting the cache, `get_secondary_fields()` stable across repeated calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
