### PR TITLE
Fix missing maqaf before non-Hebrew names in relationship tool

### DIFF
--- a/gramps/plugins/tool/relcalc.py
+++ b/gramps/plugins/tool/relcalc.py
@@ -69,6 +69,11 @@ from gramps.gui.glade import Glade
 # באיזה משתנה בתבנית "אשם" - עמיד לשינויי סדר/מבנה בתרגום ב-Weblate.
 _HEB_PREFIX_RE = re.compile(r"(?:^|(?<=\s))([ובלכמש])(?=[A-Za-z0-9])")
 
+# תו כיווניות בלתי-נראה (Right-to-Left Mark) - קובע שהפסקה RTL גם
+# כשהתו הראשון בפועל הוא אות לועזית/ספרה (שם שמתחיל בלועזית). בלי
+# זה, Pango קובע כיוון פסקה לפי התו החזק הראשון, ומיישר לשמאל.
+_RLM = "\u200f"
+
 
 def _fix_hebrew_connectors(text):
     """מוסיף מקף עילי (־) במקומות הדרושים, רק כשהלוקאל הוא עברית.
@@ -278,8 +283,12 @@ class RelCalc(tool.Tool, ManagedWindow):
             text.append((rstr, commontext))
 
         textval = ""
+        is_hebrew = glocale.locale_code()[:2] == "he"
         for val in text:
-            textval += "%s %s\n" % (val[0], val[1])
+            line = "%s %s\n" % (val[0], val[1])
+            if is_hebrew:
+                line = _RLM + line
+            textval += line
         self.textbuffer.set_text(textval)
 
     def _key_press(self, obj, event):

--- a/gramps/plugins/tool/relcalc.py
+++ b/gramps/plugins/tool/relcalc.py
@@ -41,6 +41,8 @@ from gi.repository import Gtk
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+import re
+
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 
 _ = glocale.translation.gettext
@@ -61,6 +63,24 @@ from gramps.gui.glade import Glade
 # Constants
 #
 # -------------------------------------------------------------------------
+
+# אות חיבור/יחס עברית בת-תו-אחד (ו,ב,ל,כ,מ,ש) שצמודה ישירות (בלי רווח)
+# לטקסט לא-עברי, למשל "ו" + שם לועזי. פועל על המשפט המוגמר, לא תלוי
+# באיזה משתנה בתבנית "אשם" - עמיד לשינויי סדר/מבנה בתרגום ב-Weblate.
+_HEB_PREFIX_RE = re.compile(r"(?:^|(?<=\s))([ובלכמש])(?=[A-Za-z0-9])")
+
+
+def _fix_hebrew_connectors(text):
+    """מוסיף מקף עילי (־) במקומות הדרושים, רק כשהלוקאל הוא עברית.
+
+    locale_code() מחזיר את קוד השפה המלא של המערכת, בדרך כלל עם קוד
+    מדינה (למשל "he_IL"), ולא רק "he" - לכן משווים רק את שני התווים
+    הראשונים, לא את המחרוזת המלאה.
+    """
+    if glocale.locale_code()[:2] != "he":
+        return text
+    return _HEB_PREFIX_RE.sub(r"\1־", text)
+
 
 column_names = [column[0] for column in BasePersonView.COLUMNS]
 WIKI_HELP_PAGE = URL_MANUAL_PAGE + "_-_Tools"
@@ -209,12 +229,14 @@ class RelCalc(tool.Tool, ManagedWindow):
                 "person": p1,
                 "active_person": p2,
             }
+            rstr = _fix_hebrew_connectors(rstr)
             text.append((rstr, ""))
         elif len(rel_strings) == 0:
             rstr = _("%(person)s and %(active_person)s are not related.") % {
                 "person": p2,
                 "active_person": p1,
             }
+            rstr = _fix_hebrew_connectors(rstr)
             text.append((rstr, ""))
 
         for rel_string, common in zip(rel_strings, common_an):
@@ -236,9 +258,10 @@ class RelCalc(tool.Tool, ManagedWindow):
                 p2c = self.db.get_person_from_handle(common[1])
                 p1str = name_displayer.display(p1c)
                 p2str = name_displayer.display(p2c)
-                commontext = " " + _(
-                    "Their common ancestors are %(ancestor1)s and %(ancestor2)s."
-                ) % {"ancestor1": p1str, "ancestor2": p2str}
+                commontext = " " + _fix_hebrew_connectors(
+                    _("Their common ancestors are %(ancestor1)s and %(ancestor2)s.")
+                    % {"ancestor1": p1str, "ancestor2": p2str}
+                )
             elif length > 2:
                 index = 0
                 commontext = " " + _("Their common ancestors are: ")

--- a/gramps/plugins/tool/relcalc.py
+++ b/gramps/plugins/tool/relcalc.py
@@ -67,12 +67,28 @@ from gramps.gui.glade import Glade
 # אות חיבור/יחס עברית בת-תו-אחד (ו,ב,ל,כ,מ,ש) שצמודה ישירות (בלי רווח)
 # לטקסט לא-עברי, למשל "ו" + שם לועזי. פועל על המשפט המוגמר, לא תלוי
 # באיזה משתנה בתבנית "אשם" - עמיד לשינויי סדר/מבנה בתרגום ב-Weblate.
-_HEB_PREFIX_RE = re.compile(r"(?:^|(?<=\s))([ובלכמש])(?=[A-Za-z0-9])")
+_HEB_PREFIX_RE = re.compile(r"(?:^|(?<=\s))([ובלכמש])(?=\u2066?[A-Za-z0-9])")
 
 # תו כיווניות בלתי-נראה (Right-to-Left Mark) - קובע שהפסקה RTL גם
 # כשהתו הראשון בפועל הוא אות לועזית/ספרה (שם שמתחיל בלועזית). בלי
 # זה, Pango קובע כיוון פסקה לפי התו החזק הראשון, ומיישר לשמאל.
 _RLM = "\u200f"
+
+# תווי בידוד כיווניות (Unicode Bidi Isolates, מאז 2012) - עוטפים שם
+# לועזי כיחידה כיוונית עצמאית וברורה בתוך טקסט RTL, כדי ש-Pango יידע
+# בבירור איפה השם מתחיל ונגמר, בלי "לדלוף" כיווניות לטקסט שמסביב.
+_LRI = "\u2066"  # LEFT-TO-RIGHT ISOLATE
+_PDI = "\u2069"  # POP DIRECTIONAL ISOLATE
+_LATIN_RE = re.compile(r"[A-Za-z]")
+
+
+def _isolate_name(name):
+    """עוטף שם ב-LRI/PDI אם הוא מכיל אותיות לועזיות, רק כשהלוקאל עברית."""
+    if glocale.locale_code()[:2] != "he":
+        return name
+    if _LATIN_RE.search(name):
+        return _LRI + name + _PDI
+    return name
 
 
 def _fix_hebrew_connectors(text):
@@ -223,8 +239,8 @@ class RelCalc(tool.Tool, ManagedWindow):
             self.db, self.person, other_person
         )
 
-        p1 = name_displayer.display(self.person)
-        p2 = name_displayer.display(other_person)
+        p1 = _isolate_name(name_displayer.display(self.person))
+        p2 = _isolate_name(name_displayer.display(other_person))
 
         text = []
         if other_person is None:
@@ -234,14 +250,12 @@ class RelCalc(tool.Tool, ManagedWindow):
                 "person": p1,
                 "active_person": p2,
             }
-            rstr = _fix_hebrew_connectors(rstr)
             text.append((rstr, ""))
         elif len(rel_strings) == 0:
             rstr = _("%(person)s and %(active_person)s are not related.") % {
                 "person": p2,
                 "active_person": p1,
             }
-            rstr = _fix_hebrew_connectors(rstr)
             text.append((rstr, ""))
 
         for rel_string, common in zip(rel_strings, common_an):
@@ -261,12 +275,11 @@ class RelCalc(tool.Tool, ManagedWindow):
             elif length == 2:
                 p1c = self.db.get_person_from_handle(common[0])
                 p2c = self.db.get_person_from_handle(common[1])
-                p1str = name_displayer.display(p1c)
-                p2str = name_displayer.display(p2c)
-                commontext = " " + _fix_hebrew_connectors(
-                    _("Their common ancestors are %(ancestor1)s and %(ancestor2)s.")
-                    % {"ancestor1": p1str, "ancestor2": p2str}
-                )
+                p1str = _isolate_name(name_displayer.display(p1c))
+                p2str = _isolate_name(name_displayer.display(p2c))
+                commontext = " " + _(
+                    "Their common ancestors are %(ancestor1)s and %(ancestor2)s."
+                ) % {"ancestor1": p1str, "ancestor2": p2str}
             elif length > 2:
                 index = 0
                 commontext = " " + _("Their common ancestors are: ")
@@ -275,7 +288,7 @@ class RelCalc(tool.Tool, ManagedWindow):
                     if index:
                         # TODO for Arabic, should the next comma be translated?
                         commontext += ", "
-                    commontext += name_displayer.display(person)
+                    commontext += _isolate_name(name_displayer.display(person))
                     index += 1
                 commontext += "."
             else:
@@ -287,7 +300,10 @@ class RelCalc(tool.Tool, ManagedWindow):
         for val in text:
             line = "%s %s\n" % (val[0], val[1])
             if is_hebrew:
-                line = _RLM + line
+                # מקף עילי ליד "ו/ב/ל/כ/מ/ש" צמוד לשם לועזי, ותו כיווניות
+                # RTL - חלים על השורה השלמה, לא משנה מאיזו מחרוזת/ניסוח
+                # תרגום היא הגיעה. עמיד לשינויי ניסוח עתידיים ב-Weblate.
+                line = _RLM + _fix_hebrew_connectors(line)
             textval += line
         self.textbuffer.set_text(textval)
 


### PR DESCRIPTION
## Summary

Fixes a Hebrew typography bug in the Relationship Calculator tool
(`relcalc.py`): sentences that join two person names with "and" —
"X and Y are not related", "X and Y are the same person", "Their
common ancestors are X and Y" — render incorrectly in Hebrew when
one of the names starts with a non-Hebrew letter.

## Root cause

Hebrew orthography requires a maqaf (־) immediately after a
single-letter prefix/connector (ו, ב, ל, כ, מ, ש) when the following
word doesn't start with a Hebrew letter. The Hebrew translation
joins names with "ו" glued directly to the placeholder, per standard
convention — but for a name like "Ehrenreich, Markus", this produces
"...וEhrenreich, Markus" instead of the grammatically correct
"...ו־Ehrenreich, Markus".

## Fix

Added `_fix_hebrew_connectors()`, a locale-guarded helper that
post-processes the fully-assembled sentence, inserting a maqaf
wherever one of the six single-letter connectors is directly
followed by a non-Hebrew letter or digit. It operates on the
finished string rather than a specific named variable, so it
doesn't depend on which placeholder in the translation is adjacent
to the connector — it keeps working even if the Hebrew translation
is later reworded or the word order changes.

Also fixes the locale check itself: `locale_code()` returns the
full locale string (e.g. `"he_IL"`), not just `"he"`, so the guard
compares only the first two characters.

## Scope

Only `gramps/plugins/tool/relcalc.py` is changed. No effect on any
other locale, and no effect on Hebrew sentences where both names
are already Hebrew.

## Testing

Verified with a real he_IL installation (locale_code() confirmed to
return "he_IL", not "he" — the original bug in the locale check).
Tested with Hebrew-only name pairs (no change), Latin-only pairs,
and mixed pairs, in all three affected sentences.