### PR TITLE
Fix left-aligned links in WelcomeGramplet for RTL locales

### DIFF
--- a/gramps/plugins/gramplet/welcomegramplet.py
+++ b/gramps/plugins/gramplet/welcomegramplet.py
@@ -57,8 +57,18 @@ def boldst(text):
 
 def linkst(text, url):
     """Return text as link styled text"""
+    # The "  • " bullet prefix is entirely bidi-neutral (spaces + bullet
+    # character), so per-paragraph direction auto-detection (which looks
+    # for the first "strong" - i.e. directional - character) fails to
+    # find one at the very start of the paragraph and defaults to LTR,
+    # even though the actual link text that follows is Hebrew. An RLM
+    # (Right-to-Left Mark, U+200F) right before the link text supplies
+    # that missing strong-RTL signal without being visible itself.
+    prefix = "  • "
+    if glocale.locale_code()[:2] == "he":
+        prefix += "‏"
     tags = [StyledTextTag(StyledTextTagType.LINK, url, [(0, len(text))])]
-    return StyledText("  • ") + StyledText(text, tags)
+    return StyledText(prefix) + StyledText(text, tags)
 
 
 def wiki(page, manual=False):


### PR DESCRIPTION
Summary
Hyperlinks in the Welcome gramplet's bulleted list items render flush-left even in Hebrew, while every other paragraph (including bold section headings) correctly renders right-aligned.

Root cause
linkst() hardcodes a "  • " bullet prefix (two spaces, a bullet character, one space) before the link text. Every character in that prefix is bidi-neutral (spaces and a bullet symbol carry no inherent direction). Per-paragraph direction auto-detection, which looks for the first "strong" (i.e. directional) character to decide a paragraph's base direction, finds nothing directional in the prefix and falls back to left-to-right - even though the Hebrew link text that immediately follows is unambiguously right-to-left. Bold headings elsewhere in the same gramplet start directly with translated Hebrew text (no neutral prefix), so they are detected correctly, which is why the bug is isolated to exactly these bulleted link paragraphs and nowhere else in the same widget.

Fix
Insert an RLM (Right-to-Left Mark, U+200F) immediately after the bullet prefix and before the link text, guarded to Hebrew locale only. RLM is invisible and carries no width of its own, but is a strong-RTL character, so it supplies the missing directional signal right where auto-detection needs it. StyledText.__add__ computes tag offsets from the actual prefix length rather than a hardcoded value, so the LINK tag's range shifts automatically and continues to cover exactly the link text with no manual offset math needed.

Scope
gramps/plugins/gramplet/welcomegramplet.py only, in the shared linkst() helper. No other locale is affected.

Testing
Verified against a real he_IL Gramps installation: both bulleted links in the Welcome gramplet ("Start with Genealogy and Gramps" and "Example.gramps") rendered flush-left before the fix and correctly right-aligned after, with click targets unchanged.