### PR TITLE
Avoid redundant DB write per object during Gramps XML import

### DIFF
--- a/gramps/plugins/importer/importxml.py
+++ b/gramps/plugins/importer/importxml.py
@@ -874,27 +874,34 @@ class GrampsParser(UpdateCallback):
                 while has_handle_func(handle):
                     handle = create_id()
             self.import_handles[orig_handle] = {target: [handle, False]}
-        # method is called by a reference
-        if isinstance(prim_obj, abc.Callable):
+        # method is called by a reference: a placeholder must be committed
+        # now so a later forward reference can fetch its raw (empty) data.
+        # When called for the object's own definition, the corresponding
+        # stop_<target> handler commits the fully populated object once
+        # parsing of it completes, so committing an empty shell here would
+        # only be overwritten immediately and is skipped.
+        is_reference = isinstance(prim_obj, abc.Callable)
+        if is_reference:
             prim_obj = prim_obj()
         else:
             self.import_handles[orig_handle][target][INSTANTIATED] = True
         prim_obj.set_handle(handle)
-        if target == "tag":
-            self.db.add_tag(prim_obj, self.trans)
-        else:
-            add_func = {
-                "person": self.db.add_person,
-                "family": self.db.add_family,
-                "event": self.db.add_event,
-                "place": self.db.add_place,
-                "source": self.db.add_source,
-                "citation": self.db.add_citation,
-                "repository": self.db.add_repository,
-                "media": self.db.add_media,
-                "note": self.db.add_note,
-            }[target]
-            add_func(prim_obj, self.trans, set_gid=False)
+        if is_reference:
+            if target == "tag":
+                self.db.add_tag(prim_obj, self.trans)
+            else:
+                add_func = {
+                    "person": self.db.add_person,
+                    "family": self.db.add_family,
+                    "event": self.db.add_event,
+                    "place": self.db.add_place,
+                    "source": self.db.add_source,
+                    "citation": self.db.add_citation,
+                    "repository": self.db.add_repository,
+                    "media": self.db.add_media,
+                    "note": self.db.add_note,
+                }[target]
+                add_func(prim_obj, self.trans, set_gid=False)
         return handle
 
     def inaugurate_id(self, id_, key, prim_obj):


### PR DESCRIPTION
## Summary

`GrampsParser.inaugurate()` in `gramps/plugins/importer/importxml.py` was
writing every primary object to the database **twice** while importing a
Gramps XML file:

1. A near-empty placeholder commit when the object's `start_<tag>` handler
   first assigned it a handle.
2. A second, full commit when `stop_<tag>` finished parsing the object and
   called `db.commit_<object>()`.

The first write only matters when a handle is genuinely forward-referenced
elsewhere in the file (e.g. `hlink`/`parentin` pointing at an object not yet
parsed) — the eventual `get_raw_<object>_data()` lookup used to backfill state
needs a row to exist. For the common case of an object first encountered via
its own tag, that placeholder write is discarded moments later by the real
commit.

This change skips the placeholder commit unless `inaugurate()` is invoked
from a reference site (i.e. `prim_obj` is a class, not an instance), deferring
the single actual database write to the object's own `stop_<tag>` commit.

## Testing

- Imported `example/gramps/example.gramps` (2157 people / 762 families / 3432
  events / ...) and a synthetic 32,001-person / 16,000-family file (with
  `parentin hlink` forward references to families) before and after the
  change; dumped every object's serialized state and diffed — **byte-for-byte
  identical** in both cases.
- Benchmarked import of the 32k/16k file, median of 3 runs:
  - before: 11.61s
  - after: 8.25s (~29% faster)
- Benchmarked the smaller example file, median of 9 runs:
  - before: 1.83s
  - after: 1.41s (~23% faster)
- `black --check` and `mypy` pass on the changed file.

## Test plan

- [x] Verified import produces identical database contents before/after
- [x] Benchmarked import time improvement on two dataset sizes
- [x] `black --check gramps/plugins/importer/importxml.py`
- [x] `mypy gramps/plugins/importer/importxml.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
