### PR TITLE
Make maclocale_test independent of the host locale module

### DIFF
--- a/gramps/gen/utils/test/maclocale_test.py
+++ b/gramps/gen/utils/test/maclocale_test.py
@@ -26,6 +26,7 @@ Tests for the Mac localization helpers in :mod:`gramps.gen.utils.maclocale`.
 # Python modules
 # ------------------------
 import io
+import locale
 import os
 import subprocess
 import unittest
@@ -101,6 +102,12 @@ class MacLocaleDefaultsTest(unittest.TestCase):
     ``OSError`` before ``Popen`` returns. To exercise it everywhere we
     replace ``subprocess.Popen`` with a stub that records the ``stderr``
     argument it is handed, then drive the public entry point.
+
+    ``maclocale`` also assumes the POSIX ``locale.LC_MESSAGES`` constant
+    is defined, which is true on the real macOS Pythons it runs on but
+    not on CPython for Windows. Since this test drives it on any host,
+    ``LC_MESSAGES`` is stood in for here too so the stubbed run behaves
+    like it would on macOS.
     """
 
     def _run_with_stub(self):
@@ -120,9 +127,12 @@ class MacLocaleDefaultsTest(unittest.TestCase):
         for var in ("COLLATION", "LANGUAGE", "LANG"):
             environ.pop(var, None)
 
-        with patch.object(maclocale.subprocess, "Popen", fake_popen):
-            with patch.dict(os.environ, environ, clear=True):
-                maclocale.mac_setup_localization(_FakeGLocale())
+        lc_messages = getattr(locale, "LC_MESSAGES", locale.LC_CTYPE)
+
+        with patch.object(maclocale.locale, "LC_MESSAGES", lc_messages, create=True):
+            with patch.object(maclocale.subprocess, "Popen", fake_popen):
+                with patch.dict(os.environ, environ, clear=True):
+                    maclocale.mac_setup_localization(_FakeGLocale())
 
         return captured
 


### PR DESCRIPTION
## Summary
- `locale.LC_MESSAGES` is a POSIX-only constant CPython's `locale` module never defines on Windows.
- `maclocale.py` is fine to assume it exists: `mac_setup_localization()` is only ever called behind `if sys.platform == "darwin":` in `grampslocale.py`, so it never actually runs on Windows in production.
- `maclocale_test.py` deliberately calls `mac_setup_localization()` directly on any host OS (stubbing `subprocess.Popen` to fake being on a Mac), which let a Windows CI runner reach the `LC_MESSAGES` lookup and crash with `AttributeError` before the `Popen` stub was ever exercised.
- This failed the `maclocale_test` suite in the "Windows AIO" workflow: https://github.com/gramps-project/gramps/actions/runs/32670650282
- Fix: stand `LC_MESSAGES` in for the duration of the stubbed run in the test, rather than adding Windows-specific handling to the mac-only production module.

## Test plan
- [x] `python3 -m unittest gramps.gen.utils.test.maclocale_test -v` passes
- [x] Verified the test passes even with `locale.LC_MESSAGES` removed from the real `locale` module (simulating Windows), with `maclocale.py` unchanged from upstream
- [x] `black --check gramps/gen/utils/test/maclocale_test.py`
- [x] `mypy gramps/gen/utils/test/maclocale_test.py`