### PR TITLE
   Fix Hebrew/RTL webreport bugs: translation lookup order and footer layout

### DIFF
--- a/data/css/Web_Basic-Ash.css
+++ b/data/css/Web_Basic-Ash.css
@@ -977,6 +977,18 @@ a.family_map {
     text-align: right;
     padding-right: 15px;
 }
+#footer p#createdate.rtl {
+    float: right;
+    text-align: right;
+    padding-left: 0;
+    padding-right: 15px;
+}
+#footer p#copyright.rtl {
+    float: left;
+    text-align: left;
+    padding-right: 0;
+    padding-left: 15px;
+}
 
 /* Updates
 ----------------------------------------------------- */

--- a/data/css/Web_Basic-Blue.css
+++ b/data/css/Web_Basic-Blue.css
@@ -372,6 +372,23 @@ div#footer p#copyright img {
     margin-right: 10px;
     margin-bottom: 10px;
 }
+div#footer p#createdate.rtl {
+    float: right;
+    text-align: right;
+    margin-left: 0;
+    margin-right: 10px;
+}
+div#footer p#copyright.rtl {
+    float: left;
+    text-align: left;
+    margin: 10px 0px 0px 10px;
+}
+div#footer p#copyright.rtl img {
+    float: left;
+    margin-right: 0;
+    margin-left: 10px;
+    margin-bottom: 10px;
+}
 #user_footer {
     width: 70%;
     float: left;

--- a/data/css/Web_Basic-Cypress.css
+++ b/data/css/Web_Basic-Cypress.css
@@ -1044,6 +1044,18 @@ a.family_map {
     text-align: right;
     padding-right: 15px;
 }
+#footer p#createdate.rtl {
+    float: right;
+    text-align: right;
+    padding-left: 0;
+    padding-right: 15px;
+}
+#footer p#copyright.rtl {
+    float: left;
+    text-align: left;
+    padding-right: 0;
+    padding-left: 15px;
+}
 
 /* Updates
 ----------------------------------------------------- */

--- a/data/css/Web_Basic-Lilac.css
+++ b/data/css/Web_Basic-Lilac.css
@@ -1048,6 +1048,18 @@ a.family_map {
     text-align: right;
     padding-right: 15px;
 }
+#footer p#createdate.rtl {
+    float: right;
+    text-align: right;
+    padding-left: 0;
+    padding-right: 15px;
+}
+#footer p#copyright.rtl {
+    float: left;
+    text-align: left;
+    padding-right: 0;
+    padding-left: 15px;
+}
 #footer a[href]:hover {
     background-color: #B4B4CB;
 }

--- a/data/css/Web_Basic-Peach.css
+++ b/data/css/Web_Basic-Peach.css
@@ -1047,6 +1047,18 @@ a.family_map {
     text-align: right;
     padding-right: 15px;
 }
+#footer p#createdate.rtl {
+    float: right;
+    text-align: right;
+    padding-left: 0;
+    padding-right: 15px;
+}
+#footer p#copyright.rtl {
+    float: left;
+    text-align: left;
+    padding-right: 0;
+    padding-left: 15px;
+}
 #footer a[href]:hover {
     background-color: #FFC35E;
 }

--- a/data/css/Web_Basic-Spruce.css
+++ b/data/css/Web_Basic-Spruce.css
@@ -1051,6 +1051,18 @@ a.family_map {
     text-align: right;
     padding-right: 15px;
 }
+#footer p#createdate.rtl {
+    float: right;
+    text-align: right;
+    padding-left: 0;
+    padding-right: 15px;
+}
+#footer p#copyright.rtl {
+    float: left;
+    text-align: left;
+    padding-right: 0;
+    padding-left: 15px;
+}
 #footer a[href]:hover {
     background-color: #BFD0EA;
 }

--- a/data/css/Web_Mainz.css
+++ b/data/css/Web_Mainz.css
@@ -1008,6 +1008,23 @@ div.grampsstylednote a:visited {
     margin-bottom: 10px;
     vertical-align: middle;
 }
+#footer p#createdate.rtl {
+    float: right;
+    text-align: right;
+    margin-left: 0;
+    margin-right: 10px;
+}
+#footer p#copyright.rtl {
+    float: left;
+    text-align: left;
+}
+#footer p#copyright.rtl img {
+    float: left;
+    margin-right: 0;
+    margin-left: 10px;
+    margin-bottom: 10px;
+    vertical-align: middle;
+}
 #footer > * {
     font-size: 80%;
     background: url(../images/Web_Mainz_MidLight.png) #FFF2C6;

--- a/data/css/Web_Nebraska.css
+++ b/data/css/Web_Nebraska.css
@@ -1585,6 +1585,22 @@ div#pedigree {
 #footer p#copyright img {
     margin-right: 10px;
 }
+#footer p#createdate.rtl {
+    float: right;
+    text-align: right;
+    margin-left: 0;
+    margin-right: 10px;
+}
+#footer p#copyright.rtl {
+    float: left;
+    text-align: left;
+    margin-right: 0;
+    margin-left: 10px;
+}
+#footer p#copyright.rtl img {
+    margin-right: 0;
+    margin-left: 10px;
+}
 #user_footer {
     width: 70%;
     float: left;

--- a/data/css/Web_Visually.css
+++ b/data/css/Web_Visually.css
@@ -267,6 +267,22 @@ div#footer p#copyright img {
     float:right;
     margin-right: 10px;
 }
+div#footer p#createdate.rtl {
+    float:right;
+    text-align:right;
+    margin-left:0;
+    margin-right:10px;
+}
+div#footer p#copyright.rtl {
+    float:left;
+    text-align:left;
+    margin: 10px 0px 0px 10px;
+}
+div#footer p#copyright.rtl img {
+    float:left;
+    margin-right: 0;
+    margin-left: 10px;
+}
 #user_footer {
     width:70%;
     float:left;

--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -1749,7 +1749,7 @@ class BasePage:
                     }
 
             # creation author
-            footer += Html("p", msg, id="createdate")
+            footer += Html("p", msg, id="createdate", class_=self.dir)
 
             # get copyright license for all pages
             copy_nr = self.report.copyright
@@ -1775,7 +1775,7 @@ class BasePage:
                     fname = "/".join(["images", "somerights20.gif"])
                 url = self.report.build_url_fname(fname, None, self.uplink, image=True)
                 text = _CC[copy_nr] % {"gif_fname": url}
-            footer += Html("p", text, id="copyright")
+            footer += Html("p", text, id="copyright", class_=self.dir)
 
         # return footer to its callers
         return footer

--- a/gramps/plugins/webreport/updates.py
+++ b/gramps/plugins/webreport/updates.py
@@ -99,8 +99,8 @@ class UpdatesPage(BasePage):
                 "This page contains the last updated objects "
                 "in the database in the last %(days)d days and"
                 " for a maximum of %(nb)d objects per object "
-                "type." % {"days": self.days, "nb": self.nbr}
-            )
+                "type."
+            ) % {"days": self.days, "nb": self.nbr}
             section += Html("p", description)
 
             header = self._("People")


### PR DESCRIPTION
## Summary

Two separate, unrelated bugs affecting the Narrated Web Site report:
a translation-lookup bug that silently discards Hebrew (and every
other) translation for one specific message, and a hardcoded LTR
footer layout that never mirrors for RTL locales.

## Root cause

**1. `updates.py` "last updated objects" message**

The `%`-substitution was applied to the raw English string before
passing it to `self._()` for translation lookup, instead of after:

```python
self._(
    "This page contains the last updated objects "
    "in the database in the last %(days)d days and"
    " for a maximum of %(nb)d objects per object "
    "type." % {"days": self.days, "nb": self.nbr}
)
```

Because `%`-substitution bakes real, per-database numbers into the
string first, the value passed to `self._()` never matches the
catalog's msgid (which always contains the literal `%(days)d` /
`%(nb)d` placeholders). The lookup fails silently and gettext falls
back to the untranslated English source - regardless of how
complete or correct the actual translation is.

**2. Two-column footer (`#footer p#createdate` / `#footer p#copyright`)**

Every bundled theme hardcodes `float`/`text-align: left` for the
"created date" paragraph and `right` for "copyright", with no
RTL-aware counterpart. Elsewhere in `basepage.py`, `self.dir`
(`"rtl"`/`"ltr"`, based on `self.rlocale.rtl_locale`) is already
added as a CSS class to many other elements specifically so themes
can provide RTL overrides (e.g. `div#header.rtl`,
`div#nav.wrappernav.rtl` already exist) - the footer paragraphs
were simply missed when that pattern was applied.

## Fix

1. Moved the `% {...}` substitution outside the `self._()` call, so
   `self._()` always receives the stable, translatable template
   string, and substitution happens afterward on the (possibly
   already-translated) result - the standard, correct gettext usage
   already followed everywhere else in this same file.

2. Added `class_=self.dir` to both footer paragraphs in
   `basepage.py`, matching the existing pattern used elsewhere.
   Added a matching `#footer p#createdate.rtl` /
   `#footer p#copyright.rtl` rule to each of the 9 bundled themes
   that mirrors `float`, `text-align`, and the associated
   margin/padding, following the same `.rtl`-override convention
   already present in each theme's CSS (e.g. `Web_Mainz.css` already
   has `div#header.rtl`, `div#nav.wrappernav.rtl`). The original LTR
   rules are untouched; the `.rtl` rules sit alongside them with
   higher selector specificity, so nothing changes for LTR locales.

## Scope

`gramps/plugins/webreport/updates.py`, `gramps/plugins/webreport/
basepage.py`, and all 9 bundled theme CSS files under `data/css/`.
No translation files touched. No effect on any locale other than
the `.rtl` override activating only when `self.rlocale.rtl_locale`
is true.

## Testing

Verified against a real `he_IL` Gramps installation with a generated
Narrated Web Site: the "last updated objects" message now correctly
shows the Hebrew translation instead of falling back to English, and
both footer paragraphs (created-date and copyright) now render
mirrored - created-date on the right, copyright on the left -
matching the reading direction of the rest of the page. LTR output
verified unchanged.