### PR TITLE
fix maclocale regression tests on Windows

### DIFF
--- a/gramps/gen/utils/test/maclocale_test.py
+++ b/gramps/gen/utils/test/maclocale_test.py
@@ -120,9 +120,17 @@ class MacLocaleDefaultsTest(unittest.TestCase):
         for var in ("COLLATION", "LANGUAGE", "LANG"):
             environ.pop(var, None)
 
-        with patch.object(maclocale.subprocess, "Popen", fake_popen):
-            with patch.dict(os.environ, environ, clear=True):
-                maclocale.mac_setup_localization(_FakeGLocale())
+        # Windows does not define LC_MESSAGES, but this test intentionally
+        # exercises the macOS setup path on every platform.
+        message_category = getattr(
+            maclocale.locale, "LC_MESSAGES", maclocale.locale.LC_CTYPE
+        )
+        with patch.object(
+            maclocale.locale, "LC_MESSAGES", message_category, create=True
+        ):
+            with patch.object(maclocale.subprocess, "Popen", fake_popen):
+                with patch.dict(os.environ, environ, clear=True):
+                    maclocale.mac_setup_localization(_FakeGLocale())
 
         return captured
 


### PR DESCRIPTION
Fixing mac tests that were blocking windows AIO from building.

```
ResourceWarning: Implicitly cleaning up <HTTPError 404: 'Not Found'>
  _warnings.warn(self.warn_message, ResourceWarning)
.......Could not determine macOS version from platform.mac_ver(); compiled wheels will not be matched.
.............................................................................................................................................requires_mod value 'bs4' is a Python import name, not a PyPI package name.  Please update the addon to use 'beautifulsoup4' instead.  The correct name has been applied automatically this time.
.requires_mod value 'cv2' is a Python import name, not a PyPI package name.  Please update the addon to use 'opencv-python' instead.  The correct name has been applied automatically this time.
...requires_mod value 'serial' is a Python import name, not a PyPI package name.  Please update the addon to use 'pyserial' instead.  The correct name has been applied automatically this time.
.requires_mod value 'sklearn' is a Python import name, not a PyPI package name.  Please update the addon to use 'scikit-learn' instead.  The correct name has been applied automatically this time.
..requires_mod value 'yaml' is a Python import name, not a PyPI package name.  Please update the addon to use 'PyYAML' instead.  The correct name has been applied automatically this time.
........................................................ss............................................................................................................................................................................................................D:/a/gramps/gramps/gramps/gen/utils/grampstranslation.py:295: ResourceWarning: unclosed database in <sqlite3.Connection object at 0x000002b401278f40>
  def gettext(self, msgid: str, context: str = "") -> str:
ResourceWarning: Enable tracemalloc to get the object allocation traceback
D:/a/gramps/gramps/gramps/gen/utils/grampstranslation.py:295: ResourceWarning: unclosed database in <sqlite3.Connection object at 0x000002b4012c96c0>
  def gettext(self, msgid: str, context: str = "") -> str:
ResourceWarning: Enable tracemalloc to get the object allocation traceback
...............................................................................sss.ssD:/a/_temp/msys64/ucrt64/lib/python3.14/unittest/mock.py:2259: ResourceWarning: unclosed database in <sqlite3.Connection object at 0x000002b4106287c0>
  def __init__(self, name, parent):
ResourceWarning: Enable tracemalloc to get the object allocation traceback
.............................................................................
======================================================================
ERROR: test_defaults_stderr_is_devnull (gramps.gen.utils.test.maclocale_test.MacLocaleDefaultsTest.test_defaults_stderr_is_devnull)
Pin the specific sink to ``subprocess.DEVNULL`` so a future
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:/a/gramps/gramps/gramps/gen/utils/test/maclocale_test.py", line 158, in test_defaults_stderr_is_devnull
    captured = self._run_with_stub()
  File "D:/a/gramps/gramps/gramps/gen/utils/test/maclocale_test.py", line 125, in _run_with_stub
    maclocale.mac_setup_localization(_FakeGLocale())
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "D:/a/gramps/gramps/gramps/gen/utils/maclocale.py", line 310, in mac_setup_localization
    _find_language(glocale)
    ~~~~~~~~~~~~~~^^^^^^^^^
  File "D:/a/gramps/gramps/gramps/gen/utils/maclocale.py", line 230, in _find_language
    lang = locale.getlocale(locale.LC_MESSAGES)[0]
                            ^^^^^^^^^^^^^^^^^^
AttributeError: module 'locale' has no attribute 'LC_MESSAGES'

======================================================================
ERROR: test_defaults_stderr_is_not_a_leaked_file (gramps.gen.utils.test.maclocale_test.MacLocaleDefaultsTest.test_defaults_stderr_is_not_a_leaked_file)
``defaults`` must be invoked with a stderr sink that does not
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:/a/gramps/gramps/gramps/gen/utils/test/maclocale_test.py", line 140, in test_defaults_stderr_is_not_a_leaked_file
    captured = self._run_with_stub()
  File "D:/a/gramps/gramps/gramps/gen/utils/test/maclocale_test.py", line 125, in _run_with_stub
    maclocale.mac_setup_localization(_FakeGLocale())
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "D:/a/gramps/gramps/gramps/gen/utils/maclocale.py", line 310, in mac_setup_localization
    _find_language(glocale)
    ~~~~~~~~~~~~~~^^^^^^^^^
  File "D:/a/gramps/gramps/gramps/gen/utils/maclocale.py", line 230, in _find_language
    lang = locale.getlocale(locale.LC_MESSAGES)[0]
                            ^^^^^^^^^^^^^^^^^^
AttributeError: module 'locale' has no attribute 'LC_MESSAGES'

----------------------------------------------------------------------
Ran 32959 tests in 597.090s

FAILED (errors=2, skipped=66)
Error: Process completed with exit code 1.
```